### PR TITLE
removed the unused generic unknown source abbr.

### DIFF
--- a/tools/pod/blockette.go
+++ b/tools/pod/blockette.go
@@ -140,6 +140,7 @@ func lookupGenericAbbreviation(desc string) int {
 	return abbr
 }
 
+//nolint:unused // for completeness
 type CitedSourceDictionary struct {
 	Code      int
 	Name      string

--- a/tools/pod/pod.go
+++ b/tools/pod/pod.go
@@ -46,15 +46,6 @@ func (p *Pod) Header() error {
 			Content: b.String(),
 		}.String())
 	}
-	lines = append(lines, Blockette{
-		Type: 32,
-		Content: CitedSourceDictionary{
-			Code:      1,
-			Name:      "Unknown",
-			Publisher: "Unknown Publisher",
-			Date:      time.Now(),
-		}.String(),
-	}.String())
 	for _, b := range genericAbbreviations {
 		lines = append(lines, Blockette{
 			Type:    33,


### PR DESCRIPTION

> The NZ dataless since 20190107 have failed to load into our DB due to the Blockette 32 Dictionary information.
> There is not enough information provided in the “Cited_Source 0001 Unknown” provided in the Dictionary:

This is related to building the POD headers, the entry in question will have existed in the previous system and has been retained to make checking the change between systems easier (i.e. Oracle based vs git based).  The generic "unknown" abbreviation is no longer required so removing it. 