### PR TITLE
update pod to use network description rather than station description

### DIFF
--- a/tools/pod/pod.go
+++ b/tools/pod/pod.go
@@ -104,11 +104,11 @@ func (p *Pod) Station(net *stationxml.Network, sta *stationxml.Station) error {
 			Elevation: sta.Elevation.Value,
 			Name:      sta.Site.Name,
 			Description: func() int {
-				switch lookupGenericAbbreviation(sta.Description) {
+				switch lookupGenericAbbreviation(net.Description) {
 				case 0:
 					return lookupGenericAbbreviation("New Zealand National Seismograph Network")
 				default:
-					return lookupGenericAbbreviation(sta.Description)
+					return lookupGenericAbbreviation(net.Description)
 				}
 			}(),
 			Opened: sta.CreationDate.Time,


### PR DESCRIPTION
@quiffman Small bug shown up in comparing stationxml derived dataless volumes vs the current set. It comes out with the wrong network abbreviation code for non-national network sites (i.e. they should all be "New Zealand ...." but some were coming out like "Tongariro Network ..."