### PR TITLE
updated pod abbreviations to handle stationxml style units

### DIFF
--- a/tools/pod/blockette.go
+++ b/tools/pod/blockette.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"time"
 )
@@ -46,7 +47,7 @@ var unitsAbbreviation = []UnitsAbbreviation{
 	{Key: "M/S", Code: 1, Description: "Velocity in Meters Per Second"},
 	{Key: "A", Code: 2, Description: "Amperes"},
 	{Key: "V", Code: 3, Description: "Volts"},
-	{Key: "COUNTS", Code: 4, Description: "Digital Counts"},
+	{Key: "COUNT", Code: 4, Description: "Digital Counts"},
 	{Key: "M/S**2", Code: 5, Description: "Acceleration in Meters Per Second Per Second"},
 	{Key: "C", Code: 6, Description: "Degrees Centigrade"},
 	{Key: "M", Code: 7, Description: "Displacement in Meters"},
@@ -54,12 +55,14 @@ var unitsAbbreviation = []UnitsAbbreviation{
 }
 
 func lookupUnitsAbbreviation(key string) int {
-	for _, a := range unitsAbbreviation {
-		if a.Key == key {
-			return a.Code
+	for _, k := range []string{key, strings.ToUpper(key)} {
+		for _, a := range unitsAbbreviation {
+			if a.Key == k {
+				return a.Code
+			}
 		}
 	}
-	fmt.Println("UNABLE TO FIND: ", key)
+	log.Println("UNABLE TO FIND: ", key)
 	return 0
 }
 
@@ -124,12 +127,16 @@ var genericAbbreviations = []GenericAbbreviation{
 }
 
 func lookupGenericAbbreviation(desc string) int {
-	var abbr int
 	for _, a := range genericAbbreviations {
 		if a.Description == desc {
-			abbr = a.Code
+			return a.Code
 		}
 	}
+	abbr := len(genericAbbreviations)
+	genericAbbreviations = append(genericAbbreviations, GenericAbbreviation{
+		Code:        abbr,
+		Description: desc,
+	})
 	return abbr
 }
 

--- a/tools/pod/pod.go
+++ b/tools/pod/pod.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"io/ioutil"
-	"log"
 	"math"
 	"os"
 	"path/filepath"
@@ -262,7 +261,6 @@ func (p *Pod) Channel(cha *stationxml.Channel) []Blockette {
 					case "Nanometrics Trillium 120QA":
 						model = "Nanometrics Nanometrics Trillium 120QA"
 					default:
-						log.Println("missing sensor model lookup ->>>", cha.Sensor.Model, "<<<--")
 						model = cha.Sensor.Model
 					}
 					if abbr := lookupGenericAbbreviation(model); abbr > 0 {


### PR DESCRIPTION
@quiffman stationxml prefers lowercase unit names whereas the traditional dataless seed liked uppercase. 

I've also allowed unknown sensors to be added to the abbreviation list, the matching cases are there to allow comparison with the existing files for checking/testing (missing ones will not match any so should be fine to add as is).