### PR TITLE
updated kinemtrics sbepi paz

### DIFF
--- a/resp/auto.go
+++ b/resp/auto.go
@@ -1200,9 +1200,16 @@ var Responses []Response = []Response{
 				FilterList: []string{"Kinemetrics SBEPI"},
 				Stages: []ResponseStage{
 					{
-						Type:       "paz",
-						Lookup:     "Kinemetrics SBEPI",
-						Filter:     "Kinemetrics SBEPI",
+						Type:   "paz",
+						Lookup: "FBA-ES-T",
+						Filter: "Kinemetrics SBEPI",
+						StageSet: PAZ{
+							Name:  "FBA-ES-T",
+							Code:  PZFunctionLaplaceRadiansPerSecond,
+							Type:  "Laplace transform analog stage response, in rad/sec.",
+							Notes: "Standard response of an Kinemetric's EpiSensor FBA-ES sensor, they are built with a wide range of gains. We use +/- 20V @ +/-2 g for the National Network, and +/- 2.5V @ +/- 2g for the ETNA strong motion recorders.",
+							Poles: []complex128{(-981 + 1009i), (-981 - 1009i), (-3290 + 1263i), (-3290 - 1263i)},
+						},
 						Frequency:  1,
 						SampleRate: 0,
 						Decimate:   0,

--- a/resp/responses/sensors/kinemetrics.yaml
+++ b/resp/responses/sensors/kinemetrics.yaml
@@ -168,7 +168,7 @@ filter:
     outputunits: V
   Kinemetrics SBEPI:
   - type: paz
-    lookup: Kinemetrics SBEPI
+    lookup: FBA-ES-T
     frequency: 1
     samplerate: 0
     decimate: 0


### PR DESCRIPTION
The PAZ lookup for the borehole SBEPI sensor was set to a missing value, this should have been pointing to the existing FBA-ES-T lookup.