### PR TITLE
add little more debugging on ac-tools script

### DIFF
--- a/run/deploy/10-ac-tools-trigger.sh
+++ b/run/deploy/10-ac-tools-trigger.sh
@@ -20,6 +20,8 @@ then
 
     if [[ $STATUSCODE -ne 200 ]]
     then
+            echo "Status: $STATUSCODE" 1>&2
+
             exit 1
     fi
 


### PR DESCRIPTION
There's a problem with the ac-tools script, it works but has an error state when the return indicates a "pending" state (will eventually work). We may be able to trap on another status code.