### PR TITLE
added go fmt and go vet tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -10,10 +10,10 @@ error_handler () {
 trap error_handler ERR
 
 echo "go formatting" 1>&2
-test -z "$(find ./meta ./resp ./tests ./tools -name "*.go" -exec gofmt -l {} \; | tee /dev/stderr)"
+test -z "$(find ./meta ./resp ./internal ./tests ./tools -name "*.go" -exec gofmt -l {} \; | tee /dev/stderr)"
 
 echo "go vetting" 1>&2
-go vet ./meta ./resp ./tests ./tools/...
+go vet ./meta ./resp ./internal/... ./tests ./tools/...
 
 echo "go testing" 1>&2
 go test ./meta

--- a/test.sh
+++ b/test.sh
@@ -9,6 +9,13 @@ error_handler () {
 
 trap error_handler ERR
 
+echo "go formatting" 1>&2
+test -z "$(find ./meta ./resp ./tests ./tools -name "*.go" -exec gofmt -l {} \; | tee /dev/stderr)"
+
+echo "go vetting" 1>&2
+go vet ./meta ./resp ./tests ./tools/...
+
+echo "go testing" 1>&2
 go test ./meta
 go test ./tests
 go test ./tools/stationxml
@@ -19,6 +26,16 @@ go test ./tools/spectra
 go test ./tools/chart
 go test ./tools/impact
 go test ./tools/rinexml
+
+echo "go building" 1>&2
+go build ./tools/stationxml
+go build ./tools/altus
+go build ./tools/cusp
+go build ./tools/amplitude
+go build ./tools/spectra
+go build ./tools/chart
+go build ./tools/impact
+go build ./tools/rinexml
 
 exit $errcount
 

--- a/tools/gloria/main.go
+++ b/tools/gloria/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/GeoNet/kit/gloria_pb"
 	"github.com/GeoNet/delta/meta"
+	"github.com/GeoNet/kit/gloria_pb"
 	"github.com/golang/protobuf/proto"
 	"io/ioutil"
 	"os"

--- a/tools/sit/main.go
+++ b/tools/sit/main.go
@@ -99,11 +99,10 @@ func main() {
 			Location: m.Location,
 			Span: &sit_delta_pb.Span{
 				Start: m.Start.Unix(),
-				End: m.End.Unix(),
+				End:   m.End.Unix(),
 			},
 		})
 	}
