### PR TITLE
added extra stationxml constraints for logger/sensor and operational state

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -x
 
+set -x
+
 errcount=0
 
 error_handler () {
@@ -12,8 +14,23 @@ trap error_handler ERR
 mkdir -p .tmp/geonet-meta/stationxml || exit 255
 
 (cd ./tools/stationxml; go build; ./stationxml -output ../../.tmp/geonet-meta/stationxml/complete.xml)
+(cd ./tools/stationxml; go build; ./stationxml -output ../../.tmp/geonet-meta/stationxml/scp.xml \
+    -operational \
+    -channels '([EHB][HN][ZNE23])' \
+)
+(cd ./tools/stationxml; go build; ./stationxml -output ../../.tmp/geonet-meta/stationxml/iris.xml \
+    -stations '(KHZ|QRZ|OUZ|HIZ|BKZ|ODZ|BFZ|CTZ|URZ|RPZ|WPVZ)' \
+    -sensors '(STS-2|CMG-3TB|CMG-40T-60S|FBA-ES-T)' \
+    -dataloggers '(Q330HR/6|Q4120/6|Q330/3)' \
+    -channels '([HLV]H[ZNE23]|[HBL]N[ZNE])' \
+    -output ../../.tmp/geonet-meta/stationxml/iris.xml
+)
 
 mkdir -p .tmp/geonet-meta/seed || exit 255
+
+(cd ./tools/pod; go build; ./pod --output  ../../.tmp/geonet-meta/seed/pod/complete ../../.tmp/geonet-meta/stationxml/complete.xml)
+(cd ./tools/pod; go build; ./pod --output  ../../.tmp/geonet-meta/seed/pod/scp ../../.tmp/geonet-meta/stationxml/scp.xml)
+(cd ./tools/pod; go build; ./pod --output  ../../.tmp/geonet-meta/seed/pod/iris ../../.tmp/geonet-meta/stationxml/iris.xml)
 
 exit $errcount
 

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -x
 
-set -x
-
 errcount=0
 
 error_handler () {
@@ -16,13 +14,13 @@ mkdir -p .tmp/geonet-meta/stationxml || exit 255
 (cd ./tools/stationxml; go build; ./stationxml -output ../../.tmp/geonet-meta/stationxml/complete.xml)
 (cd ./tools/stationxml; go build; ./stationxml -output ../../.tmp/geonet-meta/stationxml/scp.xml \
     -operational \
-    -channels '([EHB][HN][ZNE23])' \
+    -channels '([EHB][HN][ZNE12])' \
 )
 (cd ./tools/stationxml; go build; ./stationxml -output ../../.tmp/geonet-meta/stationxml/iris.xml \
     -stations '(KHZ|QRZ|OUZ|HIZ|BKZ|ODZ|BFZ|CTZ|URZ|RPZ|WPVZ)' \
     -sensors '(STS-2|CMG-3TB|CMG-40T-60S|FBA-ES-T)' \
     -dataloggers '(Q330HR/6|Q4120/6|Q330/3)' \
-    -channels '([HLV]H[ZNE23]|[HBL]N[ZNE])' \
+    -channels '([HLV]H[ZNE12]|[HBL]N[ZNE])' \
     -output ../../.tmp/geonet-meta/stationxml/iris.xml
 )
 


### PR DESCRIPTION
@quiffman starting to look at tailoring the stationxml extracts, a couple of constraints from the old system were missing, these were being specific about loggers and sensors to be extracted. I've also added for real-time related work whether the site is currently, or recently, operational.

e.g. this is the original mapping for the IRIS dataless SEED files.

```
$pod->streams(
        network_remap => {'CH' => 'NZ'},
        networks => ['NZ', 'CH'],
        stations => ['KHZ', 'QRZ', 'OUZ', 'HIZ', 'BKZ', 'ODZ', 'BFZ', 'CTZ', 'URZ', 'RPZ', 'WPVZ'],
        sensors => ['STS-2', 'CMG-3TB', 'CMG-40T-60S', 'FBA-ES-T'],
        loggers => ['Q330HR/6', 'Q4120/6', 'Q330/3'],
        channels => ['HHZ', 'HHN', 'HHE', 'HH1', 'HH2', 'LHZ', 'LHN', 'LHE', 'LH1', 'LH2', 'VHZ', 'VHN', 'VHE', 'VH1', 'VH2', 'HNZ', 'HNN', 'HNE', 'BNZ', 'BNN', 'BNE', 'LNZ', 'LNN',
'LNE']

```

I've included these in the `build.sh` script as an example at this stage, together with an operational sc3 output. I'm also building the pod headers but have left the next step to another outside process for now.

The only thing at the back of my mind is that for times when the filters are used should stations with no channels (after filtering) be ignored.
