### PR TITLE
RFC3339 timestamps in GeoJSON.

### DIFF
--- a/tests/marks_test.go
+++ b/tests/marks_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"bytes"
+	"time"
 )
 
 const apiDir = "../.tmp/api/delta"
@@ -344,8 +345,8 @@ func TestMarks(t *testing.T) {
 		 bf.WriteString(fmt.Sprintf(",\"name\":\"%s\"", v.Name))
 		 bf.WriteString(fmt.Sprintf(",\"datum\":\"%s\"", v.Point.Datum))
 		 bf.WriteString(fmt.Sprintf(",\"elevation\":%f", v.Point.Elevation))
-		 bf.WriteString(fmt.Sprintf(",\"start\":\"%d\"", v.Span.Start))
-		 bf.WriteString(fmt.Sprintf(",\"end\":\"%d\"", v.Span.End))
+		 bf.WriteString(fmt.Sprintf(",\"start\":\"%s\"", time.Unix(v.Span.Start, 0).UTC().Format(time.RFC3339)))
+		 bf.WriteString(fmt.Sprintf(",\"end\":\"%s\"", time.Unix(v.Span.End, 0).UTC().Format(time.RFC3339)))
 
 		 var group string
 

--- a/tests/stations_test.go
+++ b/tests/stations_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"strings"
 	"encoding/json"
+	"time"
 )
 
 func TestStations(t *testing.T) {
@@ -320,8 +321,8 @@ func writeProps(station *delta.Station, site *delta.Site, sensor *delta.Installe
 	b.WriteString(fmt.Sprintf(",\"datum\":\"%s\"", site.Point.Datum))
 	b.WriteString(fmt.Sprintf(",\"elevation\":%f", site.Point.Elevation))
 	b.WriteString(fmt.Sprintf(",\"vertical_offset\":%f", sensor.Offset.Vertical))
-	b.WriteString(fmt.Sprintf(",\"start\":\"%d\"", sensor.Span.Start))
-	b.WriteString(fmt.Sprintf(",\"end\":\"%d\"", sensor.Span.End))
+	b.WriteString(fmt.Sprintf(",\"start\":\"%s\"", time.Unix(sensor.Span.Start, 0).UTC().Format(time.RFC3339)))
+	b.WriteString(fmt.Sprintf(",\"end\":\"%s\"", time.Unix(sensor.Span.End, 0).UTC().Format(time.RFC3339)))
 
 	b.WriteString(`}}`)
 }


### PR DESCRIPTION
Start and end properties in the GeoJSON as RFC3339 (instead of epoch).  This makes them the same as other timestamps in GeoJSON from api.geonet.org.nz for consistency.

