### PR TITLE
Remove superfluous mounts.csv entry for N

### DIFF
--- a/network/mounts.csv
+++ b/network/mounts.csv
@@ -3,8 +3,7 @@ A,,White Island,-37.949622999,177.002304198,10,WGS84,Images of White Island from
 CVTP,,Ruapehu & Ngauruhoe,-39.29642,175.7663,1366,WGS84,Images of Mounts Ruapehu and Ngauruhoe from the volcano camera situated at Tai Ping.,2009-03-03T02:00:00Z,9999-01-01T00:00:00Z
 CVWF,,White Island Crater Floor,-37.526515575,177.189407876,10,WGS84,Images of White Island crater from the volcano camera situated at the abandoned sulphur works.,2001-10-12T12:00:00Z,9999-01-01T00:00:00Z
 MTSR,,Ruapehu South,-39.384607843,175.470410324,840,WGS84,Images of Mount Ruapehu from the volcano camera situated at Mangateitei.,2011-09-08T00:10:00Z,9999-01-01T00:00:00Z
-N,,Ngauruhoe,-39.156143224,175.491281443,9999,WGS84,Images of Mount Ngauruhoe from the volcano camera situated at Chateau Airport.,2002-04-09T13:00:10Z,2019-05-22T21:50:00Z
-N,,Ngauruhoe,-39.156143224,175.491281443,9999,WGS84,Images of Mount Ngauruhoe from the volcano camera situated at Chateau Airport.,2019-05-23T00:00:00Z,9999-01-01T00:00:00Z
+N,,Ngauruhoe,-39.156143224,175.491281443,9999,WGS84,Images of Mount Ngauruhoe from the volcano camera situated at Chateau Airport.,2002-04-09T13:00:10Z,9999-01-01T00:00:00Z
 P,,Tongariro,-38.97490003,175.694834619,1327,WGS84,Images of Mount Tongariro from the volcano camera situated at Kakaramea.,2011-09-05T00:01:00Z,9999-01-01T00:00:00Z
 R,,Ruapehu North,-39.156143224,175.491281443,9999,WGS84,Images of Mount Ruapehu from the volcano camera situated at Chateau Airport.,2000-11-14T13:00:10Z,9999-01-01T00:00:00Z
 RIMM,,Raoul Island,-29.267332,-177.907235,490,WGS84,Images looking into Green Lake on Raoul Island from the volcano camera situated on Mount Moumoukai.,2009-05-18T00:00:02Z,9999-01-01T00:00:00Z


### PR DESCRIPTION
As per delta meeting, removing the extra entry for mount `N` in the mounts.csv file

It was introduced in PR: https://github.com/GeoNet/delta/pull/530 but is not required.