### PR TITLE
add gain and calibration tables

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -18,6 +18,8 @@ Meta information for the GeoNet equipment network.
 * `dataloggers.csv` - Recording dataloggers
 * `connections.csv` - Datalogger and sensor connection details
 * `streams.csv` - Datalogger and recorder sampling configurations
+* `gains.csv` - site specific settings applied to individual datalogger and sensor that may impact overall sensitivities
+* `calibrations.csv` - Individual sensor sensitivity values that can be used rather than default values.
 
 * `cameras.csv` - Installed field cameras.
 * `doases.csv` - Installed field DOAS (Differential Optical Absorption Spectrometer) equipment.
@@ -212,6 +214,44 @@ A list of _datalogger_ sampling configurations for a given _station_ and recordi
 | _Triggered_ | Whether the stream represents</br>triggered recordings|_"yes"_ or _"no"_
 | _Start_ | Stream start time|
 | _Stop_ | Stream stop time|
+
+#### _GAINS_ ####
+ 
+Site specific gain settings applied to correct for local conditions. A list of installation times where gains need to be applied to datalogger or sensor settings.
+For the scale factor and bias either a value can be given directly or an expression can be used if that makes it clearer where the number has come from.
+
+| Field | Description | Units |
+| --- | --- | --- |
+| _Station_ | Datalogger recording _Station_|
+| _Location_ | Recording sensor site _Location_ |
+| _SubLocation_ | additional location identifier for multiparametric sensors installations, if applicable |
+| _Channel_ | The sensor channel, as defined in the response configuration, which requires a gain adjustment, multiple channels can be joined (e.g _"Z"_ or _"ZNE"_).
+| _Scale Factor_ | Scale, or gain factor, that the input signal is multiplied by prior to digitisation, or for polynomial responses it is the factor used to convert Volts into the signal units. If this field is empty, it should be assumed to have a value of __1.0__ which in theory should have no impact.
+| _Scale Bias_ | An offset value that needs to be added to the signal prior to digitisation and indicates a polynomial response is expected, if this field is blank it is assumed that the value is __0.0__.
+| _Start_ | Gain start time|
+| _Stop_ | Gain stop time|
+
+For a second order polynomial response, the output is expected to be `Y = a * X + b` where `X` is normally the input voltage, and Y the corrected signal. The terms `a` and `b` are the factor and bias respectively. The gain adjustments (`a'`, `b'`) update this via `Y = (a * a') * X + (b + b')`
+
+#### _CALIBRATIONS_ ####
+ 
+Sensor specific calibrations that may impact overall sensitivity. A list of installation times where calibrated values of the _Sensor_ sensitivity are known and can be used to override 
+the default _Model_ sensitivities.
+For the component, sensitivity, and frequency either a value can be given directly or an expression can be used if that is more readible.
+
+| Field | Description | Units |
+| --- | --- | --- |
+| _Make_ | Sensor make
+| _Model_ | Sensor model name
+| _Serial_ | Sensor serial number
+| _Component_ | The sensor component, as defined in the response configuration or elsewhere, which overrides the default values, a blank value is interpreted as the first sensor component, or __"pin"__ zero.
+| _Scale Factor_ | Sensitivity, or scale factor, that the input signal is generally multiplied by to convert to Volts, or for polynomial responses the value used to convert Volts into the signal units. A blank value is expected to be read as __1.0__, an expicit value of zero is required to be entered if intended.
+| _Scale Bias_ | An offset, or scale bias, for polynomial responses that is added to the converted volts to give the signal values. If this field is blank it should be assumed that the value is __0.0__.
+| _Frequency_ | Frequency at which the calibration value is correct for if appropriate.
+| _Start_ | Calibration start time|
+| _Stop_ | Calibration stop time|
+
+For a second order polynomial response, the output is expected to be `Y = a * X + b` where `X` is normally the input voltage, and Y the corrected signal. The terms `a` and `b` are the factor and bias respectively. The gain adjustments (`a'`, `b'`) update this via `Y =  a' * X + b'`
 
 ### CAMERA ###
 

