### PR TITLE
handle sample rates less than 1 Hz in responses

### DIFF
--- a/internal/metadb/streams.go
+++ b/internal/metadb/streams.go
@@ -37,6 +37,10 @@ func (s *streams) loadStreams(base string) error {
 }
 
 func (m *MetaDB) StationLocationSamplingRateStartStream(sta, loc string, rate float64, start time.Time) (*meta.Stream, error) {
+	if rate < 0 {
+		rate = -1.0 / rate
+	}
+
 	if err := m.loadStreams(m.base); err != nil {
 		return nil, err
 	}

--- a/resp/generate/generate.go
+++ b/resp/generate/generate.go
@@ -57,7 +57,7 @@ var generateTemplate = `
 			Coefficients: []Coefficient{{"{"}}{{ range $z := .Coefficients}}Coefficient{Value: {{ $z }}{{"}"}},{{end}}{{"}"}},
 		},{{end}}{{end}}
 		Frequency: {{$v.Frequency}},
-		SampleRate: {{$v.SampleRate}},
+		SampleRate: {{rate $v.SampleRate}},
 		Decimate: {{$v.Decimate}},
 		Gain: {{$v.Gain}},
 		//Scale: {{$v.Scale}},
@@ -76,7 +76,7 @@ var generateTemplate = `
                 DataloggerList: []string{{"{"}}{{range $s := $v.Dataloggers}}"{{$s}}",{{end}}{{"}"}},
                 Type: "{{$v.Type}}",
                 Label: "{{$v.Label}}",
-                SampleRate: {{$v.SampleRate}},
+                SampleRate: {{rate $v.SampleRate}},
                 Frequency: {{$v.Frequency}},
                 StorageFormat: "{{$v.StorageFormat}}",
                 ClockDrift: {{$v.ClockDrift}},
@@ -123,12 +123,12 @@ var generateTemplate = `
 		},{{end}}{{end}}
 		Frequency: {{$v.Frequency}},
 		{{if $v.InputRate}}InputRate: {{$v.InputRate}},
-{{end }}                SampleRate: {{$v.SampleRate}},
+{{end }}                SampleRate: {{rate $v.SampleRate}},
 		Decimate: {{if eq $v.Type "fir"}}{{with $b.FIR $v.Lookup}}{{.Decimation}}{{end}}{{else}}{{$v.Decimate}}{{end}},
 		Gain: {{$v.Gain}},
 		//Scale: {{$v.Scale}},{{if eq $v.Type "fir"}}{{with $b.FIR $v.Lookup}}{{if and (eq $v.Correction 0.0) (gt .Decimation 1.0)}}
-		Correction: {{.Correction $v.SampleRate}},
-		Delay: {{.Correction $v.SampleRate}},{{else}}
+		Correction: {{.Correction (rate $v.SampleRate)}},
+		Delay: {{.Correction (rate $v.SampleRate)}},{{else}}
 		Correction: {{$v.Correction}},
 		Delay: {{$v.Correction}},{{end}}{{end}}{{end}}
 		InputUnits: "{{$v.InputUnits}}",
@@ -221,6 +221,12 @@ func (g Generate) generate(w io.Writer) error {
 	t, err := template.New("generate").Funcs(
 		template.FuncMap{
 			"escape": func(s string) string { return strings.Join(strings.Fields(s), " ") },
+			"rate": func(f float64) float64 {
+				if f < 0.0 {
+					return -1.0 / f
+				}
+				return f
+			},
 		},
 	).Parse(generateTemplate)
 	if err != nil {


### PR DESCRIPTION
This gets ready to build the response information for any streams that are sampled longer than 1 Hz.

The value `-900` is actually 15m sampling ( -1/-900) seconds.  When the streams are loaded into the memory this conversion is made so that it needs to be used for comparing against pre-calculated responses.

One side benefit is that the longer the sampling interval the lower the negative number gets, so the ordering in the streams files can be maintained (i.e -600 < -15 etc.). 