### PR TITLE
add channel and component

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -20,6 +20,8 @@ Meta information for the GeoNet equipment network.
 * `streams.csv` - Datalogger and recorder sampling configurations
 * `gains.csv` - site specific settings applied to individual datalogger and sensor that may impact overall sensitivities
 * `calibrations.csv` - Individual sensor sensitivity values that can be used rather than default values.
+* `components.csv` - Individual sensor elements including measurement position and responses.
+* `channels.csv` - Individual datalogger recording elements including digitiser position, sampling rate, and responses.
 
 * `cameras.csv` - Installed field cameras.
 * `doases.csv` - Installed field DOAS (Differential Optical Absorption Spectrometer) equipment.
@@ -262,6 +264,44 @@ For the component, sensitivity, and frequency either a value can be given direct
 | _Stop_ | Calibration stop time|
 
 For a second order polynomial response, the output is expected to be `Y = a * X + b` where `X` is normally the input voltage, and Y the corrected signal. The terms `a` and `b` are the factor and bias respectively. The gain adjustments (`a'`, `b'`) update this via `Y =  a' * X + b'`
+
+#### _COMPONENTS_ ####
+
+Sensor model component descriptions. The type is generally of the form "Accelerometer, Short Period Seismometer" etc.
+The number represents the order of sensor components, this generally maps to the sensor cable and how it is connected
+into the datalogger.
+Subsource is the general term used for labelling the sensor component and is usually the last character in the SEED channel convention.
+Dip and Azimuth are used to indicate the relative position of the sensor component within the sensor package and will be used with the
+overall sensor installation values to provide component dips and azimuths.
+
+| Field       | Description | 
+| ----------- | ----------- |
+| _Make_      | Sensor make
+| _Model_     | Sensor model name
+| _Type_      | Sensor type
+| _Number_    | Sensor component offset
+| _Subsource_ | Sensor component label
+| _Dip_       | Internal dip of the compnent relative to whole sensor
+| _Azimuth_   | Internal azimuth of the compnent relative to whole sensor
+| _Types_     | A shorthand reference to the SEED type labels
+| _Response_  | A reference to the nominal StationXML response 
+
+
+#### _CHANNELS_ ####
+
+The individual channels configured for a given datalogger model, these include the channel numbers and sampling rates.
+The channel number is an offset into the digitiser or digitisers and are used to match the connected sensor component
+and the expected response. Some digitisers have different nominal responses for different groups of digitiser channels.
+
+| Field           | Description | 
+| --------------- | ----------- |
+| _Make_          | Datalogger make
+| _Model_         | Datalogger model name
+| _Type_          | Datalogger type
+| _Number_        | Datalogger channel offset, an empty value will map to zero
+| _Sampling Rate_ | Configured Channel sampling rate
+| _Response_      | A reference to the nominal StationXML response 
+
 
 ### CAMERA ###
 

--- a/meta/channel.go
+++ b/meta/channel.go
@@ -1,0 +1,145 @@
+package meta
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	channelMake = iota
+	channelModel
+	channelType
+	channelNumber
+	channelSamplingRate
+	channelResponse
+	channelLast
+)
+
+// Channel is used to describe a generic recording from a Datalogger.
+type Channel struct {
+	Make         string
+	Model        string
+	Type         string
+	SamplingRate float64
+	Response     string
+	Number       int
+
+	number       string
+	samplingRate string
+}
+
+// Less compares Channel structs suitable for sorting.
+func (c Channel) Less(comp Channel) bool {
+
+	switch {
+	case strings.ToLower(c.Make) < strings.ToLower(comp.Make):
+		return true
+	case strings.ToLower(c.Make) > strings.ToLower(comp.Make):
+		return false
+	case strings.ToLower(c.Model) < strings.ToLower(comp.Model):
+		return true
+	case strings.ToLower(c.Model) > strings.ToLower(comp.Model):
+		return false
+	case c.Number < comp.Number:
+		return true
+	case c.Number > comp.Number:
+		return false
+	case c.SamplingRate < comp.SamplingRate:
+		return true
+	case c.SamplingRate > comp.SamplingRate:
+		return false
+	default:
+		return true
+	}
+}
+
+type ChannelList []Channel
+
+func (s ChannelList) Len() int           { return len(s) }
+func (s ChannelList) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s ChannelList) Less(i, j int) bool { return s[i].Less(s[j]) }
+
+func (s ChannelList) encode() [][]string {
+	data := [][]string{{
+		"Make",
+		"Model",
+		"Type",
+		"Number",
+		"SamplingRate",
+		"Response",
+	}}
+
+	for _, v := range s {
+		data = append(data, []string{
+			strings.TrimSpace(v.Make),
+			strings.TrimSpace(v.Model),
+			strings.TrimSpace(v.Type),
+			strings.TrimSpace(v.number),
+			strings.TrimSpace(v.samplingRate),
+			strings.TrimSpace(v.Response),
+		})
+	}
+
+	return data
+}
+func (s *ChannelList) decode(data [][]string) error {
+	var channels []Channel
+
+	if !(len(data) > 1) {
+		return nil
+	}
+
+	for _, d := range data[1:] {
+		if len(d) != channelLast {
+			return fmt.Errorf("incorrect number of installed channel fields")
+		}
+
+		var number int
+		if s := strings.TrimSpace(d[channelNumber]); s != "" {
+			v, err := strconv.Atoi(s)
+			if err != nil {
+				return err
+			}
+			number = v
+		}
+
+		samplingRate, err := strconv.ParseFloat(d[channelSamplingRate], 64)
+		if err != nil {
+			return err
+		}
+		if samplingRate < 0.0 {
+			samplingRate = -1.0 / samplingRate
+		}
+
+		channels = append(channels, Channel{
+			Make:     strings.TrimSpace(d[channelMake]),
+			Model:    strings.TrimSpace(d[channelModel]),
+			Type:     strings.TrimSpace(d[channelType]),
+			Response: strings.TrimSpace(d[channelResponse]),
+
+			Number:       number,
+			SamplingRate: samplingRate,
+
+			samplingRate: strings.TrimSpace(d[channelSamplingRate]),
+			number:       strings.TrimSpace(d[channelNumber]),
+		})
+	}
+
+	*s = ChannelList(channels)
+
+	return nil
+}
+
+func LoadChannels(path string) ([]Channel, error) {
+	var s []Channel
+
+	if err := LoadList(path, (*ChannelList)(&s)); err != nil {
+		return nil, err
+	}
+
+	sort.Sort(ChannelList(s))
+
+	return s, nil
+}