--- a/install/calibrations.csv
+++ b/install/calibrations.csv
@@ -1,0 +1,1 @@
+Make,Model,Serial,Component,Scale Factor,Scale Bias,Frequency,Start Date,End Date

--- a/install/gains.csv
+++ b/install/gains.csv
@@ -1,0 +1,1 @@
+Station,Location,SubLocation,Channel,Scale Factor,Scale Bias,Start Date,End Date

--- a/internal/metadb/calibrations.go
+++ b/internal/metadb/calibrations.go
@@ -1,0 +1,60 @@
+package metadb
+
+import (
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/GeoNet/delta/meta"
+)
+
+type calibrations struct {
+	list   meta.CalibrationList
+	lookup map[string][]meta.Calibration
+	once   sync.Once
+}
+
+func (c *calibrations) loadCalibrations(base string) error {
+	var err error
+
+	c.once.Do(func() {
+		if err = meta.LoadList(filepath.Join(base, "install", "calibrations.csv"), &c.list); err == nil {
+			lookup := make(map[string][]meta.Calibration)
+			for _, v := range c.list {
+				lookup[v.Model] = append(lookup[v.Model], v)
+			}
+			c.lookup = lookup
+		}
+	})
+
+	return err
+}
+
+func (m *MetaDB) Calibration(model, serial string, comp int, at time.Time) (*meta.Calibration, error) {
+
+	if err := m.loadCalibrations(m.base); err != nil {
+		return nil, err
+	}
+
+	s, ok := m.calibrations.lookup[model]
+	if !ok {
+		return nil, nil
+	}
+	for _, g := range s {
+		if g.Serial != serial {
+			continue
+		}
+		if g.Component != comp {
+			continue
+		}
+		if g.Start.After(at) {
+			continue
+		}
+		if g.End.Before(at) {
+			continue
+		}
+		return &g, nil
+	}
+
+	return nil, nil
+}

--- a/internal/metadb/gains.go
+++ b/internal/metadb/gains.go
@@ -1,0 +1,60 @@
+package metadb
+
+import (
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/GeoNet/delta/meta"
+)
+
+type gains struct {
+	list   meta.GainList
+	lookup map[string][]meta.Gain
+	once   sync.Once
+}
+
+func (g *gains) loadGains(base string) error {
+	var err error
+
+	g.once.Do(func() {
+		if err = meta.LoadList(filepath.Join(base, "install", "gains.csv"), &g.list); err == nil {
+			lookup := make(map[string][]meta.Gain)
+			for _, v := range g.list {
+				lookup[v.Station] = append(lookup[v.Station], v.Gains()...)
+			}
+			g.lookup = lookup
+		}
+	})
+
+	return err
+}
+
+func (m *MetaDB) Gain(sta, loc, cha string, at time.Time) (*meta.Gain, error) {
+
+	if err := m.loadGains(m.base); err != nil {
+		return nil, err
+	}
+
+	s, ok := m.gains.lookup[sta]
+	if !ok {
+		return nil, nil
+	}
+	for _, g := range s {
+		if g.Location != loc {
+			continue
+		}
+		if g.Channel != cha {
+			continue
+		}
+		if g.Start.After(at) {
+			continue
+		}
+		if g.End.Before(at) {
+			continue
+		}
+		return &g, nil
+	}
+
+	return nil, nil
+}

