### PR TITLE
remove spaces from dart filter names

### DIFF
--- a/resp/auto.go
+++ b/resp/auto.go
@@ -1038,12 +1038,12 @@ var Responses []Response = []Response{
 				Frequency:      1,
 				StorageFormat:  "Steim2",
 				ClockDrift:     0.0001,
-				FilterList:     []string{"Water Height 15s"},
+				FilterList:     []string{"WaterHeight15s"},
 				Stages: []ResponseStage{
 					{
 						Type:   "a2d",
 						Lookup: "A2D",
-						Filter: "Water Height 15s",
+						Filter: "WaterHeight15s",
 						StageSet: A2D{
 							Name:  "A2D",
 							Code:  PZFunctionLaplaceZTransform,
@@ -1068,12 +1068,12 @@ var Responses []Response = []Response{
 				Frequency:      1,
 				StorageFormat:  "Steim2",
 				ClockDrift:     0.0001,
-				FilterList:     []string{"Water Height 15m"},
+				FilterList:     []string{"WaterHeight15m"},
 				Stages: []ResponseStage{
 					{
 						Type:   "a2d",
 						Lookup: "A2D",
-						Filter: "Water Height 15m",
+						Filter: "WaterHeight15m",
 						StageSet: A2D{
 							Name:  "A2D",
 							Code:  PZFunctionLaplaceZTransform,

--- a/resp/responses/configurations/pressure.yaml
+++ b/resp/responses/configurations/pressure.yaml
@@ -364,16 +364,16 @@ response:
       - Water Depth 10
       reversed: false
 
-  DART Systems (Derived):
+  "DART Systems (Derived)":
     sensors:
     - sensors:
-      - BPR Subsystem
+      - "BPR Subsystem"
       filters: []
       channels: Z
       reversed: false
     dataloggers:
     - dataloggers:
-      - BPR Subsystem
+      - "BPR Subsystem"
       type: CG
       label: UT
       samplerate: -15
@@ -381,7 +381,7 @@ response:
       storageformat: Steim2
       clockdrift: 0.0001
       filters:
-      - Water Height 15s
+      - "WaterHeight15s"
       reversed: false
     - dataloggers:
       - BPR Subsystem
@@ -392,7 +392,7 @@ response:
       storageformat: Steim2
       clockdrift: 0.0001
       filters:
-      - Water Height 15m
+      - "WaterHeight15m"
       reversed: false
 
 # vim: tabstop=2 expandtab shiftwidth=2 softtabstop=2

--- a/resp/responses/sensors/generic.yaml
+++ b/resp/responses/sensors/generic.yaml
@@ -98,7 +98,7 @@ filter:
     delay: 0
     inputunits: m
     outputunits: count
-  Water Height 15s:
+  "WaterHeight15s":
   - type: a2d
     lookup: A2D
     frequency: 0
@@ -110,7 +110,7 @@ filter:
     delay: 0
     inputunits: m
     outputunits: count
-  Water Height 15m:
+  "WaterHeight15m":
   - type: a2d
     lookup: A2D
     frequency: 0


### PR DESCRIPTION
To avoid one possible problem when loading the derived stationxml. 