-
 
 	//asset files -- All have the same format so just pull them all into a single big map
 	assetFiles := []string{
@@ -167,7 +166,7 @@ func main() {
 				AssetNumber:  assets[i.Make+i.Model+i.Serial].Number,
 				SerialNumber: i.Serial,
 				Manufacturer: i.Make,
-				Height: -i.Vertical,
+				Height:       -i.Vertical,
 			},
 			Installed: &sit_delta_pb.Span{
 				Start: i.Start.Unix(),
@@ -184,9 +183,9 @@ func main() {
 	}
 	connections := make(map[string][]string)
 	for _, c := range connectionList {
-		 //TODO - Do we need to display 'connection' info?
+		//TODO - Do we need to display 'connection' info?
 
-		arr := connections[strings.TrimSpace(c.Place + c.Role)]
+		arr := connections[strings.TrimSpace(c.Place+c.Role)]
 		found := false
 		for _, s := range arr {
 			if s == c.Station {
@@ -206,7 +205,7 @@ func main() {
 		os.Exit(-1)
 	}
 	for _, i := range deployedDataloggerList {
-		stations := connections[strings.TrimSpace(i.Place + i.Role)]
+		stations := connections[strings.TrimSpace(i.Place+i.Role)]
 		for _, s := range stations {
 			equipment[s] = append(equipment[s], &sit_delta_pb.Equipment_Install{
 				Equipment: &sit_delta_pb.Equipment{
@@ -260,7 +259,7 @@ func main() {
 				AssetNumber:  assets[i.Make+i.Model+i.Serial].Number,
 				SerialNumber: i.Serial,
 				Manufacturer: i.Make,
-				Height: -i.Vertical,
+				Height:       -i.Vertical,
 			},
 			Installed: &sit_delta_pb.Span{
 				Start: i.Start.Unix(),
@@ -332,7 +331,7 @@ func main() {
 				AssetNumber:  assets[i.Make+i.Model+i.Serial].Number,
 				SerialNumber: i.Serial,
 				Manufacturer: i.Make,
-				Height: -i.Vertical,
+				Height:       -i.Vertical,
 			},
 			Installed: &sit_delta_pb.Span{
 				Start: i.Start.Unix(),
@@ -345,7 +344,6 @@ func main() {
 			}
 		}
 	}
-
 
 	for _, m := range markList {
 
@@ -361,7 +359,7 @@ func main() {
 				},
 				Monument: &sit_delta_pb.Monument{
 					DomesNumber: l.DomesNumber,
-					Height: l.GroundRelationship,
+					Height:      l.GroundRelationship,
 				},
 			}
 			im = append(im, &newMonument)
@@ -374,9 +372,9 @@ func main() {
 			InstalledMonument: im,
 			Point: &sit_delta_pb.Point{
 				Longitude: m.Longitude,
-				Latitude: m.Latitude,
+				Latitude:  m.Latitude,
 				Elevation: m.Elevation,
-				Datum: m.Datum,
+				Datum:     m.Datum,
 			},
 		}
 

--- a/tools/stationxml/build.go
+++ b/tools/stationxml/build.go
@@ -384,8 +384,8 @@ func (b *Builder) Construct(base string) ([]stationxml.Network, error) {
 					channels = append(channels, stationxml.Channel{
 						BaseNode: stationxml.BaseNode{
 							Code:      channel, //response.Label + string(cha),
-							StartDate: &stationxml.DateTime{installation.Start},
-							EndDate:   &stationxml.DateTime{installation.End},
+							StartDate: &stationxml.DateTime{Time: installation.Start},
+							EndDate:   &stationxml.DateTime{Time: installation.End},
 							RestrictedStatus: func() stationxml.RestrictedStatus {
 								switch network.Restricted {
 								case true:
@@ -493,11 +493,11 @@ func (b *Builder) Construct(base string) ([]stationxml.Network, error) {
 							Model:        installation.Sensor.Model,
 							SerialNumber: installation.Sensor.Serial,
 							InstallationDate: func() *stationxml.DateTime {
-								return &stationxml.DateTime{installation.Sensor.Start}
+								return &stationxml.DateTime{Time: installation.Sensor.Start}
 							}(),
 							RemovalDate: func() *stationxml.DateTime {
 								if time.Now().After(installation.Sensor.End) {
-									return &stationxml.DateTime{installation.Sensor.End}
+									return &stationxml.DateTime{Time: installation.Sensor.End}
 								}
 								return nil
 							}(),
@@ -532,11 +532,11 @@ func (b *Builder) Construct(base string) ([]stationxml.Network, error) {
 							Model:        installation.Datalogger.Model,
 							SerialNumber: installation.Datalogger.Serial,
 							InstallationDate: func() *stationxml.DateTime {
-								return &stationxml.DateTime{installation.Datalogger.Start}
+								return &stationxml.DateTime{Time: installation.Datalogger.Start}
 							}(),
 							RemovalDate: func() *stationxml.DateTime {
 								if time.Now().After(installation.Datalogger.End) {
-									return &stationxml.DateTime{installation.Datalogger.End}
+									return &stationxml.DateTime{Time: installation.Datalogger.End}
 								}
 								return nil
 							}(),
@@ -609,7 +609,7 @@ func (b *Builder) Construct(base string) ([]stationxml.Network, error) {
 
 		sort.Sort(Channels(channels))
 
-		start, end := &(stationxml.DateTime{station.Start}), &(stationxml.DateTime{station.End})
+		start, end := &(stationxml.DateTime{Time: station.Start}), &(stationxml.DateTime{Time: station.End})
 		if b.Installed() && len(channels) > 0 {
 			start, end = channels[0].StartDate, channels[len(channels)-1].EndDate
 		}
@@ -673,12 +673,12 @@ func (b *Builder) Construct(base string) ([]stationxml.Network, error) {
 					return ""
 				}(),
 			},
-			CreationDate: stationxml.DateTime{station.Start},
+			CreationDate: stationxml.DateTime{Time: station.Start},
 			TerminationDate: func() *stationxml.DateTime {
 				if time.Now().Before(station.End) {
 					return nil
 				}
-				return &stationxml.DateTime{station.End}
+				return &stationxml.DateTime{Time: station.End}
 			}(),
 			Channels: channels,
 		})

--- a/tools/stationxml/response.go
+++ b/tools/stationxml/response.go
@@ -33,7 +33,7 @@ func a2dResponseStage(stage Stage) stationxml.ResponseStage {
 			Frequency: stage.frequency,
 		},
 		Decimation: &stationxml.Decimation{
-			InputSampleRate: stationxml.Frequency{stationxml.Float{Value: stage.responseStage.SampleRate}},
+			InputSampleRate: stationxml.Frequency{Float: stationxml.Float{Value: stage.responseStage.SampleRate}},
 			Factor: func() int32 {
 				if stage.responseStage.Decimate != 0 {
 					return stage.responseStage.Decimate
@@ -80,7 +80,7 @@ func firResponseStage(filter resp.FIR, stage Stage) stationxml.ResponseStage {
 			Frequency: stage.frequency,
 		},
 		Decimation: &stationxml.Decimation{
-			InputSampleRate: stationxml.Frequency{stationxml.Float{Value: filter.Decimation * stage.responseStage.SampleRate}},
+			InputSampleRate: stationxml.Frequency{Float: stationxml.Float{Value: filter.Decimation * stage.responseStage.SampleRate}},
 			Factor: func() int32 {
 				if stage.responseStage.Decimate != 0 {
 					return stage.responseStage.Decimate
@@ -110,8 +110,8 @@ func polyResponseStage(filter resp.Polynomial, stage Stage) stationxml.ResponseS
 			OutputUnits: stationxml.Units{Name: stage.responseStage.OutputUnits},
 		},
 		ApproximationType:       stationxml.ApproximationType(filter.ApproximationType),
-		FrequencyLowerBound:     stationxml.Frequency{stationxml.Float{Value: filter.FrequencyLowerBound}},
-		FrequencyUpperBound:     stationxml.Frequency{stationxml.Float{Value: filter.FrequencyUpperBound}},
+		FrequencyLowerBound:     stationxml.Frequency{Float: stationxml.Float{Value: filter.FrequencyLowerBound}},
+		FrequencyUpperBound:     stationxml.Frequency{Float: stationxml.Float{Value: filter.FrequencyUpperBound}},
 		ApproximationLowerBound: strconv.FormatFloat(filter.ApproximationLowerBound, 'g', -1, 64),
 		ApproximationUpperBound: strconv.FormatFloat(filter.ApproximationUpperBound, 'g', -1, 64),
 		MaximumError:            filter.MaximumError,
@@ -165,7 +165,7 @@ func pazResponseStage(filter resp.PAZ, stage Stage) stationxml.ResponseStage {
 			return 1.0 / filter.Gain(stage.frequency)
 		}(),
 		NormalizationFrequency: stationxml.Frequency{
-			stationxml.Float{Value: stage.frequency},
+			Float: stationxml.Float{Value: stage.frequency},
 		},
 		Zeros: zeros,
 		Poles: poles,

--- a/tools/stationxml/stage.go
+++ b/tools/stationxml/stage.go
@@ -46,7 +46,7 @@ func (s Stage) a2d() stationxml.ResponseStage {
 			Frequency: s.frequency,
 		},
 		Decimation: &stationxml.Decimation{
-			InputSampleRate: stationxml.Frequency{stationxml.Float{Value: s.responseStage.SampleRate}},
+			InputSampleRate: stationxml.Frequency{Float: stationxml.Float{Value: s.responseStage.SampleRate}},
 			Factor: func() int32 {
 				if s.responseStage.Decimate != 0 {
 					return s.responseStage.Decimate
@@ -90,7 +90,7 @@ func (s Stage) paz(pz resp.PAZ) stationxml.ResponseStage {
 			return 1.0 / pz.Gain(s.frequency)
 		}(),
 		NormalizationFrequency: stationxml.Frequency{
-			stationxml.Float{Value: s.frequency},
+			Float: stationxml.Float{Value: s.frequency},
 		},
 		Zeros: zeros,
 		Poles: poles,
@@ -130,8 +130,8 @@ func (s Stage) polynomial(p resp.Polynomial) stationxml.ResponseStage {
 			OutputUnits: stationxml.Units{Name: s.responseStage.OutputUnits},
 		},
 		ApproximationType:       stationxml.ApproximationType(p.ApproximationType),
-		FrequencyLowerBound:     stationxml.Frequency{stationxml.Float{Value: p.FrequencyLowerBound}},
-		FrequencyUpperBound:     stationxml.Frequency{stationxml.Float{Value: p.FrequencyUpperBound}},
+		FrequencyLowerBound:     stationxml.Frequency{Float: stationxml.Float{Value: p.FrequencyLowerBound}},
+		FrequencyUpperBound:     stationxml.Frequency{Float: stationxml.Float{Value: p.FrequencyUpperBound}},
 		ApproximationLowerBound: strconv.FormatFloat(p.ApproximationLowerBound, 'g', -1, 64),
 		ApproximationUpperBound: strconv.FormatFloat(p.ApproximationUpperBound, 'g', -1, 64),
 		MaximumError:            p.MaximumError,
@@ -203,7 +203,7 @@ func (s Stage) fir(f resp.FIR) stationxml.ResponseStage {
 			Frequency: s.frequency,
 		},
 		Decimation: &stationxml.Decimation{
-			InputSampleRate: stationxml.Frequency{stationxml.Float{Value: f.Decimation * s.responseStage.SampleRate}},
+			InputSampleRate: stationxml.Frequency{Float: stationxml.Float{Value: f.Decimation * s.responseStage.SampleRate}},
 			Factor: func() int32 {
 				if s.responseStage.Decimate != 0 {
 					return s.responseStage.Decimate

--- a/vendor/github.com/ozym/fdsn/stationxml/response_stage.go
+++ b/vendor/github.com/ozym/fdsn/stationxml/response_stage.go
@@ -7,7 +7,7 @@ type ResponseStage struct {
 	// A choice of response types. There should be one response per stage.
 	PolesZeros   *PolesZeros   `xml:",omitempty" json:",omitempty"`
 	Coefficients *Coefficients `xml:",omitempty" json:",omitempty"`
-	ResponseList *ResponseList `xml:,omitempty" json:",omitempty"`
+	ResponseList *ResponseList `xml:",omitempty" json:",omitempty"`
 	FIR          *FIR          `xml:",omitempty" json:",omitempty"`
 	Polynomial   *Polynomial   `xml:",omitempty" json:",omitempty"`
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -21,10 +21,10 @@
 			"revisionTime": "2017-08-16T00:15:14Z"
 		},
 		{
-			"checksumSHA1": "GoEtguzRyXdK8vyOEKFLynWOIcM=",
+			"checksumSHA1": "RfmPu6hns5G1FNuZU5KtLNxaKjo=",
 			"path": "github.com/ozym/fdsn/stationxml",
-			"revision": "fb491902e5f3d19c617a215b80cfe895e8db35e3",
-			"revisionTime": "2017-03-31T10:01:14Z"
+			"revision": "071f85c039b8e5f6c110ea9e8c83e994fe917d51",
+			"revisionTime": "2017-12-07T09:02:38Z"
 		},
 		{
 			"checksumSHA1": "0KwOlQV1dNUh9X8t+5s7nX5bqfk=",


### PR DESCRIPTION
seems like a good idea.

mostly fixes `"uses unkeyed fields"` vetting warnings and some fmt changes in sit and gloria pb code.

am not  using the "-s" tag to gofmt, will add this once I update my vim macros.

you have to jump through hoops to avoid ./vendor. currently the yaml code isn't passing go vet.