--- a/meta/component.go
+++ b/meta/component.go
@@ -1,0 +1,165 @@
+package meta
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	componentMake = iota
+	componentModel
+	componentType
+	componentNumber
+	componentSubsource
+	componentDip
+	componentAzimuth
+	componentTypes
+	componentResponse
+	componentLast
+)
+
+type Component struct {
+	Make      string
+	Model     string
+	Type      string
+	Number    int
+	Subsource string
+	Dip       float64
+	Azimuth   float64
+	Types     string
+	Response  string
+
+	number  string
+	dip     string
+	azimuth string
+}
+
+// Less compares Component structs suitable for sorting.
+func (c Component) Less(comp Component) bool {
+
+	switch {
+	case strings.ToLower(c.Make) < strings.ToLower(comp.Make):
+		return true
+	case strings.ToLower(c.Make) > strings.ToLower(comp.Make):
+		return false
+	case strings.ToLower(c.Model) < strings.ToLower(comp.Model):
+		return true
+	case strings.ToLower(c.Model) > strings.ToLower(comp.Model):
+		return false
+	case c.Number < comp.Number:
+		return true
+	case c.Number > comp.Number:
+		return false
+	default:
+		return true
+	}
+}
+
+type ComponentList []Component
+
+func (s ComponentList) Len() int           { return len(s) }
+func (s ComponentList) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s ComponentList) Less(i, j int) bool { return s[i].Less(s[j]) }
+
+func (s ComponentList) encode() [][]string {
+	data := [][]string{{
+		"Make",
+		"Model",
+		"Type",
+		"Number",
+		"Subsource",
+		"Dip",
+		"Azimuth",
+		"Types",
+		"Response",
+	}}
+
+	for _, v := range s {
+		data = append(data, []string{
+			strings.TrimSpace(v.Make),
+			strings.TrimSpace(v.Model),
+			strings.TrimSpace(v.Type),
+			strings.TrimSpace(v.number),
+			strings.TrimSpace(v.Subsource),
+			strings.TrimSpace(v.dip),
+			strings.TrimSpace(v.azimuth),
+			strings.TrimSpace(v.Types),
+			strings.TrimSpace(v.Response),
+		})
+	}
+	return data
+}
+func (s *ComponentList) decode(data [][]string) error {
+	var components []Component
+
+	if !(len(data) > 1) {
+		return nil
+	}
+
+	for _, d := range data[1:] {
+		if len(d) != componentLast {
+			return fmt.Errorf("incorrect pin of installed component fields")
+		}
+
+		var number int
+		if s := strings.TrimSpace(d[componentNumber]); s != "" {
+			v, err := strconv.Atoi(s)
+			if err != nil {
+				return err
+			}
+			number = v
+		}
+
+		var dip float64
+		if s := strings.TrimSpace(d[componentDip]); s != "" {
+			v, err := strconv.ParseFloat(s, 64)
+			if err != nil {
+				return err
+			}
+			dip = v
+		}
+
+		var azimuth float64
+		if s := strings.TrimSpace(d[componentAzimuth]); s != "" {
+			v, err := strconv.ParseFloat(d[componentAzimuth], 64)
+			if err != nil {
+				return err
+			}
+			azimuth = v
+		}
+
+		components = append(components, Component{
+			Make:      strings.TrimSpace(d[componentMake]),
+			Model:     strings.TrimSpace(d[componentModel]),
+			Type:      strings.TrimSpace(d[componentType]),
+			Number:    number,
+			Subsource: strings.TrimSpace(d[componentSubsource]),
+			Dip:       dip,
+			Azimuth:   azimuth,
+			Types:     strings.TrimSpace(d[componentTypes]),
+			Response:  strings.TrimSpace(d[componentResponse]),
+
+			number:  strings.TrimSpace(d[componentNumber]),
+			dip:     strings.TrimSpace(d[componentDip]),
+			azimuth: strings.TrimSpace(d[componentAzimuth]),
+		})
+	}
+
+	*s = ComponentList(components)
+
+	return nil
+}
+
+func LoadComponents(path string) ([]Component, error) {
+	var s []Component
+
+	if err := LoadList(path, (*ComponentList)(&s)); err != nil {
+		return nil, err
+	}
+
+	sort.Sort(ComponentList(s))
+
+	return s, nil
+}

