### PR TITLE
fixed govet "composite literal uses unkeyed fields" warning

### DIFF
--- a/tools/stationxml/build.go
+++ b/tools/stationxml/build.go
@@ -384,8 +384,8 @@ func (b *Builder) Construct(base string) ([]stationxml.Network, error) {
 					channels = append(channels, stationxml.Channel{
 						BaseNode: stationxml.BaseNode{
 							Code:      channel, //response.Label + string(cha),
-							StartDate: &stationxml.DateTime{installation.Start},
-							EndDate:   &stationxml.DateTime{installation.End},
+							StartDate: &stationxml.DateTime{Time: installation.Start},
+							EndDate:   &stationxml.DateTime{Time: installation.End},
 							RestrictedStatus: func() stationxml.RestrictedStatus {
 								switch network.Restricted {
 								case true:
@@ -493,11 +493,11 @@ func (b *Builder) Construct(base string) ([]stationxml.Network, error) {
 							Model:        installation.Sensor.Model,
 							SerialNumber: installation.Sensor.Serial,
 							InstallationDate: func() *stationxml.DateTime {
-								return &stationxml.DateTime{installation.Sensor.Start}
+								return &stationxml.DateTime{Time: installation.Sensor.Start}
 							}(),
 							RemovalDate: func() *stationxml.DateTime {
 								if time.Now().After(installation.Sensor.End) {
-									return &stationxml.DateTime{installation.Sensor.End}
+									return &stationxml.DateTime{Time: installation.Sensor.End}
 								}
 								return nil
 							}(),
@@ -532,11 +532,11 @@ func (b *Builder) Construct(base string) ([]stationxml.Network, error) {
 							Model:        installation.Datalogger.Model,
 							SerialNumber: installation.Datalogger.Serial,
 							InstallationDate: func() *stationxml.DateTime {
-								return &stationxml.DateTime{installation.Datalogger.Start}
+								return &stationxml.DateTime{Time: installation.Datalogger.Start}
 							}(),
 							RemovalDate: func() *stationxml.DateTime {
 								if time.Now().After(installation.Datalogger.End) {
-									return &stationxml.DateTime{installation.Datalogger.End}
+									return &stationxml.DateTime{Time: installation.Datalogger.End}
 								}
 								return nil
 							}(),
@@ -609,7 +609,7 @@ func (b *Builder) Construct(base string) ([]stationxml.Network, error) {
 
 		sort.Sort(Channels(channels))
 
-		start, end := &(stationxml.DateTime{station.Start}), &(stationxml.DateTime{station.End})
+		start, end := &(stationxml.DateTime{Time: station.Start}), &(stationxml.DateTime{Time: station.End})
 		if b.Installed() && len(channels) > 0 {
 			start, end = channels[0].StartDate, channels[len(channels)-1].EndDate
 		}
@@ -673,12 +673,12 @@ func (b *Builder) Construct(base string) ([]stationxml.Network, error) {
 					return ""
 				}(),
 			},
-			CreationDate: stationxml.DateTime{station.Start},
+			CreationDate: stationxml.DateTime{Time: station.Start},
 			TerminationDate: func() *stationxml.DateTime {
 				if time.Now().Before(station.End) {
 					return nil
 				}
-				return &stationxml.DateTime{station.End}
+				return &stationxml.DateTime{Time: station.End}
 			}(),
 			Channels: channels,
 		})

--- a/tools/stationxml/response.go
+++ b/tools/stationxml/response.go
@@ -33,7 +33,7 @@ func a2dResponseStage(stage Stage) stationxml.ResponseStage {
 			Frequency: stage.frequency,
 		},
 		Decimation: &stationxml.Decimation{
-			InputSampleRate: stationxml.Frequency{stationxml.Float{Value: stage.responseStage.SampleRate}},
+			InputSampleRate: stationxml.Frequency{Float: stationxml.Float{Value: stage.responseStage.SampleRate}},
 			Factor: func() int32 {
 				if stage.responseStage.Decimate != 0 {
 					return stage.responseStage.Decimate
@@ -80,7 +80,7 @@ func firResponseStage(filter resp.FIR, stage Stage) stationxml.ResponseStage {
 			Frequency: stage.frequency,
 		},
 		Decimation: &stationxml.Decimation{
-			InputSampleRate: stationxml.Frequency{stationxml.Float{Value: filter.Decimation * stage.responseStage.SampleRate}},
+			InputSampleRate: stationxml.Frequency{Float: stationxml.Float{Value: filter.Decimation * stage.responseStage.SampleRate}},
 			Factor: func() int32 {
 				if stage.responseStage.Decimate != 0 {
 					return stage.responseStage.Decimate
@@ -110,8 +110,8 @@ func polyResponseStage(filter resp.Polynomial, stage Stage) stationxml.ResponseS
 			OutputUnits: stationxml.Units{Name: stage.responseStage.OutputUnits},
 		},
 		ApproximationType:       stationxml.ApproximationType(filter.ApproximationType),
-		FrequencyLowerBound:     stationxml.Frequency{stationxml.Float{Value: filter.FrequencyLowerBound}},
-		FrequencyUpperBound:     stationxml.Frequency{stationxml.Float{Value: filter.FrequencyUpperBound}},
+		FrequencyLowerBound:     stationxml.Frequency{Float: stationxml.Float{Value: filter.FrequencyLowerBound}},
+		FrequencyUpperBound:     stationxml.Frequency{Float: stationxml.Float{Value: filter.FrequencyUpperBound}},
 		ApproximationLowerBound: strconv.FormatFloat(filter.ApproximationLowerBound, 'g', -1, 64),
 		ApproximationUpperBound: strconv.FormatFloat(filter.ApproximationUpperBound, 'g', -1, 64),
 		MaximumError:            filter.MaximumError,
@@ -165,7 +165,7 @@ func pazResponseStage(filter resp.PAZ, stage Stage) stationxml.ResponseStage {
 			return 1.0 / filter.Gain(stage.frequency)
 		}(),
 		NormalizationFrequency: stationxml.Frequency{
-			stationxml.Float{Value: stage.frequency},
+			Float: stationxml.Float{Value: stage.frequency},
 		},
 		Zeros: zeros,
 		Poles: poles,

--- a/tools/stationxml/stage.go
+++ b/tools/stationxml/stage.go
@@ -46,7 +46,7 @@ func (s Stage) a2d() stationxml.ResponseStage {
 			Frequency: s.frequency,
 		},
 		Decimation: &stationxml.Decimation{
-			InputSampleRate: stationxml.Frequency{stationxml.Float{Value: s.responseStage.SampleRate}},
+			InputSampleRate: stationxml.Frequency{Float: stationxml.Float{Value: s.responseStage.SampleRate}},
 			Factor: func() int32 {
 				if s.responseStage.Decimate != 0 {
 					return s.responseStage.Decimate
@@ -90,7 +90,7 @@ func (s Stage) paz(pz resp.PAZ) stationxml.ResponseStage {
 			return 1.0 / pz.Gain(s.frequency)
 		}(),
 		NormalizationFrequency: stationxml.Frequency{
-			stationxml.Float{Value: s.frequency},
+			Float: stationxml.Float{Value: s.frequency},
 		},
 		Zeros: zeros,
 		Poles: poles,
@@ -130,8 +130,8 @@ func (s Stage) polynomial(p resp.Polynomial) stationxml.ResponseStage {
 			OutputUnits: stationxml.Units{Name: s.responseStage.OutputUnits},
 		},
 		ApproximationType:       stationxml.ApproximationType(p.ApproximationType),
-		FrequencyLowerBound:     stationxml.Frequency{stationxml.Float{Value: p.FrequencyLowerBound}},
-		FrequencyUpperBound:     stationxml.Frequency{stationxml.Float{Value: p.FrequencyUpperBound}},
+		FrequencyLowerBound:     stationxml.Frequency{Float: stationxml.Float{Value: p.FrequencyLowerBound}},
+		FrequencyUpperBound:     stationxml.Frequency{Float: stationxml.Float{Value: p.FrequencyUpperBound}},
 		ApproximationLowerBound: strconv.FormatFloat(p.ApproximationLowerBound, 'g', -1, 64),
 		ApproximationUpperBound: strconv.FormatFloat(p.ApproximationUpperBound, 'g', -1, 64),
 		MaximumError:            p.MaximumError,
@@ -203,7 +203,7 @@ func (s Stage) fir(f resp.FIR) stationxml.ResponseStage {
 			Frequency: s.frequency,
 		},
 		Decimation: &stationxml.Decimation{
-			InputSampleRate: stationxml.Frequency{stationxml.Float{Value: f.Decimation * s.responseStage.SampleRate}},
+			InputSampleRate: stationxml.Frequency{Float: stationxml.Float{Value: f.Decimation * s.responseStage.SampleRate}},
 			Factor: func() int32 {
 				if s.responseStage.Decimate != 0 {
 					return s.responseStage.Decimate


### PR DESCRIPTION
@danieldooley to make the latest govet happy, this will be needed before updating the go version as per #469 

Only adds "Float:" and "Time:" to the composite literals.