### PR TITLE
only use the lowest matching location code

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -20,6 +20,8 @@ go test ./tools/spectra
 go test ./tools/chart
 go test ./tools/impact
 go test ./tools/rinexml
+go test ./tools/sc3
+go test ./tools/caps
 
 exit $errcount
 

--- a/tools/sc3/autopick.go
+++ b/tools/sc3/autopick.go
@@ -9,7 +9,6 @@ const DefaultFilter = "RMHP(10)>>BW(4,2,15)>>STALTA(0.5,20)"
 const DefaultCorrection = -0.05
 
 const autopickTemplate = `###
-###
 ### Delivered by puppet
 ###
 # Defines the filter to be used for picking.

--- a/tools/sc3/autopick_test.go
+++ b/tools/sc3/autopick_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 const broadband = `###
-###
 ### Delivered by puppet
 ###
 # Defines the filter to be used for picking.

--- a/tools/sc3/main.go
+++ b/tools/sc3/main.go
@@ -130,6 +130,17 @@ func main() {
 						continue
 					}
 
+					key := Station{
+						Code:    station.Code,
+						Network: network.External,
+					}.Key()
+
+					if s, ok := stations[key]; ok {
+						if !(installation.Location < s.Global.Location) {
+							continue
+						}
+					}
+
 					global := Global{
 						Stream:   channel[0:2],
 						Location: installation.Location,

--- a/tools/sc3/station.go
+++ b/tools/sc3/station.go
@@ -5,7 +5,6 @@ import (
 )
 
 const stationTemplate = `###
-###
 ### Delivered by puppet
 ###
 global:{{.Global.Key}}

--- a/tools/sc3/station_test.go
+++ b/tools/sc3/station_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 const stationStrong = `###
-###
 ### Delivered by puppet
 ###
 global:strong_lowrate_20
@@ -16,7 +15,6 @@ scautopick:strong
 `
 
 const stationWeak = `###
-###
 ### Delivered by puppet
 ###
 global:weak_10
@@ -29,7 +27,7 @@ func TestStation(t *testing.T) {
 		station Station
 		content string
 	}{
-		"station/station_NZ_MAGS": {
+		"station_NZ_MAGS": {
 			station: Station{
 				Global: Global{
 					Location: "20",
@@ -45,7 +43,7 @@ func TestStation(t *testing.T) {
 			},
 			content: stationStrong,
 		},
-		"station/station_NZ_CAW": {
+		"station_NZ_CAW": {
 			station: Station{
 				Global: Global{
 					Location: "10",


### PR DESCRIPTION
@ardrigh @salichon There is a corner case at the moment that involves a site having multiple sensors.  The output sc3 profile may use a less desired stream ..... This PR will adjust it to favour the channel set with the "lowest" location code in an alphabetical sense.