--- a/internal/metadb/metadb.go
+++ b/internal/metadb/metadb.go
@@ -12,10 +12,12 @@ type MetaDB struct {
 	sensors
 	recorders
 	dataloggers
+	calibrations
 
-	// instrment configuration
+	// instrument configuration
 	connections
 	streams
+	gains
 
 	// base directory for raw meta files
 	base string

--- a/meta/calibration.go
+++ b/meta/calibration.go
@@ -1,0 +1,196 @@
+package meta
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/GeoNet/delta/internal/expr"
+)
+
+const (
+	calibrationMake = iota
+	calibrationModel
+	calibrationSerial
+	calibrationComponent
+	calibrationScaleFactor
+	calibrationScaleBias
+	calibrationFrequency
+	calibrationStart
+	calibrationEnd
+	calibrationLast
+)
+
+// Calibration defines times where sensor scaling or offsets are needed, these will be overwrite the
+// existing values, i.e. A + BX => A' + B' X, where A' and B' are the given bias and scaling factors.
+type Calibration struct {
+	Install
+
+	component string
+	factor    string
+	bias      string
+	frequency string
+
+	ScaleFactor float64
+	ScaleBias   float64
+	Frequency   float64
+
+	Component int
+}
+
+// Id returns a unique string which can be used for sorting or checking.
+func (c Calibration) Id() string {
+	return strings.Join([]string{c.Make, c.Model, c.Serial, strconv.Itoa(c.Component)}, ":")
+}
+
+// Less returns whether one Calibration sorts before another.
+func (s Calibration) Less(calibration Calibration) bool {
+	switch {
+	case s.Install.Less(calibration.Install):
+		return true
+	case calibration.Install.Less(s.Install):
+		return false
+	case s.Component < calibration.Component:
+		return true
+	default:
+		return false
+	}
+}
+
+// CalibrationList is a slice of Calibration types.
+type CalibrationList []Calibration
+
+func (c CalibrationList) Len() int           { return len(c) }
+func (c CalibrationList) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
+func (c CalibrationList) Less(i, j int) bool { return c[i].Less(c[j]) }
+
+func (c CalibrationList) encode() [][]string {
+	data := [][]string{{
+		"Make",
+		"Model",
+		"Serial",
+		"Component",
+		"Scale Factor",
+		"Scale Bias",
+		"Frequency",
+		"Start Date",
+		"End Date",
+	}}
+
+	for _, v := range c {
+		data = append(data, []string{
+			strings.TrimSpace(v.Make),
+			strings.TrimSpace(v.Model),
+			strings.TrimSpace(v.Serial),
+			strconv.Itoa(v.Component),
+			strings.TrimSpace(v.factor),
+			strings.TrimSpace(v.bias),
+			strings.TrimSpace(v.frequency),
+			v.Start.Format(DateTimeFormat),
+			v.End.Format(DateTimeFormat),
+		})
+	}
+	return data
+}
+
+func (c *CalibrationList) toFloat64(str string, def float64) (float64, error) {
+	switch s := strings.TrimSpace(str); {
+	case s != "":
+		return expr.ToFloat64(s)
+	default:
+		return def, nil
+	}
+}
+
+func (c *CalibrationList) toInt(str string, def int) (int, error) {
+	switch s := strings.TrimSpace(str); {
+	case s != "":
+		return expr.ToInt(s)
+	default:
+		return def, nil
+	}
+}
+
+func (c *CalibrationList) decode(data [][]string) error {
+	var calibrations []Calibration
+	if len(data) > 1 {
+		for _, d := range data[1:] {
+			if len(d) != calibrationLast {
+				return fmt.Errorf("incorrect number of installed calibration fields")
+			}
+
+			factor, err := c.toFloat64(d[calibrationScaleFactor], 1.0)
+			if err != nil {
+				return err
+			}
+
+			bias, err := c.toFloat64(d[calibrationScaleBias], 0.0)
+			if err != nil {
+				return err
+			}
+
+			freq, err := c.toFloat64(d[calibrationFrequency], 0.0)
+			if err != nil {
+				return err
+			}
+
+			comp, err := c.toInt(d[calibrationComponent], 0)
+			if err != nil {
+				return err
+			}
+
+			start, err := time.Parse(DateTimeFormat, d[calibrationStart])
+			if err != nil {
+				return err
+			}
+
+			end, err := time.Parse(DateTimeFormat, d[calibrationEnd])
+			if err != nil {
+				return err
+			}
+
+			calibrations = append(calibrations, Calibration{
+				Install: Install{
+					Equipment: Equipment{
+						Make:   strings.TrimSpace(d[calibrationMake]),
+						Model:  strings.TrimSpace(d[calibrationModel]),
+						Serial: strings.TrimSpace(d[calibrationSerial]),
+					},
+					Span: Span{
+						Start: start,
+						End:   end,
+					},
+				},
+				Component: comp,
+
+				ScaleFactor: factor,
+				ScaleBias:   bias,
+				Frequency:   freq,
+
+				component: strings.TrimSpace(d[calibrationComponent]),
+				factor:    strings.TrimSpace(d[calibrationScaleFactor]),
+				bias:      strings.TrimSpace(d[calibrationScaleBias]),
+				frequency: strings.TrimSpace(d[calibrationFrequency]),
+			})
+		}
+	}
+
+	*c = CalibrationList(calibrations)
+
+	return nil
+}
+
+// LoadCalibrations reads a CSV formatted file and returns a slice of Calibration types.
+func LoadCalibrations(path string) ([]Calibration, error) {
+	var c []Calibration
+
+	if err := LoadList(path, (*CalibrationList)(&c)); err != nil {
+		return nil, err
+	}
+
+	sort.Sort(CalibrationList(c))
+
+	return c, nil
+}

