### PR TITLE
MAVL 2011 GNSS antenna adversely impacting time series

### DIFF
--- a/assets/antennas.csv
+++ b/assets/antennas.csv
@@ -225,7 +225,7 @@ Trimble Navigation Ltd.,TRM57971.00,1441027211,14089,
 Trimble Navigation Ltd.,TRM57971.00,1441027245,14087,
 Trimble Navigation Ltd.,TRM57971.00,1441027295,14220,
 Trimble Navigation Ltd.,TRM57971.00,1441027338,14208,
-Trimble Navigation Ltd.,TRM57971.00,1441027455,14092,
+Trimble Navigation Ltd.,TRM57971.00,1441027455,14092,malfunctioning
 Trimble Navigation Ltd.,TRM57971.00,1441027597,14094,
 Trimble Navigation Ltd.,TRM57971.00,1441027609,14091,
 Trimble Navigation Ltd.,TRM57971.00,1441027701,14095,


### PR DESCRIPTION
The antenna installed between Dec 2010 and July 2011 at MAVL GNSS site was probably malfunctioning, with largest impact on the North component.
This is confirmed by some independent test data from October 2017, where we have used this antenna for some testing and noticed again an unexplained offset in the North component when swapping with other antennas. That antenna (TRM57971 sn. 1441027455) has not been installed elsewhere since 2011.

/cc @nbalfour @ozym 