### PR TITLE
update geodetic contact to comply with IGS latest recommendations

### DIFF
--- a/tools/sitelogs/config/config.yaml
+++ b/tools/sitelogs/config/config.yaml
@@ -1,7 +1,7 @@
 ---
 
-PreparedBy: "Elisabetta D'Anastasio"
-PrimaryDatacentre: "ftp.geonet.org.nz"
+PreparedBy: "Geodetic Processing Specialist"
+PrimaryDatacentre: "data.geonet.org.nz"
 URLForMoreInformation: "www.geonet.org.nz"
 ExtraNotes: "additional information and pictures could be found\nat http://www.geonet.org.nz/data/types/geodetic"
 
@@ -16,11 +16,11 @@ ContactAgency:
     Fax:    "+64 4 570 4676"
     Email:        "info@geonet.org.nz"
   SecondaryContact:
-    Name:         "Elisabetta D'Anastasio"
-    TelephonePrimary:   "+64 4 570 4744"
+    Name:         "Geodetic Processing Specialist"
+    TelephonePrimary:   "+64 4 570 1444"
     TelephoneSecondary: ""
     Fax:    ""
-    Email:        "e.danastasio@gns.cri.nz"
+    Email:        "info@geonet.org.nz"
   Notes: ""
 
 ResponsibleAgency:
@@ -34,11 +34,11 @@ ResponsibleAgency:
     Fax:    "+64 4 472 2244"
     Email:        "positionz@linz.govt.nz"
   SecondaryContact:
-    Name:         "Rachelle Winefield"
-    TelephonePrimary:   "+64 4 460 2757"
+    Name:         ""
+    TelephonePrimary:   ""
     TelephoneSecondary: ""
     Fax:    ""
-    Email:        "rwinefield@linz.govt.nz"
+    Email:        ""
   Notes: "CGPS site is part of the LINZ PositioNZ Network http://www.linz.govt.nz/positionz"
 
 # used to determine country name

--- a/tools/sitelogs/config_auto.go
+++ b/tools/sitelogs/config_auto.go
@@ -11,9 +11,9 @@ package main
  *
  */
 
-var preparedBy = "Elisabetta D'Anastasio"
+var preparedBy = "Geodetic Processing Specialist"
 
-var primaryDatacentre = `ftp.geonet.org.nz`
+var primaryDatacentre = `data.geonet.org.nz`
 var urlForMoreInformation = `www.geonet.org.nz`
 var extraNotes = `additional information and pictures could be found
 at http://www.geonet.org.nz/data/types/geodetic`
@@ -32,11 +32,11 @@ New Zealand`,
 		Email:              `info@geonet.org.nz`,
 	},
 	SecondaryContact: Contact{
-		Name:               `Elisabetta D'Anastasio`,
-		TelephonePrimary:   `+64 4 570 4744`,
+		Name:               `Geodetic Processing Coordinator`,
+		TelephonePrimary:   `+64 4 570 1444`,
 		TelephoneSecondary: ``,
 		Fax:                ``,
-		Email:              `e.danastasio@gns.cri.nz`,
+		Email:              `info@geonet.org.nz`,
 	},
 	Notes: ``,
 }
@@ -54,11 +54,11 @@ New Zealand`,
 		Email:              `positionz@linz.govt.nz`,
 	},
 	SecondaryContact: Contact{
-		Name:               `Rachelle Winefield`,
-		TelephonePrimary:   `+64 4 460 2757`,
+		Name:               ``,
+		TelephonePrimary:   ``,
 		TelephoneSecondary: ``,
 		Fax:                ``,
-		Email:              `rwinefield@linz.govt.nz`,
+		Email:              ``,
 	},
 	Notes: `CGPS site is part of the LINZ PositioNZ Network http://www.linz.govt.nz/positionz`,
 }


### PR DESCRIPTION
Hi, 

IGS has recommended to avoid personal contact in IGS stations sitelogs.

The IGS public sitelogs of our stations has now been updated on the Site Log Manager.

This pr is to reflect a similar change on sitelogs of all our GNSS continuous sites. 

I have tested locally the change and it works fine. This pr is also updating the repository to https://data.geonet.org.nz 