### PR TITLE
Update WIWR metadata showing camera bracket slip events

### DIFF
--- a/install/cameras.csv
+++ b/install/cameras.csv
@@ -29,7 +29,9 @@ Mobotix AG,M15,10.18.101.137,CVTP,,10,290,-2.5,0,0,2019-06-19T22:00:00Z,2019-07-
 Mobotix AG,M15,10.18.101.137,CVTP,,4,290,-2.5,0,0,2019-07-06T21:20:00Z,2019-07-08T00:40:00Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
 Mobotix AG,M15,10.18.101.137,CVTP,,0.5,290,-2.5,0,0,2019-07-08T00:50:00Z,2019-11-27T20:50:00Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
 Mobotix AG,M15,10.18.101.137,CVTP,,9.5,290,-2.5,0,0,2019-11-27T21:00:00Z,2020-05-07T00:19:59Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
-Mobotix AG,M15,10.18.101.33,WIWR,,0,0,1.5,0,0,2016-10-03T06:14:00Z,9999-01-01T00:00:00Z,White Island West Rim looking into the crater
+Mobotix AG,M15,10.18.101.33,WIWR,,65,128,-1.5,0,0,2016-10-03T06:14:00Z,2018-07-14T17:50:01Z,White Island West Rim looking into the crater
+Mobotix AG,M15,10.18.101.33,WIWR,,57,128,-1.5,0,0,2018-07-14T19:49:01Z,2020-11-05T07:09:17Z,White Island West Rim looking into the crater
+Mobotix AG,M15,10.18.101.33,WIWR,,55,128,-1.5,0,0,2020-11-05T07:09:18Z,9999-01-01T00:00:00Z,White Island West Rim looking into the crater
 Mobotix AG,M15,10.18.168.61,CVWF,,0,0,0,0,0,2016-06-01T23:40:00Z,9999-01-01T00:00:00Z,White Island Factory looking across the crater floor
 Mobotix AG,M15,10.20.210.120,CVTP,,9.5,290,-2.5,0,0,2020-05-07T00:20:00Z,9999-01-01T00:00:00Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
 Mobotix AG,M15,10.20.245.115,TOTM,,0,0,0,0,0,2018-05-03T00:00:00Z,9999-01-01T00:00:00Z,Karewerewa looking at TeMaari


### PR DESCRIPTION
2018 slip: https://github.com/GeoNet/tickets/issues/4792

2020 slip: https://github.com/GeoNet/tickets/issues/7537

Estimated historic and new dip/azimuth from 3d models.
Changed height to a negative to indicate above ground