### PR TITLE
add obsidian 4x response

### DIFF
--- a/resp/auto.go
+++ b/resp/auto.go
@@ -103,6 +103,13 @@ var DataloggerModels map[string]DataloggerModel = map[string]DataloggerModel{
 		Manufacturer: "Nanometrics",
 		Vendor:       "",
 	},
+	"Obsidian 4X Datalogger": DataloggerModel{
+		Name:         "Obsidian 4X Datalogger",
+		Type:         "Strong Motion Recorder",
+		Description:  "Obsidian",
+		Manufacturer: "Kinemetrics",
+		Vendor:       "",
+	},
 	"Q330/3": DataloggerModel{
 		Name:         "Q330/3",
 		Type:         "Datalogger",
@@ -6138,7 +6145,7 @@ var Responses []Response = []Response{
 		},
 		Dataloggers: []Datalogger{
 			Datalogger{
-				DataloggerList: []string{"OBSIDIAN"},
+				DataloggerList: []string{"OBSIDIAN", "Obsidian 4X Datalogger"},
 				Type:           "TG",
 				Label:          "HN",
 				SampleRate:     200,
@@ -6252,7 +6259,7 @@ var Responses []Response = []Response{
 				},
 				Reversed: false,
 			}, Datalogger{
-				DataloggerList: []string{"OBSIDIAN"},
+				DataloggerList: []string{"OBSIDIAN", "Obsidian 4X Datalogger"},
 				Type:           "CG",
 				Label:          "BN",
 				SampleRate:     50,

--- a/resp/responses/dataloggers.yaml
+++ b/resp/responses/dataloggers.yaml
@@ -15,6 +15,11 @@ dataloggermodel:
     description: Obsidian
     manufacturer: Kinemetrics
     vendor: ""
+  Obsidian 4X Datalogger:
+    type: Strong Motion Recorder
+    description: Obsidian
+    manufacturer: Kinemetrics
+    vendor: ""
   ETNA:
     type: Strong Motion Recorder
     description: Etna

--- a/resp/responses/responses.yaml
+++ b/resp/responses/responses.yaml
@@ -664,6 +664,7 @@ response:
     dataloggers:
     - dataloggers:
       - OBSIDIAN
+      - Obsidian 4X Datalogger
       type: TG
       label: HN
       samplerate: 200
@@ -675,6 +676,7 @@ response:
       reversed: false
     - dataloggers:
       - OBSIDIAN
+      - Obsidian 4X Datalogger
       type: CG
       label: BN
       samplerate: 50

--- a/tools/impact/build.go
+++ b/tools/impact/build.go
@@ -85,7 +85,7 @@ func buildStreams(base, channels string) (map[string]Stream, error) {
 
 				switch installation.Datalogger.Model {
 				case "Q330/3", "Q330/6", "Q330HR/6", "Q330S/3", "Q330S/6", "Q330HRS/6":
-				case "BASALT", "OBSIDIAN", "CUSP3D", "CUSP3C":
+				case "BASALT", "OBSIDIAN", "CUSP3D", "CUSP3C", "Obsidian 4X Datalogger":
 				default:
 					continue
 				}


### PR DESCRIPTION
@quiffman  I've added the Obsidian 4x response information, it acts like a datalogger (no internal sensor) rather than the normal Obsidian (which is a recorder). The `auto.go` file is generated via `go generate` from the information stored in the `yaml` files.

I've also add the 4x to the "blessed" instrument list for the impact service which should solve GeoNet/tickets#1479

The instrument names come directly out of the oracle db and can be looked at again once this is no longer a constraint.

/cc @nbalfour @gclitheroe 