--- a/meta/list_test.go
+++ b/meta/list_test.go
@@ -1100,6 +1100,92 @@ func TestList(t *testing.T) {
 				},
 			},
 		},
+		{
+			"testdata/components.csv",
+			&ComponentList{
+				Component{
+					Make:      "Guralp",
+					Model:     "Fortis",
+					Type:      "Accelerometer",
+					Number:    0,
+					Subsource: "Z",
+					Dip:       -90.0,
+					Azimuth:   0.0,
+					Types:     "G",
+					Response:  "sensor_guralp_fortis_response",
+
+					number:  "0",
+					dip:     "-90",
+					azimuth: "0",
+				},
+				Component{
+					Make:      "Guralp",
+					Model:     "Fortis",
+					Type:      "Accelerometer",
+					Number:    1,
+					Subsource: "N",
+					Dip:       0.0,
+					Azimuth:   0.0,
+					Types:     "G",
+					Response:  "sensor_guralp_fortis_response",
+
+					number:  "1",
+					dip:     "0",
+					azimuth: "0",
+				},
+				Component{
+					Make:      "Guralp",
+					Model:     "Fortis",
+					Type:      "Accelerometer",
+					Number:    2,
+					Subsource: "E",
+					Dip:       0.0,
+					Azimuth:   90.0,
+					Types:     "G",
+					Response:  "sensor_guralp_fortis_response",
+
+					number:  "2",
+					dip:     "0",
+					azimuth: "90",
+				},
+			},
+		},
+		{
+			"testdata/channels.csv",
+			&ChannelList{
+				Channel{
+					Make:         "Nanometrics",
+					Model:        "Centaur CTR4-6S",
+					Type:         "Datalogger",
+					SamplingRate: 200,
+					Response:     "datalogger_nanometrics_centaur_200_response",
+
+					samplingRate: "200",
+				},
+				Channel{
+					Make:         "Quanterra",
+					Model:        "Q330HR/6",
+					Type:         "Datalogger",
+					Number:       0,
+					SamplingRate: 200,
+					Response:     "datalogger_quanterra_q330_highgain_200_response",
+
+					number:       "0",
+					samplingRate: "200",
+				},
+				Channel{
+					Make:         "Quanterra",
+					Model:        "Q330HR/6",
+					Type:         "Datalogger",
+					Number:       3,
+					SamplingRate: 200,
+					Response:     "datalogger_quanterra_q330_200_response",
+
+					number:       "3",
+					samplingRate: "200",
+				},
+			},
+		},
 	}
 
 	for _, tt := range listtests {

--- a/meta/testdata/channels.csv
+++ b/meta/testdata/channels.csv
@@ -1,0 +1,4 @@
+Make,Model,Type,Number,SamplingRate,Response
+Nanometrics,Centaur CTR4-6S,Datalogger,,200,datalogger_nanometrics_centaur_200_response
+Quanterra,Q330HR/6,Datalogger,0,200,datalogger_quanterra_q330_highgain_200_response
+Quanterra,Q330HR/6,Datalogger,3,200,datalogger_quanterra_q330_200_response

--- a/meta/testdata/components.csv
+++ b/meta/testdata/components.csv
@@ -1,0 +1,4 @@
+Make,Model,Type,Number,Subsource,Dip,Azimuth,Types,Response
+Guralp,Fortis,Accelerometer,0,Z,-90,0,G,sensor_guralp_fortis_response
+Guralp,Fortis,Accelerometer,1,N,0,0,G,sensor_guralp_fortis_response
+Guralp,Fortis,Accelerometer,2,E,0,90,G,sensor_guralp_fortis_response


### PR DESCRIPTION
This attempts to add a reference mechanism to link simple responses (given by a label) to a sensor component (and also include base characteristics like dip and azimuth), or to a datalogger channel using a pin offset and a sampling rate. The edge case with multiple streams with the same sampling rates but different responses has been skipped for now.