--- a/meta/gain.go
+++ b/meta/gain.go
@@ -1,0 +1,201 @@
+package meta
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/GeoNet/delta/internal/expr"
+)
+
+const (
+	gainStation = iota
+	gainLocation
+	gainSubLocation
+	gainChannel
+	gainScaleFactor
+	gainScaleBias
+	gainStart
+	gainEnd
+	gainLast
+)
+
+// Gain defines times where sensor installation scaling or offsets are needed, these will be applied to the
+// existing values, i.e. A + BX => A + A' + (B * B') X, where A' and B' are the given bias and scaling factors.
+type Gain struct {
+	Span
+	Scale
+
+	Station     string
+	Location    string
+	SubLocation string
+	Channel     string
+}
+
+// Id returns a unique string which can be used for sorting or checking.
+func (g Gain) Id() string {
+	return strings.Join([]string{g.Station, g.Location, g.Channel}, ":")
+}
+
+// Less returns whether one Gain sorts before another.
+func (g Gain) Less(gain Gain) bool {
+	switch {
+	case g.Station < gain.Station:
+		return true
+	case g.Station > gain.Station:
+		return false
+	case g.Location < gain.Location:
+		return true
+	case g.Location > gain.Location:
+		return false
+	case g.SubLocation < gain.SubLocation:
+		return true
+	case g.SubLocation > gain.SubLocation:
+		return false
+	case g.Channel < gain.Channel:
+		return true
+	case g.Channel > gain.Channel:
+		return false
+	case g.Span.Start.Before(gain.Span.Start):
+		return true
+	default:
+		return false
+	}
+}
+
+// Channels returns a sorted slice of single defined components.
+func (g Gain) Channels() []string {
+	var comps []string
+	for _, c := range g.Channel {
+		comps = append(comps, string(c))
+	}
+	return comps
+}
+
+// Gains returns a sorted slice of single Gain entries.
+func (g Gain) Gains() []Gain {
+	var gains []Gain
+	for _, c := range g.Channel {
+		gains = append(gains, Gain{
+			Span:        g.Span,
+			Scale:       g.Scale,
+			Station:     g.Station,
+			Location:    g.Location,
+			SubLocation: g.SubLocation,
+			Channel:     string(c),
+		})
+	}
+
+	sort.Slice(gains, func(i, j int) bool { return gains[i].Less(gains[j]) })
+
+	return gains
+}
+
+type GainList []Gain
+
+func (g GainList) Len() int           { return len(g) }
+func (g GainList) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
+func (g GainList) Less(i, j int) bool { return g[i].Less(g[j]) }
+
+func (g GainList) encode() [][]string {
+	data := [][]string{{
+		"Station",
+		"Location",
+		"SubLocation",
+		"Channel",
+		"Scale Factor",
+		"Scale Bias",
+		"Start Date",
+		"End Date",
+	}}
+
+	for _, v := range g {
+		data = append(data, []string{
+			strings.TrimSpace(v.Station),
+			strings.TrimSpace(v.Location),
+			strings.TrimSpace(v.SubLocation),
+			strings.TrimSpace(v.Channel),
+			strings.TrimSpace(v.factor),
+			strings.TrimSpace(v.bias),
+			v.Start.Format(DateTimeFormat),
+			v.End.Format(DateTimeFormat),
+		})
+	}
+
+	return data
+}
+
+func (g *GainList) toFloat64(str string, def float64) (float64, error) {
+	switch s := strings.TrimSpace(str); {
+	case s != "":
+		return expr.ToFloat64(s)
+	default:
+		return def, nil
+	}
+}
+
+func (g *GainList) decode(data [][]string) error {
+	var gains []Gain
+	if len(data) > 1 {
+		for _, d := range data[1:] {
+			if len(d) != gainLast {
+				return fmt.Errorf("incorrect number of installed gain fields")
+			}
+
+			factor, err := g.toFloat64(d[gainScaleFactor], 1.0)
+			if err != nil {
+				return err
+			}
+
+			bias, err := g.toFloat64(d[gainScaleBias], 0.0)
+			if err != nil {
+				return err
+			}
+
+			start, err := time.Parse(DateTimeFormat, d[gainStart])
+			if err != nil {
+				return err
+			}
+
+			end, err := time.Parse(DateTimeFormat, d[gainEnd])
+			if err != nil {
+				return err
+			}
+
+			gains = append(gains, Gain{
+				Span: Span{
+					Start: start,
+					End:   end,
+				},
+				Scale: Scale{
+					Factor: factor,
+					Bias:   bias,
+
+					factor: strings.TrimSpace(d[gainScaleFactor]),
+					bias:   strings.TrimSpace(d[gainScaleBias]),
+				},
+				Station:     strings.TrimSpace(d[gainStation]),
+				Location:    strings.TrimSpace(d[gainLocation]),
+				SubLocation: strings.TrimSpace(d[gainSubLocation]),
+				Channel:     strings.TrimSpace(d[gainChannel]),
+			})
+		}
+
+		*g = GainList(gains)
+	}
+
+	return nil
+}
+
+func LoadGains(path string) ([]Gain, error) {
+	var g []Gain
+
+	if err := LoadList(path, (*GainList)(&g)); err != nil {
+		return nil, err
+	}
+
+	sort.Sort(GainList(g))
+
+	return g, nil
+}

