### PR TITLE
update test on GNSS receiver timestamp

### DIFF
--- a/tests/receivers_test.go
+++ b/tests/receivers_test.go
@@ -30,12 +30,6 @@ var testDeployedReceivers = map[string]func([]meta.DeployedReceiver) func(t *tes
 						if v[i].Start.After(v[j].End) {
 							continue
 						}
-						if v[i].End.Equal(v[j].Start) {
-							continue
-						}
-						if v[i].Start.Equal(v[j].End) {
-							continue
-						}
 
 						t.Errorf("receiver %s [%s] at %s has overlap with %s between times %s and %s",
 							v[i].Model, v[i].Serial, v[i].Mark, v[j].Mark, v[i].Start.Format(meta.DateTimeFormat), v[i].End.Format(meta.DateTimeFormat))
@@ -63,12 +57,6 @@ var testDeployedReceivers = map[string]func([]meta.DeployedReceiver) func(t *tes
 							continue
 						}
 						if v[i].Start.After(v[j].End) {
-							continue
-						}
-						if v[i].End.Equal(v[j].Start) {
-							continue
-						}
-						if v[i].Start.Equal(v[j].End) {
 							continue
 						}
 


### PR DESCRIPTION
Hi @ozym 

this pr is based on your modification to update the receiver test and don't allow anymore for GNSS receiver installation to have the same start and stop time.

Now that the delta entries have been fixed, the test passes ok.

Please just reject this pr if you already have it somewhere else

```[elidana@hutl16534 delta]$ ./test.sh 
+ errcount=0
+ trap error_handler ERR
+ go test ./meta
ok  	github.com/GeoNet/delta/meta	(cached)
+ go test ./tides
ok  	github.com/GeoNet/delta/tides	(cached)
+ go test ./tests
ok  	github.com/GeoNet/delta/tests	(cached)
+ go test ./tools/stationxml
ok  	github.com/GeoNet/delta/tools/stationxml	(cached)
+ go test ./tools/altus
ok  	github.com/GeoNet/delta/tools/altus	(cached)
+ go test ./tools/cusp
ok  	github.com/GeoNet/delta/tools/cusp	(cached)
+ go test ./tools/amplitude
ok  	github.com/GeoNet/delta/tools/amplitude	(cached)
+ go test ./tools/spectra
ok  	github.com/GeoNet/delta/tools/spectra	(cached)
+ go test ./tools/chart
ok  	github.com/GeoNet/delta/tools/chart	(cached)
+ go test ./tools/impact
ok  	github.com/GeoNet/delta/tools/impact	(cached)
+ go test ./tools/rinexml
ok  	github.com/GeoNet/delta/tools/rinexml	(cached)
+ go test ./tools/sc3
ok  	github.com/GeoNet/delta/tools/sc3	(cached)
+ go test ./tools/caps
ok  	github.com/GeoNet/delta/tools/caps	(cached)
+ exit 0
```