### PR TITLE
update Fiordland GNSS sites monuments description

### DIFF
--- a/network/monuments.csv
+++ b/network/monuments.csv
@@ -154,9 +154,9 @@ RGWC,,Forced Centering,Shallow Rod / Braced Antenna Mount,-1.17,Stainless Steel 
 RGWI,,Forced Centering,Shallow Rod / Braced Antenna Mount,-1.16,Stainless Steel Rods,2.5,2011-09-27T00:00:00Z,9999-01-01T00:00:00Z,,
 RGWV,,Forced Centering,Wyatt/Agnew Drilled-Braced,-1.5,Stainless Steel Rods,10,2009-09-04T00:00:00Z,9999-01-01T00:00:00Z,Ignimbrite,
 RIPA,,Forced Centering,Pillar,-1.6,Reinforced Concrete,2,2004-02-20T00:00:00Z,9999-01-01T00:00:00Z,Sandstone,
-RLTN,,Forced Centering,Wyatt/Agnew Drilled-Braced,0,Stainless Steel Rods,3.2,2020-03-31T00:00:00Z,9999-01-01T00:00:00Z,Bedrock,Highly Weathered Diorite
+RLTN,,Forced Centering,Shallow Rod / Braced Antenna Mount,0,Stainless Steel Rods,3.2,2020-03-31T00:00:00Z,9999-01-01T00:00:00Z,Bedrock,Highly Weathered Diorite
 SCTB,66071M001,Forced Centering,Pillar,-0.361,Reinforced Concrete,2,2004-10-28T00:00:00Z,9999-01-01T00:00:00Z,,
-SCTY,,Forced Centering,Wyatt/Agnew Drilled-Braced,-1.736,Stainless Steel Rods,3.2,2020-03-31T00:00:00Z,9999-01-01T00:00:00Z,Bedrock,Highly Weathered Meta Sedimentary
+SCTY,,Forced Centering,Shallow Rod / Braced Antenna Mount,-1.736,Stainless Steel Rods,3.2,2020-03-31T00:00:00Z,9999-01-01T00:00:00Z,Bedrock,Highly Weathered Meta Sedimentary
 SEDD,,Forced Centering,Wyatt/Agnew Drilled-Braced,-1.53,Stainless Steel Rods,10,2014-06-01T00:00:00Z,9999-01-01T00:00:00Z,,Situated On Quaternary Gravels. Depth To Underlying Strata Unknown.
 SNST,,Forced Centering,Wyatt/Agnew Drilled-Braced,-1.52,Stainless Steel Rods,10,2009-01-01T00:00:00Z,9999-01-01T00:00:00Z,Mudstone,Top Of Ridge Line Adjacent To Steep Grassy Slope
 SUTT,,Forced Centering,Wyatt/Agnew Drilled-Braced,-1.5,Stainless Steel Rods,10,2016-05-26T00:00:00Z,9999-01-01T00:00:00Z,,


### PR DESCRIPTION
Hi @CBurton90 , 
I realised that for "Wyatt/Agnew Drilled-Braced" that are shallow (foundation less than 5 m), we are using a different description in the monument.csv file, which is "Shallow Rod / Braced Antenna Mount".

Both monuments have depths of ~3.2 m, so this pull request is updating our database accordingly.

Thanks!

Elisabetta
