### PR TITLE
update tests to use t.Run

### DIFF
--- a/tests/assets_test.go
+++ b/tests/assets_test.go
@@ -1,19 +1,15 @@
 package delta_test
 
 import (
-	"bytes"
-	"encoding/csv"
-	"io/ioutil"
-	"os"
-	"os/exec"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/GeoNet/delta/meta"
 )
 
 func TestAssets(t *testing.T) {
+
+	var assets meta.AssetList
 
 	files := map[string]string{
 		"antennas":    "../assets/antennas.csv",
@@ -26,76 +22,40 @@ func TestAssets(t *testing.T) {
 		"sensors":     "../assets/sensors.csv",
 	}
 
-	reference := make(map[string]string)
-
 	for k, v := range files {
-		var assets meta.AssetList
+		t.Run("load asset files: "+k, func(t *testing.T) {
+			var a meta.AssetList
+			loadListFile(t, v, &a)
+			assets = append(assets, a...)
+		})
+	}
 
-		t.Log("Check asset file can be loaded: " + k)
-		if err := meta.LoadList(v, &assets); err != nil {
-			t.Fatal(err)
-		}
+	sort.Sort(assets)
 
-		sort.Sort(assets)
-
+	t.Run("check for duplicate asset numbers", func(t *testing.T) {
+		reference := make(map[string]string)
 		for _, a := range assets {
-			if a.Number != "" {
-				if x, ok := reference[a.Number]; ok {
-					t.Error(k + ": Duplicate asset number: " + a.String() + " " + a.Number + " [" + x + "]")
-				}
-				reference[a.Number] = a.String()
+			if a.Number == "" {
+				continue
 			}
+			if x, ok := reference[a.Number]; ok {
+				t.Errorf("duplicate asset number %s: %s [%s]", a.String(), a.Number, x)
+			}
+			reference[a.Number] = a.String()
 		}
+	})
 
+	t.Run("check for duplicate equipment", func(t *testing.T) {
 		for i := 0; i < len(assets); i++ {
 			for j := i + 1; j < len(assets); j++ {
-				if assets[i].Model != assets[j].Model {
-					continue
+				switch {
+				case assets[i].Model != assets[j].Model:
+				case assets[i].Serial != assets[j].Serial:
+				default:
+					t.Errorf("duplicate equipment %s: %s", assets[i].String(), assets[j].String())
 				}
-				if assets[i].Serial != assets[j].Serial {
-					continue
-				}
-				t.Errorf("equipment duplication: " + strings.Join([]string{assets[i].Model, assets[i].Serial}, " "))
 			}
 		}
+	})
 
-		t.Log("Check asset file consistency: " + k)
-		raw, err := ioutil.ReadFile(v)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		var buf bytes.Buffer
-		if err := csv.NewWriter(&buf).WriteAll(meta.EncodeList(assets)); err != nil {
-			t.Fatal(err)
-		}
-
-		if string(raw) != buf.String() {
-			t.Error(k + ": Assets file mismatch: " + v)
-
-			file, err := ioutil.TempFile(os.TempDir(), "tst")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.Remove(file.Name())
-			file.Write(buf.Bytes())
-
-			cmd := exec.Command("diff", "-c", v, file.Name())
-			stdout, err := cmd.StdoutPipe()
-			if err != nil {
-				t.Fatal(err)
-			}
-			err = cmd.Start()
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer cmd.Wait()
-			diff, err := ioutil.ReadAll(stdout)
-			if err != nil {
-				t.Fatal(err)
-			}
-			t.Error(string(diff))
-
-		}
-	}
 }

--- a/tests/constituents_test.go
+++ b/tests/constituents_test.go
@@ -9,36 +9,31 @@ import (
 
 func TestConstituents(t *testing.T) {
 
-	gauges := make(map[string]meta.Gauge)
-	{
-		t.Log("Load installed gauges file")
-		var list meta.GaugeList
-		if err := meta.LoadList("../network/gauges.csv", &list); err != nil {
-			t.Fatal(err)
-		}
+	var constituents meta.ConstituentList
+	loadListFile(t, "../network/constituents.csv", &constituents)
 
+	t.Run("check for constituent duplications", func(t *testing.T) {
+		for i := 0; i < len(constituents); i++ {
+			for j := i + 1; j < len(constituents); j++ {
+				if constituents[i].Gauge == constituents[j].Gauge && constituents[i].Number == constituents[j].Number {
+					t.Error("contituent duplication: " + constituents[i].Gauge + "/" + strconv.Itoa(constituents[i].Number))
+				}
+			}
+		}
+	})
+
+	t.Run("check for missing constituent gauges", func(t *testing.T) {
+		var list meta.GaugeList
+		loadListFile(t, "../network/gauges.csv", &list)
+
+		gauges := make(map[string]meta.Gauge)
 		for _, g := range list {
 			gauges[g.Code] = g
 		}
-	}
-
-	var constituents meta.ConstituentList
-	if err := meta.LoadList("../network/constituents.csv", &constituents); err != nil {
-		t.Fatal(err)
-	}
-
-	for i := 0; i < len(constituents); i++ {
-		for j := i + 1; j < len(constituents); j++ {
-			if constituents[i].Gauge == constituents[j].Gauge && constituents[i].Number == constituents[j].Number {
-				t.Error("contituent duplication: " + constituents[i].Gauge + "/" + strconv.Itoa(constituents[i].Number))
+		for _, c := range constituents {
+			if _, ok := gauges[c.Gauge]; !ok {
+				t.Error("unknown gauge: " + c.Gauge)
 			}
 		}
-	}
-
-	for _, c := range constituents {
-		if _, ok := gauges[c.Gauge]; !ok {
-			t.Error("unknown gauge: " + c.Gauge)
-		}
-
-	}
+	})
 }

--- a/tests/dataloggers_test.go
+++ b/tests/dataloggers_test.go
@@ -1,7 +1,6 @@
 package delta_test
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/GeoNet/delta/meta"
@@ -10,103 +9,76 @@ import (
 func TestDataloggers(t *testing.T) {
 	var dataloggers meta.DeployedDataloggerList
 
-	t.Log("Load deployed dataloggers file")
-	{
-		if err := meta.LoadList("../install/dataloggers.csv", &dataloggers); err != nil {
-			t.Fatal(err)
-		}
-	}
+	loadListFile(t, "../install/dataloggers.csv", &dataloggers)
 
-	t.Log("Check for datalogger installation place overlaps")
-	{
+	t.Run("check for datalogger installation place overlaps", func(t *testing.T) {
 		installs := make(map[string]meta.DeployedDataloggerList)
 		for _, d := range dataloggers {
-			_, ok := installs[d.Place]
-			if ok {
-				installs[d.Place] = append(installs[d.Place], d)
-
-			} else {
-				installs[d.Place] = meta.DeployedDataloggerList{d}
+			if _, ok := installs[d.Place]; !ok {
+				installs[d.Place] = meta.DeployedDataloggerList{}
 			}
+			installs[d.Place] = append(installs[d.Place], d)
 		}
 
-		var keys []string
-		for k, _ := range installs {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-
-		for _, k := range keys {
-			v := installs[k]
-
-			for i, n := 0, len(v); i < n; i++ {
-				for j := i + 1; j < n; j++ {
-					switch {
-					case v[i].Place != v[j].Place:
-					case v[i].Role != v[j].Role:
-					//case v[i].Model != v[j].Model:
-					case v[i].End.Before(v[j].Start):
-					case v[i].Start.After(v[j].End):
-					//case v[i].End.Equal(v[j].Start):
-					//case v[i].Start.Equal(v[j].End):
-					default:
-						t.Errorf("datalogger %s:[%s] at %-32s has place overlap between %s and %s",
-							v[i].Model, v[i].Serial, v[i].Place, v[i].Start.Format(meta.DateTimeFormat), v[i].End.Format(meta.DateTimeFormat))
+		for _, v := range installs {
+			for i := 0; i < len(v); i++ {
+				for j := i + 1; j < len(v); j++ {
+					if v[i].Place != v[j].Place {
+						continue
 					}
+					if v[i].Role != v[j].Role {
+						continue
+					}
+					if v[i].End.Before(v[j].Start) {
+						continue
+					}
+					if v[i].Start.After(v[j].End) {
+						continue
+					}
+
+					t.Errorf("datalogger %s:[%s] at %-32s has place overlap between %s and %s",
+						v[i].Model, v[i].Serial, v[i].Place,
+						v[i].Start.Format(meta.DateTimeFormat),
+						v[i].End.Format(meta.DateTimeFormat))
 				}
 			}
 		}
-	}
+	})
 
-	t.Log("Check for datalogger installation equipment overlaps")
-	{
+	t.Run("check for datalogger installation equipment overlaps", func(t *testing.T) {
 		installs := make(map[string]meta.DeployedDataloggerList)
 		for _, s := range dataloggers {
-			_, ok := installs[s.Model]
-			if ok {
-				installs[s.Model] = append(installs[s.Model], s)
-
-			} else {
-				installs[s.Model] = meta.DeployedDataloggerList{s}
+			if _, ok := installs[s.Model]; !ok {
+				installs[s.Model] = meta.DeployedDataloggerList{}
 			}
+			installs[s.Model] = append(installs[s.Model], s)
 		}
 
-		var keys []string
-		for k, _ := range installs {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-
-		for _, k := range keys {
-			v := installs[k]
-
-			for i, n := 0, len(v); i < n; i++ {
-				for j := i + 1; j < n; j++ {
-					switch {
-					case v[i].Serial != v[j].Serial:
-					case v[i].End.Before(v[j].Start):
-					case v[i].Start.After(v[j].End):
-						//		case v[i].End.Equal(v[j].Start):
-						//		case v[i].Start.Equal(v[j].End):
-					default:
-						t.Errorf("datalogger %s:[%s] at %-32s has installation overlap between %s and %s",
-							v[i].Model, v[i].Serial, v[i].Place, v[i].Start.Format(meta.DateTimeFormat), v[i].End.Format(meta.DateTimeFormat))
+		for _, v := range installs {
+			for i := 0; i < len(v); i++ {
+				for j := i + 1; j < len(v); j++ {
+					if v[i].Serial != v[j].Serial {
+						continue
 					}
+					if v[i].End.Before(v[j].Start) {
+						continue
+					}
+					if v[i].Start.After(v[j].End) {
+						continue
+					}
+
+					t.Errorf("datalogger %s:[%s] at %-32s has installation overlap between %s and %s",
+						v[i].Model, v[i].Serial, v[i].Place,
+						v[i].Start.Format(meta.DateTimeFormat),
+						v[i].End.Format(meta.DateTimeFormat))
 				}
 			}
 		}
-	}
+	})
 
-	var assets meta.AssetList
-	t.Log("Load datalogger assets file")
-	{
-		if err := meta.LoadList("../assets/dataloggers.csv", &assets); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	t.Log("Check for datalogger assets")
-	{
+	t.Run("check for missing datalogger assets", func(t *testing.T) {
+		var assets meta.AssetList
+		loadListFile(t, "../assets/dataloggers.csv", &assets)
 		for _, r := range dataloggers {
 			var found bool
 			for _, a := range assets {
@@ -118,10 +90,10 @@ func TestDataloggers(t *testing.T) {
 				}
 				found = true
 			}
-			if !found {
-				t.Errorf("unable to find datalogger asset: %s [%s]", r.Model, r.Serial)
+			if found {
+				continue
 			}
+			t.Errorf("unable to find datalogger asset: %s [%s]", r.Model, r.Serial)
 		}
-	}
-
+	})
 }

--- a/tests/gauges_test.go
+++ b/tests/gauges_test.go
@@ -8,42 +8,35 @@ import (
 
 func TestGauges(t *testing.T) {
 
-	stas := make(map[string]meta.Station)
-	{
-		var list meta.StationList
-		t.Log("Load stations file")
-		if err := meta.LoadList("../network/stations.csv", &list); err != nil {
-			t.Fatal(err)
+	var gauges meta.GaugeList
+	loadListFile(t, "../network/gauges.csv", &gauges)
+
+	t.Run("check for gauge duplication", func(t *testing.T) {
+		for i := 0; i < len(gauges); i++ {
+			for j := i + 1; j < len(gauges); j++ {
+				if gauges[i].Code == gauges[j].Code {
+					t.Errorf("gauge code duplication: " + gauges[i].Code)
+				}
+				if gauges[i].Number == gauges[j].Number {
+					t.Errorf("gauge number duplication: " + gauges[i].Code)
+				}
+			}
 		}
+	})
+
+	t.Run("check for missing gauge stations ", func(t *testing.T) {
+		var list meta.StationList
+		loadListFile(t, "../network/stations.csv", &list)
+
+		stas := make(map[string]meta.Station)
 		for _, s := range list {
 			stas[s.Code] = s
 		}
-	}
-
-	var gauges meta.GaugeList
-	t.Log("Load installed gauges file")
-	{
-		if err := meta.LoadList("../network/gauges.csv", &gauges); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	for i := 0; i < len(gauges); i++ {
-		for j := i + 1; j < len(gauges); j++ {
-			if gauges[i].Code == gauges[j].Code {
-				t.Errorf("gauge code duplication: " + gauges[i].Code)
+		for _, g := range gauges {
+			if _, ok := stas[g.Code]; !ok {
+				t.Error("unknown gauge station: " + g.Code)
 			}
-			if gauges[i].Number == gauges[j].Number {
-				t.Errorf("gauge number duplication: " + gauges[i].Code)
-			}
+
 		}
-	}
-
-	for _, g := range gauges {
-		if _, ok := stas[g.Code]; !ok {
-			t.Error("unknown gauge station: " + g.Code)
-		}
-
-	}
-
+	})
 }

--- a/tests/marks_test.go
+++ b/tests/marks_test.go
@@ -1,0 +1,22 @@
+package delta_test
+
+import (
+	"testing"
+
+	"github.com/GeoNet/delta/meta"
+)
+
+func TestMarks(t *testing.T) {
+	var marks meta.MarkList
+	loadListFile(t, "../network/marks.csv", &marks)
+
+	t.Run("check for duplicated marks", func(t *testing.T) {
+		for i := 0; i < len(marks); i++ {
+			for j := i + 1; j < len(marks); j++ {
+				if marks[i].Code == marks[j].Code {
+					t.Errorf("mark duplication: " + marks[i].Code)
+				}
+			}
+		}
+	})
+}

--- a/tests/monuments_test.go
+++ b/tests/monuments_test.go
@@ -9,34 +9,37 @@ import (
 func TestMonuments(t *testing.T) {
 
 	var monuments meta.MonumentList
-	t.Log("Load network monuments file")
-	{
-		if err := meta.LoadList("../network/monuments.csv", &monuments); err != nil {
-			t.Fatal(err)
-		}
-	}
+	loadListFile(t, "../network/monuments.csv", &monuments)
 
-	for i := 0; i < len(monuments); i++ {
-		for j := i + 1; j < len(monuments); j++ {
-			if monuments[i].Mark == monuments[j].Mark {
-				t.Errorf("monument duplication: " + monuments[i].Mark)
+	t.Run("check for monument duplication", func(t *testing.T) {
+		for i := 0; i < len(monuments); i++ {
+			for j := i + 1; j < len(monuments); j++ {
+				if monuments[i].Mark == monuments[j].Mark {
+					t.Errorf("monument duplication: " + monuments[i].Mark)
+				}
 			}
 		}
-	}
+	})
 
-	for _, m := range monuments {
-		if m.GroundRelationship > 0.0 {
-			t.Errorf("positive monuments ground relationship: %s [%g]", m.Mark, m.GroundRelationship)
+	t.Run("check for monument ground relationships", func(t *testing.T) {
+		for _, m := range monuments {
+			if m.GroundRelationship > 0.0 {
+				t.Errorf("monument has a positive ground relationship: %s [%g]", m.Mark, m.GroundRelationship)
+			}
 		}
+	})
 
-		switch m.Type {
-		case "Shallow Rod / Braced Antenna Mount":
-		case "Wyatt/Agnew Drilled-Braced":
-		case "Pillar":
-		case "Steel Mast":
-		case "Unknown":
-		default:
-			t.Errorf("unknown monument type: %s [%s]", m.Mark, m.Type)
+	t.Run("check for monument types", func(t *testing.T) {
+		for _, m := range monuments {
+			switch m.Type {
+			case "Shallow Rod / Braced Antenna Mount":
+			case "Wyatt/Agnew Drilled-Braced":
+			case "Pillar":
+			case "Steel Mast":
+			case "Unknown":
+			default:
+				t.Errorf("monument has an unknown type: %s [%s]", m.Mark, m.Type)
+			}
 		}
-	}
+	})
 }

--- a/tests/networks_test.go
+++ b/tests/networks_test.go
@@ -9,19 +9,15 @@ import (
 func TestNetworks(t *testing.T) {
 
 	var networks meta.NetworkList
-	t.Log("Load installed sensors file")
-	{
-		if err := meta.LoadList("../network/networks.csv", &networks); err != nil {
-			t.Fatal(err)
-		}
-	}
+	loadListFile(t, "../network/networks.csv", &networks)
 
-	for i := 0; i < len(networks); i++ {
-		for j := i + 1; j < len(networks); j++ {
-			if networks[i].Code == networks[j].Code {
-				t.Errorf("network duplication: " + networks[i].Code)
+	t.Run("check for network duplication", func(t *testing.T) {
+		for i := 0; i < len(networks); i++ {
+			for j := i + 1; j < len(networks); j++ {
+				if networks[i].Code == networks[j].Code {
+					t.Errorf("network duplication: " + networks[i].Code)
+				}
 			}
 		}
-	}
-
+	})
 }

--- a/tests/recorders_test.go
+++ b/tests/recorders_test.go
@@ -1,7 +1,6 @@
 package delta_test
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/GeoNet/delta/meta"
@@ -9,63 +8,50 @@ import (
 
 func TestRecorders(t *testing.T) {
 	var recorders meta.InstalledRecorderList
+	loadListFile(t, "../install/recorders.csv", &recorders)
 
-	t.Log("Load installed recorders file")
-	{
-		if err := meta.LoadList("../install/recorders.csv", &recorders); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	t.Log("Check for recorder installation equipment overlaps")
-	{
+	t.Run("check for recorder installation equipment overlaps", func(t *testing.T) {
 		installs := make(map[string]meta.InstalledRecorderList)
 		for _, s := range recorders {
-			_, ok := installs[s.Model]
-			if ok {
-				installs[s.Model] = append(installs[s.Model], s)
-
-			} else {
-				installs[s.Model] = meta.InstalledRecorderList{s}
+			if _, ok := installs[s.Model]; !ok {
+				installs[s.Model] = meta.InstalledRecorderList{}
 			}
+			installs[s.Model] = append(installs[s.Model], s)
 		}
 
-		var keys []string
-		for k, _ := range installs {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-
-		for _, k := range keys {
-			v := installs[k]
-
-			for i, n := 0, len(v); i < n; i++ {
-				for j := i + 1; j < n; j++ {
-					switch {
-					case v[i].Serial != v[j].Serial:
-					case v[i].End.Before(v[j].Start):
-					case v[i].Start.After(v[j].End):
-					case v[i].End.Equal(v[j].Start):
-					case v[i].Start.Equal(v[j].End):
-					default:
-						t.Errorf("recorder %s/%s at %-5s has location %-2s overlap between %s and %s",
-							v[i].Model, v[i].Serial, v[i].Station, v[i].Location, v[i].Start.Format(meta.DateTimeFormat), v[i].End.Format(meta.DateTimeFormat))
+		for _, v := range installs {
+			for i := 0; i < len(v); i++ {
+				for j := i + 1; j < len(v); j++ {
+					if v[i].Serial != v[j].Serial {
+						continue
 					}
+					if v[i].End.Before(v[j].Start) {
+						continue
+					}
+					if v[i].Start.After(v[j].End) {
+						continue
+					}
+					if v[i].End.Equal(v[j].Start) {
+						continue
+					}
+					if v[i].Start.Equal(v[j].End) {
+						continue
+					}
+					t.Errorf("recorder %s/%s at %-5s has location %-2s overlap between %s and %s",
+						v[i].Model, v[i].Serial,
+						v[i].Station, v[i].Location,
+						v[i].Start.Format(meta.DateTimeFormat),
+						v[i].End.Format(meta.DateTimeFormat))
 				}
 			}
 		}
-	}
+	})
 
-	t.Log("Check for missing recorder stations")
-	{
+	t.Run("check for missing recorder stations", func(t *testing.T) {
 		var stations meta.StationList
-
-		if err := meta.LoadList("../network/stations.csv", &stations); err != nil {
-			t.Fatal(err)
-		}
+		loadListFile(t, "../network/stations.csv", &stations)
 
 		keys := make(map[string]interface{})
-
 		for _, s := range stations {
 			keys[s.Code] = true
 		}
@@ -76,18 +62,11 @@ func TestRecorders(t *testing.T) {
 			}
 			t.Errorf("unable to find recorder installed station %-5s", s.Station)
 		}
-	}
+	})
 
-	var assets meta.AssetList
-	t.Log("Load recorder assets file")
-	{
-		if err := meta.LoadList("../assets/recorders.csv", &assets); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	t.Log("Check for recorder assets")
-	{
+	t.Run("check for recorder assets", func(t *testing.T) {
+		var assets meta.AssetList
+		loadListFile(t, "../assets/recorders.csv", &assets)
 		for _, r := range recorders {
 			var found bool
 			for _, a := range assets {
@@ -99,10 +78,11 @@ func TestRecorders(t *testing.T) {
 				}
 				found = true
 			}
-			if !found {
-				t.Errorf("unable to find recorders asset: %s [%s]", r.DataloggerModel, r.Serial)
+			if found {
+				continue
 			}
+			t.Errorf("unable to find recorders asset: %s [%s]", r.DataloggerModel, r.Serial)
 		}
-	}
+	})
 
 }

--- a/tests/sensors_test.go
+++ b/tests/sensors_test.go
@@ -9,20 +9,11 @@ import (
 
 func TestSensors(t *testing.T) {
 	var installed meta.InstalledSensorList
-	t.Log("Load installed sensors file")
-	{
-		if err := meta.LoadList("../install/sensors.csv", &installed); err != nil {
-			t.Fatal(err)
-		}
-		sort.Sort(installed)
-	}
+	loadListFile(t, "../install/sensors.csv", &installed)
 
-	t.Log("Check for missing sensors")
-	{
+	t.Run("check for missing sensors", func(t *testing.T) {
 		var sensors meta.AssetList
-		if err := meta.LoadList("../assets/sensors.csv", &sensors); err != nil {
-			t.Fatal(err)
-		}
+		loadListFile(t, "../assets/sensors.csv", &sensors)
 		sort.Sort(sensors)
 		for _, i := range installed {
 			n := sort.Search(len(sensors), func(j int) bool { return !sensors[j].Equipment.Less(i.Equipment) })
@@ -30,126 +21,136 @@ func TestSensors(t *testing.T) {
 				t.Errorf("unable to find sensor: %s", i.String())
 			}
 		}
-	}
+	})
 
-	t.Log("Check for sensor installation overlaps")
-	{
+	t.Run("check for sensor installation overlaps", func(t *testing.T) {
 		installs := make(map[string]meta.InstalledSensorList)
 		for _, s := range installed {
-			_, ok := installs[s.Model]
-			if ok {
-				installs[s.Model] = append(installs[s.Model], s)
+			if _, ok := installs[s.Model]; !ok {
+				installs[s.Model] = meta.InstalledSensorList{}
+			}
+			installs[s.Model] = append(installs[s.Model], s)
+		}
 
-			} else {
-				installs[s.Model] = meta.InstalledSensorList{s}
+		for _, v := range installs {
+			for i := 0; i < len(v); i++ {
+				for j := i + 1; j < len(v); j++ {
+					if v[i].Serial != v[j].Serial {
+						continue
+					}
+					if v[i].End.Before(v[j].Start) {
+						continue
+					}
+					if v[i].Start.After(v[j].End) {
+						continue
+					}
+					if v[i].End.Equal(v[j].Start) {
+						continue
+					}
+					if v[i].Start.Equal(v[j].End) {
+						continue
+					}
+
+					t.Errorf("sensor %s/%s at %-5s has location %-2s overlap between %s and %s",
+						v[i].Model, v[i].Serial,
+						v[i].Station, v[i].Location,
+						v[i].Start.Format(meta.DateTimeFormat),
+						v[i].End.Format(meta.DateTimeFormat))
+				}
+			}
+		}
+	})
+
+	t.Run("check for missing sensor stations", func(t *testing.T) {
+		var list meta.StationList
+		loadListFile(t, "../network/stations.csv", &list)
+
+		stations := make(map[string]meta.Station)
+		for _, s := range list {
+			stations[s.Code] = s
+		}
+
+		for _, i := range installed {
+			if _, ok := stations[i.Station]; !ok {
+				t.Errorf("unable to find station: %s", i.Station)
 			}
 		}
 
-		var keys []string
-		for k, _ := range installs {
-			keys = append(keys, k)
+		for _, i := range installed {
+			if s, ok := stations[i.Station]; ok {
+				if i.Start.Before(s.Start) {
+					t.Logf("warning: installed sensor before station has been opened: %s: %s (%s %s)",
+						i.String(), i.Start.String(), s.Code, s.Start.String())
+				}
+				if i.End.After(s.End) {
+					t.Logf("warning: installed sensor after station has been closed: %s: %s (%s %s)",
+						i.String(), i.End.String(), s.Code, s.End.String())
+				}
+			}
 		}
-		sort.Strings(keys)
+	})
 
-		for _, k := range keys {
-			v := installs[k]
+	t.Run("check for missing sensor sites", func(t *testing.T) {
+		var list meta.SiteList
+		loadListFile(t, "../network/sites.csv", &list)
 
-			for i, n := 0, len(v); i < n; i++ {
-				for j := i + 1; j < n; j++ {
-					switch {
-					case v[i].Serial != v[j].Serial:
-					case v[i].End.Before(v[j].Start):
-					case v[i].Start.After(v[j].End):
-					case v[i].End.Equal(v[j].Start):
-					case v[i].Start.Equal(v[j].End):
-					default:
-						t.Errorf("sensor %s/%s at %-5s has location %-2s overlap between %s and %s",
-							v[i].Model, v[i].Serial, v[i].Station, v[i].Location, v[i].Start.Format(meta.DateTimeFormat), v[i].End.Format(meta.DateTimeFormat))
+		sites := make(map[string]map[string]meta.Site)
+		for _, s := range list {
+			if _, ok := sites[s.Station]; !ok {
+				sites[s.Station] = make(map[string]meta.Site)
+			}
+			sites[s.Station][s.Location] = s
+		}
+
+		for _, i := range installed {
+			if _, ok := sites[i.Station]; !ok {
+				t.Errorf("unable to find sites for station: %s", i.Station)
+			}
+		}
+
+		for _, i := range installed {
+			if s, ok := sites[i.Station]; ok {
+				if _, ok := s[i.Location]; !ok {
+					t.Errorf("unable to find sites for station/location: %s/%s", i.Station, i.Location)
+				}
+			}
+		}
+
+		for _, i := range installed {
+			if s, ok := sites[i.Station]; ok {
+				if l, ok := s[i.Location]; ok {
+					if i.Start.Before(l.Start) {
+						t.Logf("warning: installed sensor before site has been opened: %s: %s (%s/%s %s)",
+							i.String(), i.Start.String(), l.Station, l.Location, l.Start.String())
+					}
+					if i.End.After(l.End) {
+						t.Logf("warning: installed sensor after site has been closed: %s: %s (%s/%s %s)",
+							i.String(), i.End.String(), l.Station, l.Location, l.End.String())
 					}
 				}
 			}
 		}
-	}
+	})
 
-	/*
-		t.Log("Check for missing sensor stations")
-		{
-			var stations meta.StationList
-
-			if err := meta.LoadList("../network/stations.csv", &stations); err != nil {
-				t.Fatal(err)
-			}
-
-			sort.Sort(stations)
-
-			for _, i := range installed {
-				n := sort.Search(len(stations), func(j int) bool { return !(stations[j].Code < i.StationCode) })
-				if n < 0 || i.StationCode != stations[n].Code {
-					t.Errorf("unable to find station: %s", i.StationCode)
-				} else {
-					if i.Start.Before(stations[n].Start) {
-						t.Errorf("installed sensor before station has been opened: %s: %s (%s %s)", i.String(), i.Start.String(), stations[n].Code, stations[n].Start.String())
-					}
-					if i.End.After(stations[n].End) {
-						t.Errorf("installed sensor after station has been closed: %s: %s (%s %s)", i.String(), i.End.String(), stations[n].Code, stations[n].End.String())
-					}
-				}
+	t.Run("check for invalid sensor azimuth", func(t *testing.T) {
+		for _, i := range installed {
+			if i.Orientation.Azimuth < -360.0 || i.Orientation.Azimuth > 360.0 {
+				t.Errorf("installed sensor has invalid orientation azimuth: %s [%g]", i.String(), i.Orientation.Azimuth)
 			}
 		}
+	})
 
-		t.Log("Check for missing sensor sites")
-		{
-			var sites meta.SiteList
-
-			if err := meta.LoadList("../network/sites.csv", &sites); err != nil {
-				t.Fatal(err)
-			}
-
-			sort.Sort(sites)
-
-			for _, i := range installed {
-				n := sort.Search(len(sites), func(j int) bool {
-					if sites[j].StationCode > i.StationCode {
-						return true
-					}
-					if sites[j].StationCode < i.StationCode {
-						return false
-					}
-					return !(sites[j].LocationCode < i.LocationCode)
-				})
-				if n < 0 || i.StationCode != sites[n].StationCode || i.LocationCode != sites[n].LocationCode {
-					t.Errorf("unable to find site: %s/%s", i.StationCode, i.LocationCode)
-				} else {
-					if i.Start.Before(sites[n].Start) {
-						t.Errorf("installed sensor before site has been opened: %s: %s (%s/%s %s)", i.String(), i.Start.String(), sites[n].StationCode, sites[n].LocationCode, sites[n].Start.String())
-					}
-					if i.End.After(sites[n].End) {
-						t.Errorf("installed sensor after site has been closed: %s: %s (%s/%s %s)", i.String(), i.End.String(), sites[n].StationCode, sites[n].LocationCode, sites[n].End.String())
-					}
-				}
+	t.Run("check for invalid sensor dip", func(t *testing.T) {
+		for _, i := range installed {
+			if i.Orientation.Dip < -90.0 || i.Orientation.Dip > 90.0 {
+				t.Errorf("installed sensor has invalid orientation dip: %s [%g]", i.String(), i.Orientation.Dip)
 			}
 		}
-	*/
+	})
 
-	for _, i := range installed {
-		if i.Orientation.Azimuth < -360.0 || i.Orientation.Azimuth > 360.0 {
-			t.Errorf("installed sensor has invalid orientation azimuth: %s [%g]", i.String(), i.Orientation.Azimuth)
-		}
-		if i.Orientation.Dip < -90.0 || i.Orientation.Dip > 90.0 {
-			t.Errorf("installed sensor has invalid orientation dip: %s [%g]", i.String(), i.Orientation.Dip)
-		}
-	}
-
-	var assets meta.AssetList
-	t.Log("Load receiver sensors file")
-	{
-		if err := meta.LoadList("../assets/sensors.csv", &assets); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	t.Log("Check for sensor assets")
-	{
+	t.Run("check for missing sensor assets", func(t *testing.T) {
+		var assets meta.AssetList
+		loadListFile(t, "../assets/sensors.csv", &assets)
 		for _, s := range installed {
 			var found bool
 			for _, a := range assets {
@@ -161,10 +162,11 @@ func TestSensors(t *testing.T) {
 				}
 				found = true
 			}
-			if !found {
-				t.Errorf("unable to find sensor asset: %s [%s]", s.Model, s.Serial)
+			if found {
+				continue
 			}
+			t.Errorf("unable to find sensor asset: %s [%s]", s.Model, s.Serial)
 		}
-	}
+	})
 
 }

--- a/tests/sessions_test.go
+++ b/tests/sessions_test.go
@@ -10,25 +10,39 @@ import (
 func TestSessions(t *testing.T) {
 
 	var sessions meta.SessionList
+	loadListFile(t, "../install/sessions.csv", &sessions)
 
-	t.Log("Load sessions file")
-	if err := meta.LoadList("../install/sessions.csv", &sessions); err != nil {
-		t.Fatal(err)
-	}
-
-	for i := 0; i < len(sessions); i++ {
-		for j := i + 1; j < len(sessions); j++ {
-			if sessions[i].Mark != sessions[j].Mark {
-				continue
-			}
-			if sessions[i].Model != sessions[j].Model {
-				continue
-			}
-			if sessions[i].Interval != sessions[j].Interval {
-				continue
-			}
-			if sessions[i].End.Equal(sessions[j].Start) {
-				t.Errorf("session start matches end: " + strings.Join([]string{
+	t.Run("check for session overlaps", func(t *testing.T) {
+		for i := 0; i < len(sessions); i++ {
+			for j := i + 1; j < len(sessions); j++ {
+				if sessions[i].Mark != sessions[j].Mark {
+					continue
+				}
+				if sessions[i].Model != sessions[j].Model {
+					continue
+				}
+				if sessions[i].Interval != sessions[j].Interval {
+					continue
+				}
+				if sessions[i].End.Equal(sessions[j].Start) {
+					t.Errorf("session start matches end: " + strings.Join([]string{
+						sessions[i].Mark,
+						sessions[i].Interval.String(),
+						sessions[i].Start.String(),
+						sessions[i].End.String(),
+						sessions[j].Interval.String(),
+						sessions[j].Start.String(),
+						sessions[j].End.String(),
+					}, " "))
+					continue
+				}
+				if sessions[i].Start.After(sessions[j].End) {
+					continue
+				}
+				if !sessions[i].End.After(sessions[j].Start) {
+					continue
+				}
+				t.Errorf("session overlap: " + strings.Join([]string{
 					sessions[i].Mark,
 					sessions[i].Interval.String(),
 					sessions[i].Start.String(),
@@ -37,57 +51,49 @@ func TestSessions(t *testing.T) {
 					sessions[j].Start.String(),
 					sessions[j].End.String(),
 				}, " "))
-				continue
 			}
-			if sessions[i].Start.After(sessions[j].End) {
-				continue
-			}
-			if !sessions[i].End.After(sessions[j].Start) {
-				continue
-			}
-			t.Errorf("session overlap: " + strings.Join([]string{
-				sessions[i].Mark,
-				sessions[i].Interval.String(),
-				sessions[i].Start.String(),
-				sessions[i].End.String(),
-				sessions[j].Interval.String(),
-				sessions[j].Start.String(),
-				sessions[j].End.String(),
-			}, " "))
 		}
-	}
+	})
 
-	marks := make(map[string]meta.Mark)
-	{
+	t.Run("check for missing session marks", func(t *testing.T) {
 		var list meta.MarkList
-		t.Log("Load marks file")
-		if err := meta.LoadList("../network/marks.csv", &list); err != nil {
-			t.Fatal(err)
-		}
+		loadListFile(t, "../network/marks.csv", &list)
+
+		marks := make(map[string]meta.Mark)
 		for _, m := range list {
 			marks[m.Code] = m
 		}
-	}
+		for _, s := range sessions {
+			if _, ok := marks[s.Mark]; !ok {
+				t.Errorf("unknown session mark: " + s.Mark)
+			}
+		}
+	})
 
-	for _, s := range sessions {
-		if _, ok := marks[s.Mark]; !ok {
-			t.Log("unknown session mark: " + s.Mark)
+	t.Run("check for session span mismatches", func(t *testing.T) {
+		for _, s := range sessions {
+			if s.Start.After(s.End) {
+				t.Errorf("session span mismatch: " + strings.Join([]string{
+					s.Mark,
+					s.Interval.String(),
+					s.Start.String(),
+					"after",
+					s.End.String(),
+				}, " "))
+			}
 		}
-		if s.Start.After(s.End) {
-			t.Log("session span mismatch: " + strings.Join([]string{
-				s.Mark,
-				s.Interval.String(),
-				s.Start.String(),
-				"after",
-				s.End.String(),
-			}, " "))
+	})
+
+	t.Run("check for unknown session satellite systems", func(t *testing.T) {
+		for _, s := range sessions {
+			switch s.SatelliteSystem {
+			case "GPS":
+			case "GPS+GLO":
+			case "GPS+GLO+GAL+BDS+QZSS":
+			default:
+				t.Error("unknown satellite system: " + s.SatelliteSystem)
+			}
 		}
-		switch s.SatelliteSystem {
-		case "GPS":
-		case "GPS+GLO":
-		case "GPS+GLO+GAL+BDS+QZSS":
-		default:
-			t.Error("unknown satellite system: " + s.SatelliteSystem)
-		}
-	}
+
+	})
 }

--- a/tests/sites_test.go
+++ b/tests/sites_test.go
@@ -9,19 +9,16 @@ import (
 func TestSites(t *testing.T) {
 
 	var sites meta.SiteList
-	t.Log("Load installed sites file")
-	{
-		if err := meta.LoadList("../network/sites.csv", &sites); err != nil {
-			t.Fatal(err)
-		}
-	}
+	loadListFile(t, "../network/sites.csv", &sites)
 
-	for i := 0; i < len(sites); i++ {
-		for j := i + 1; j < len(sites); j++ {
-			if sites[i].Station == sites[j].Station && sites[i].Location == sites[j].Location {
-				t.Errorf("site duplication: " + sites[i].Station + "/" + sites[i].Location)
+	t.Run("check for duplicated sites", func(t *testing.T) {
+		for i := 0; i < len(sites); i++ {
+			for j := i + 1; j < len(sites); j++ {
+				if sites[i].Station == sites[j].Station && sites[i].Location == sites[j].Location {
+					t.Errorf("site duplication: " + sites[i].Station + "/" + sites[i].Location)
+				}
 			}
 		}
-	}
+	})
 
 }

--- a/tests/streams_test.go
+++ b/tests/streams_test.go
@@ -15,146 +15,164 @@ var sensorSamplingRates = []float64{0.1, 1, 10, 50, 100, 200}
 func TestStreams(t *testing.T) {
 
 	var streams meta.StreamList
+	loadListFile(t, "../install/streams.csv", &streams)
 
-	t.Log("Load streams file")
-	if err := meta.LoadList("../install/streams.csv", &streams); err != nil {
-		t.Fatal(err)
-	}
+	t.Run("check for overlapping streams", func(t *testing.T) {
+		for i := 0; i < len(streams); i++ {
+			for j := i + 1; j < len(streams); j++ {
+				if streams[i].Station != streams[j].Station {
+					continue
+				}
+				if streams[i].Location != streams[j].Location {
+					continue
+				}
+				if streams[i].Start.After(streams[j].End) {
+					continue
+				}
+				if streams[i].End.Before(streams[j].Start) {
+					continue
+				}
+				if streams[i].SamplingRate != streams[j].SamplingRate {
+					continue
+				}
 
-	for i := 0; i < len(streams); i++ {
-		for j := i + 1; j < len(streams); j++ {
-			if streams[i].Station != streams[j].Station {
-				continue
+				t.Errorf("stream overlap: " + strings.Join([]string{
+					streams[i].Station,
+					streams[i].Location,
+					streams[i].Start.String(),
+					streams[i].End.String(),
+				}, " "))
 			}
-			if streams[i].Location != streams[j].Location {
-				continue
-			}
-			if streams[i].Start.After(streams[j].End) {
-				continue
-			}
-			if streams[i].End.Before(streams[j].Start) {
-				continue
-			}
-			if streams[i].SamplingRate != streams[j].SamplingRate {
-				continue
-			}
-			t.Errorf("stream overlap: " + strings.Join([]string{
-				streams[i].Station,
-				streams[i].Location,
-				streams[i].Start.String(),
-				streams[i].End.String(),
-			}, " "))
 		}
-	}
+	})
 
 	stas := make(map[string]meta.Station)
-	{
+	t.Run("load stations file", func(t *testing.T) {
 		var list meta.StationList
-		t.Log("Load stations file")
-		if err := meta.LoadList("../network/stations.csv", &list); err != nil {
-			t.Fatal(err)
-		}
+		loadListFile(t, "../network/stations.csv", &list)
 		for _, s := range list {
 			stas[s.Code] = s
 		}
-	}
+	})
 
 	sites := make(map[string]map[string]meta.Site)
-	{
+	t.Run("load sites file", func(t *testing.T) {
 		var list meta.SiteList
-		t.Log("Load sites file")
-		if err := meta.LoadList("../network/sites.csv", &list); err != nil {
-			t.Fatal(err)
-		}
+		loadListFile(t, "../network/sites.csv", &list)
 		for _, s := range list {
 			if _, ok := sites[s.Station]; !ok {
 				sites[s.Station] = make(map[string]meta.Site)
 			}
 			sites[s.Station][s.Location] = s
 		}
-	}
+	})
 
-	for _, s := range streams {
-		if s.SamplingRate == 0 {
-			t.Errorf("invalid stream sample rate: " + strings.Join([]string{
-				s.Station,
-				s.Location,
-				s.Start.String(),
-				s.End.String(),
-			}, " "))
+	t.Run("check for invalid stream sample rates", func(t *testing.T) {
+		for _, s := range streams {
+			if s.SamplingRate == 0 {
+				t.Errorf("invalid stream sample rate: " + strings.Join([]string{
+					s.Station,
+					s.Location,
+					s.Start.String(),
+					s.End.String(),
+				}, " "))
+			}
 		}
-	}
+	})
 
-	for _, c := range streams {
-		if _, ok := stas[c.Station]; !ok {
-			t.Log("unknown stream station: " + c.Station)
-		} else if s, ok := sites[c.Station]; !ok {
-			t.Log("unknown stream station: " + c.Station)
-		} else if _, ok := s[c.Location]; !ok {
-			t.Log("unknown stream station/location: " + c.Station + "/" + c.Location)
+	t.Run("check for invalid stream spans", func(t *testing.T) {
+		for _, c := range streams {
+			if c.Start.After(c.End) {
+				t.Error("stream span mismatch: " + strings.Join([]string{
+					c.Station,
+					c.Location,
+					c.Start.String(),
+					"after",
+					c.End.String(),
+				}, " "))
+			}
 		}
-		if c.Start.After(c.End) {
-			t.Log("stream span mismatch: " + strings.Join([]string{
-				c.Station,
-				c.Location,
-				c.Start.String(),
-				"after",
-				c.End.String(),
-			}, " "))
-		}
-	}
+	})
 
-	var assets = make(map[string]meta.Asset)
-	{
-		var list meta.AssetList
-		t.Log("Load recorders assets file")
-		if err := meta.LoadList("../assets/recorders.csv", &list); err != nil {
-			t.Fatal(err)
+	t.Run("check for invalid stream stations", func(t *testing.T) {
+		for _, c := range streams {
+			if _, ok := stas[c.Station]; !ok {
+				t.Error("unknown stream station: " + c.Station)
+			}
 		}
-		for _, l := range list {
-			assets[l.Model+":::"+l.Serial] = l
-		}
-		t.Log("Load sensors assets file")
-		if err := meta.LoadList("../assets/sensors.csv", &list); err != nil {
-			t.Fatal(err)
-		}
-		for _, s := range list {
-			assets[s.Model+":::"+s.Serial] = s
-		}
-	}
+	})
 
-	var recorders []meta.InstalledRecorder
-	{
-		var list meta.InstalledRecorderList
-		t.Log("Load recorders file")
-		if err := meta.LoadList("../install/recorders.csv", &list); err != nil {
-			t.Fatal(err)
+	t.Run("check for invalid stream sites", func(t *testing.T) {
+		for _, c := range streams {
+			if _, ok := sites[c.Station]; !ok {
+				t.Error("unknown stream station: " + c.Station)
+			}
 		}
-		for _, r := range list {
-			recorders = append(recorders, r)
+	})
+
+	t.Run("check for invalid stream locations", func(t *testing.T) {
+		for _, c := range streams {
+			if s, ok := sites[c.Station]; ok {
+				if _, ok := s[c.Location]; !ok {
+					t.Error("unknown stream station/location: " + c.Station + "/" + c.Location)
+				}
+			}
 		}
-	}
+	})
+
+	t.Run("check for invalid stream spans", func(t *testing.T) {
+		for _, c := range streams {
+			if c.Start.After(c.End) {
+				t.Error("stream span mismatch: " + strings.Join([]string{
+					c.Station,
+					c.Location,
+					c.Start.String(),
+					"after",
+					c.End.String(),
+				}, " "))
+			}
+		}
+	})
 
 	var missing []meta.Stream
 
-	for _, r := range recorders {
-		if a, ok := assets[r.DataloggerModel+":::"+r.Serial]; !ok || a.Number == "" {
-			continue
+	t.Run("check for missing recorder streams", func(t *testing.T) {
+
+		var list meta.AssetList
+		loadListFile(t, "../assets/recorders.csv", &list)
+
+		var assets = make(map[string]meta.Asset)
+		for _, l := range list {
+			assets[l.Model+":::"+l.Serial] = l
 		}
-		if r.End.Before(time.Now()) {
-			continue
-		}
-		var handled bool
-		for _, s := range streams {
-			if s.Station != r.Station || r.Location != s.Location {
+
+		var recorders meta.InstalledRecorderList
+		loadListFile(t, "../install/recorders.csv", &recorders)
+
+		for _, r := range recorders {
+			a, ok := assets[r.DataloggerModel+":::"+r.Serial]
+			if !ok {
 				continue
 			}
-			if r.Start.After(s.End) || r.End.Before(s.Start) {
+			if a.Number == "" {
 				continue
 			}
-			handled = true
-		}
-		if !handled {
+			if r.End.Before(time.Now()) {
+				continue
+			}
+			var handled bool
+			for _, s := range streams {
+				if s.Station != r.Station || r.Location != s.Location {
+					continue
+				}
+				if r.Start.After(s.End) || r.End.Before(s.Start) {
+					continue
+				}
+				handled = true
+			}
+			if handled {
+				continue
+			}
 			for _, sps := range recorderSamplingRates {
 				missing = append(missing, meta.Stream{
 					Station:      r.Station,
@@ -166,40 +184,47 @@ func TestStreams(t *testing.T) {
 					},
 				})
 			}
-			t.Errorf("no current stream defined for recorder: %s [%s/%s] %s %s", r.String(), r.Station, r.Location, r.Start, r.End)
+			t.Errorf("no current stream defined for recorder: %s [%s/%s] %s %s",
+				r.String(), r.Station, r.Location, r.Start, r.End)
 		}
-	}
+	})
 
-	var sensors []meta.InstalledSensor
-	{
-		var list meta.InstalledSensorList
-		t.Log("Load sensors file")
-		if err := meta.LoadList("../install/sensors.csv", &list); err != nil {
-			t.Fatal(err)
-		}
-		for _, s := range list {
-			sensors = append(sensors, s)
-		}
-	}
+	t.Run("check for missing sensor streams", func(t *testing.T) {
+		var sensors meta.InstalledSensorList
+		loadListFile(t, "../install/sensors.csv", &sensors)
 
-	for _, v := range sensors {
-		if a, ok := assets[v.Model+":::"+v.Serial]; !ok || a.Number == "" {
-			continue
+		var list meta.AssetList
+		loadListFile(t, "../assets/sensors.csv", &list)
+
+		var assets = make(map[string]meta.Asset)
+		for _, l := range list {
+			assets[l.Model+":::"+l.Serial] = l
 		}
-		if v.End.Before(time.Now()) {
-			continue
-		}
-		var handled bool
-		for _, s := range streams {
-			if s.Station != v.Station || v.Location != s.Location {
+
+		for _, v := range sensors {
+			a, ok := assets[v.Model+":::"+v.Serial]
+			if !ok {
 				continue
 			}
-			if v.Start.After(s.End) || v.End.Before(s.Start) {
+			if a.Number == "" {
 				continue
 			}
-			handled = true
-		}
-		if !handled {
+			if v.End.Before(time.Now()) {
+				continue
+			}
+			var handled bool
+			for _, s := range streams {
+				if s.Station != v.Station || v.Location != s.Location {
+					continue
+				}
+				if v.Start.After(s.End) || v.End.Before(s.Start) {
+					continue
+				}
+				handled = true
+			}
+			if handled {
+				continue
+			}
 			for _, sps := range sensorSamplingRates {
 				missing = append(missing, meta.Stream{
 					Station:      v.Station,
@@ -211,13 +236,15 @@ func TestStreams(t *testing.T) {
 					},
 				})
 			}
-			t.Errorf("no current stream defined for sensor: %s [%s/%s] %s %s", v.String(), v.Station, v.Location, v.Start, v.End)
+			t.Errorf("no current stream defined for sensor: %s [%s/%s] %s %s",
+				v.String(), v.Station, v.Location, v.Start, v.End)
 		}
-	}
+	})
+
+	sort.Sort(meta.StreamList(missing))
 
 	if len(missing) > 0 {
-		sort.Sort(meta.StreamList(missing))
-		t.Log("\n" + string(meta.MarshalList(meta.StreamList(missing))))
+		t.Error("\n" + string(meta.MarshalList(meta.StreamList(missing))))
 	}
 
 }


### PR DESCRIPTION
@dc735 an update to the testing code. There's not much new here, rather a switch to using the `t.Run` mechanism that became available in `go 1.7`. 
It basically allows some form of isolation between tests (one part can have a fatal result and stop but other parts will continue to be tested if possible).

I've also tried to make them a little more readable, e.g. being explicit about lists of 

> `if ( something ) { continue }` 

rather than use a switch which is more compact but isn't as obvious what it's doing.

I've also brought all the `csv` file loading parts into a single function which is called with the test variable so that it can have a fatal error.

There are still a couple of tests that only make a warning message (need `go test -v` to see them), I'll think of a way to bring these online but it may need some adjustments to the db or to the extraction code - mostly related to station/site stop/start times not matching when sensors are installed.