--- a/meta/list_test.go
+++ b/meta/list_test.go
@@ -1026,6 +1026,55 @@ func TestList(t *testing.T) {
 				},
 			},
 		},
+		{
+			"testdata/calibrations.csv",
+			&CalibrationList{
+				Calibration{
+					Install: Install{
+						Equipment: Equipment{
+							Make:   "Acme",
+							Model:  "ACME01",
+							Serial: "257",
+						},
+						Span: Span{
+							Start: time.Date(2021, time.July, 1, 0, 0, 0, 0, time.UTC),
+							End:   time.Date(9999, time.January, 1, 0, 0, 0, 0, time.UTC),
+						},
+					},
+					ScaleFactor: 2000.169 / 2.0,
+					ScaleBias:   1.0,
+					Frequency:   10.0,
+					Component:   0,
+
+					component: "0",
+					factor:    "2000.169/2.0",
+					bias:      "1.0",
+					frequency: "10.0",
+				},
+			},
+		},
+		{
+			"testdata/gains.csv",
+			&GainList{
+				Gain{
+					Span: Span{
+						Start: time.Date(2021, time.July, 1, 0, 0, 0, 0, time.UTC),
+						End:   time.Date(9999, time.January, 1, 0, 0, 0, 0, time.UTC),
+					},
+					Scale: Scale{
+						Factor: 1298.169,
+						Bias:   11865.556,
+
+						factor: "1298.169",
+						bias:   "11865.556",
+					},
+					Station:     "SBAM",
+					Location:    "50",
+					SubLocation: "01",
+					Channel:     "XZ",
+				},
+			},
+		},
 	}
 
 	for _, tt := range listtests {

--- a/meta/testdata/calibrations.csv
+++ b/meta/testdata/calibrations.csv
@@ -1,0 +1,2 @@
+Make,Model,Serial,Component,Scale Factor,Scale Bias,Frequency,Start Date,End Date
+Acme,ACME01,257,0,2000.169/2.0,1.0,10.0,2021-07-01T00:00:00Z,9999-01-01T00:00:00Z

--- a/meta/testdata/gains.csv
+++ b/meta/testdata/gains.csv
@@ -1,0 +1,2 @@
+Station,Location,SubLocation,Channel,Scale Factor,Scale Bias,Start Date,End Date
+SBAM,50,01,XZ,1298.169,11865.556,2021-07-01T00:00:00Z,9999-01-01T00:00:00Z

--- a/tests/calibrations_test.go
+++ b/tests/calibrations_test.go
@@ -1,0 +1,90 @@
+package delta_test
+
+import (
+	"testing"
+
+	"github.com/GeoNet/delta/meta"
+)
+
+var testCalibrations = map[string]func([]meta.Calibration) func(t *testing.T){
+
+	"check for calibration overlaps": func(installed []meta.Calibration) func(t *testing.T) {
+		return func(t *testing.T) {
+
+			installs := make(map[string]meta.CalibrationList)
+			for _, s := range installed {
+				installs[s.Id()] = append(installs[s.Id()], s)
+			}
+
+			for _, v := range installs {
+				for i := 0; i < len(v); i++ {
+					for j := i + 1; j < len(v); j++ {
+						if v[i].End.Before(v[j].Start) {
+							continue
+						}
+						if v[i].Start.After(v[j].End) {
+							continue
+						}
+						if v[i].End.Equal(v[j].Start) {
+							continue
+						}
+						if v[i].Start.Equal(v[j].End) {
+							continue
+						}
+
+						t.Errorf("calibration %s/%s has component \"%d\" overlap between %s and %s",
+							v[i].Model, v[i].Serial, v[i].Component,
+							v[i].Start.Format(meta.DateTimeFormat),
+							v[i].End.Format(meta.DateTimeFormat))
+					}
+				}
+			}
+		}
+	},
+}
+
+var testCalibrationsAssets = map[string]func([]meta.Calibration, []meta.Asset) func(t *testing.T){
+	"check for missing assets": func(installed []meta.Calibration, assets []meta.Asset) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, s := range installed {
+				var found bool
+				for _, a := range assets {
+					if a.Model != s.Model {
+						continue
+					}
+					if a.Serial != s.Serial {
+						continue
+					}
+					found = true
+				}
+				if found {
+					continue
+				}
+				t.Errorf("unable to find calibration asset: %s [%s]", s.Model, s.Serial)
+			}
+
+		}
+	},
+}
+
+func TestCalibrations(t *testing.T) {
+	var installed meta.CalibrationList
+	loadListFile(t, "../install/calibrations.csv", &installed)
+
+	for k, fn := range testCalibrations {
+		t.Run(k, fn(installed))
+	}
+
+}
+
+func TestCalibrations_Assets(t *testing.T) {
+	var installed meta.CalibrationList
+	loadListFile(t, "../install/calibrations.csv", &installed)
+
+	var sensors meta.AssetList
+	loadListFile(t, "../assets/sensors.csv", &sensors)
+
+	for k, fn := range testCalibrationsAssets {
+		t.Run(k, fn(installed, sensors))
+	}
+}

--- a/tests/consistency_test.go
+++ b/tests/consistency_test.go
@@ -58,6 +58,8 @@ func TestConsistency(t *testing.T) {
 		"sensors":      {f: "../install/sensors.csv", l: &meta.InstalledSensorList{}},
 		"firmware":     {f: "../install/firmware.csv", l: &meta.FirmwareHistoryList{}},
 		"streams":      {f: "../install/streams.csv", l: &meta.StreamList{}},
+		"gains":        {f: "../install/gains.csv", l: &meta.GainList{}},
+		"calibrations": {f: "../install/calibrations.csv", l: &meta.CalibrationList{}},
 		"networks":     {f: "../network/networks.csv", l: &meta.NetworkList{}},
 		"stations":     {f: "../network/stations.csv", l: &meta.StationList{}},
 		"sites":        {f: "../network/sites.csv", l: &meta.SiteList{}},

--- a/tests/gains_test.go
+++ b/tests/gains_test.go
@@ -1,0 +1,91 @@
+package delta_test
+
+import (
+	"testing"
+
+	"github.com/GeoNet/delta/meta"
+)
+
+var testGains = map[string]func([]meta.Gain) func(t *testing.T){
+
+	"check for gain installation overlaps": func(installed []meta.Gain) func(t *testing.T) {
+		return func(t *testing.T) {
+
+			installs := make(map[string]meta.GainList)
+			for _, s := range installed {
+				for _, c := range s.Gains() {
+					installs[c.Id()] = append(installs[c.Id()], c)
+				}
+			}
+
+			for _, v := range installs {
+				for i := 0; i < len(v); i++ {
+					for j := i + 1; j < len(v); j++ {
+						if v[i].End.Before(v[j].Start) {
+							continue
+						}
+						if v[i].Start.After(v[j].End) {
+							continue
+						}
+						if v[i].End.Equal(v[j].Start) {
+							continue
+						}
+						if v[i].Start.Equal(v[j].End) {
+							continue
+						}
+
+						t.Errorf("gain %s/%s has component %s overlap between %s and %s",
+							v[i].Station, v[i].Location, v[i].Channel,
+							v[i].Start.Format(meta.DateTimeFormat),
+							v[i].End.Format(meta.DateTimeFormat))
+					}
+				}
+			}
+		}
+	},
+}
+
+var testGainsSites = map[string]func([]meta.Gain, []meta.Site) func(t *testing.T){
+	"check for missing sites": func(installed []meta.Gain, sites []meta.Site) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, s := range installed {
+				var found bool
+				for _, a := range sites {
+					if a.Station != s.Station {
+						continue
+					}
+					if a.Location != s.Location {
+						continue
+					}
+					found = true
+				}
+				if found {
+					continue
+				}
+				t.Errorf("unable to find gain site: %s [%s]", s.Station, s.Location)
+			}
+
+		}
+	},
+}
+
+func TestGains(t *testing.T) {
+	var installed meta.GainList
+	loadListFile(t, "../install/gains.csv", &installed)
+
+	for k, fn := range testGains {
+		t.Run(k, fn(installed))
+	}
+}
+
+func TestGains_Sites(t *testing.T) {
+	var installed meta.GainList
+	loadListFile(t, "../install/gains.csv", &installed)
+
+	var sites meta.SiteList
+	loadListFile(t, "../network/sites.csv", &sites)
+
+	for k, fn := range testGainsSites {
+		t.Run(k, fn(installed, sites))
+	}
+}


### PR DESCRIPTION
This work is a follow on from what's required to add geomag meta data to delta, the geomag fluxgate installations have gain settings which are independent of both the sensor and the datalogger (a driver box).

By adding a gain table the complexity of the response calculation can be reduced, that is the sensor response and datalogger responses can stay constant for all installs, but individual gain adjustments can be made as required without having to track which sensor or datalogger was installed where.

The channel is defined as the expected output of the response requirement (in miniseed this would be the final channel label, e.g. ZNE, or Z12 etc), multiple values can be used if the gains or offsets impact all channels.

The calibration table is aimed at sensors where a known calibration has been performed and the nominal, or default, value used  for the sensor model can be overridden instead.

I have made some adjustments to better suit the "features" style adjustments needed.

I am likely to request that the factor and bias fields in the "installed sensors" table be removed, as this PR will make these values redundant (the installed values have problems when there are multiple components within a sensor that have different values).
