### PR TITLE
add response labels

### DIFF
--- a/meta/label.go
+++ b/meta/label.go
@@ -1,0 +1,141 @@
+package meta
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	labelType = iota
+	labelSamplingRate
+	labelAzimuth
+	labelDip
+	labelCode
+	labelFlags
+	labelLast
+)
+
+// Label is used to describe a channel stream.
+type Label struct {
+	Type  string
+	Code  string
+	Flags string
+
+	SamplingRate float64
+	Azimuth      float64
+	Dip          float64
+
+	azimuth      string
+	dip          string
+	samplingRate string
+}
+
+// Less compares Label structs suitable for sorting.
+func (c Label) Less(label Label) bool {
+
+	switch {
+	case strings.ToLower(c.Type) < strings.ToLower(label.Type):
+		return true
+	case strings.ToLower(c.Type) > strings.ToLower(label.Type):
+		return false
+	case c.SamplingRate < label.SamplingRate:
+		return true
+	case c.SamplingRate > label.SamplingRate:
+		return false
+	case c.Dip < label.Dip:
+		return true
+	case c.Dip > label.Dip:
+		return false
+	case c.Azimuth < label.Azimuth:
+		return true
+	default:
+		return false
+	}
+}
+
+type LabelList []Label
+
+func (s LabelList) Len() int           { return len(s) }
+func (s LabelList) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s LabelList) Less(i, j int) bool { return s[i].Less(s[j]) }
+
+func (s LabelList) encode() [][]string {
+	data := [][]string{{
+		"Type",
+		"Sampling Rate",
+		"Azimuth",
+		"Dip",
+		"Code",
+		"Flags",
+	}}
+
+	for _, v := range s {
+		data = append(data, []string{
+			strings.TrimSpace(v.Type),
+			strings.TrimSpace(v.samplingRate),
+			strings.TrimSpace(v.azimuth),
+			strings.TrimSpace(v.dip),
+			strings.TrimSpace(v.Code),
+			strings.TrimSpace(string(v.Flags)),
+		})
+	}
+	return data
+}
+func (s *LabelList) decode(data [][]string) error {
+	var labels []Label
+	if len(data) > 1 {
+		for _, d := range data[1:] {
+			if len(d) != labelLast {
+				return fmt.Errorf("incorrect number of label fields")
+			}
+
+			rate, err := strconv.ParseFloat(d[labelSamplingRate], 64)
+			if err != nil {
+				return err
+			}
+			if rate < 0 {
+				rate = -1.0 / rate
+			}
+
+			azimuth, err := strconv.ParseFloat(d[labelAzimuth], 64)
+			if err != nil {
+				return err
+			}
+			dip, err := strconv.ParseFloat(d[labelDip], 64)
+			if err != nil {
+				return err
+			}
+
+			labels = append(labels, Label{
+				Type:  strings.TrimSpace(d[labelType]),
+				Code:  strings.TrimSpace(d[labelCode]),
+				Flags: strings.TrimSpace(d[labelFlags]),
+
+				SamplingRate: rate,
+				Azimuth:      azimuth,
+				Dip:          dip,
+
+				samplingRate: strings.TrimSpace(d[labelSamplingRate]),
+				azimuth:      strings.TrimSpace(d[labelAzimuth]),
+				dip:          strings.TrimSpace(d[labelDip]),
+			})
+		}
+
+		*s = LabelList(labels)
+	}
+	return nil
+}
+
+func LoadLabels(path string) ([]Label, error) {
+	var s []Label
+
+	if err := LoadList(path, (*LabelList)(&s)); err != nil {
+		return nil, err
+	}
+
+	sort.Sort(LabelList(s))
+
+	return s, nil
+}

--- a/meta/label.go
+++ b/meta/label.go
@@ -13,6 +13,7 @@ const (
 	labelAzimuth
 	labelDip
 	labelCode
+	labelAxial
 	labelFlags
 	labelLast
 )
@@ -21,12 +22,14 @@ const (
 type Label struct {
 	Type  string
 	Code  string
+	Axial string
 	Flags string
 
 	SamplingRate float64
 	Azimuth      float64
 	Dip          float64
 
+	axial        string
 	azimuth      string
 	dip          string
 	samplingRate string
@@ -68,6 +71,7 @@ func (s LabelList) encode() [][]string {
 		"Azimuth",
 		"Dip",
 		"Code",
+		"Axial",
 		"Flags",
 	}}
 
@@ -78,6 +82,7 @@ func (s LabelList) encode() [][]string {
 			strings.TrimSpace(v.azimuth),
 			strings.TrimSpace(v.dip),
 			strings.TrimSpace(v.Code),
+			strings.TrimSpace(v.axial),
 			strings.TrimSpace(string(v.Flags)),
 		})
 	}
@@ -108,15 +113,22 @@ func (s *LabelList) decode(data [][]string) error {
 				return err
 			}
 
+			axial := strings.TrimSpace(d[labelCode])
+			if s := strings.TrimSpace(d[labelAxial]); s != "" {
+				axial = s
+			}
+
 			labels = append(labels, Label{
 				Type:  strings.TrimSpace(d[labelType]),
 				Code:  strings.TrimSpace(d[labelCode]),
 				Flags: strings.TrimSpace(d[labelFlags]),
+				Axial: axial,
 
 				SamplingRate: rate,
 				Azimuth:      azimuth,
 				Dip:          dip,
 
+				axial:        strings.TrimSpace(d[labelAxial]),
 				samplingRate: strings.TrimSpace(d[labelSamplingRate]),
 				azimuth:      strings.TrimSpace(d[labelAzimuth]),
 				dip:          strings.TrimSpace(d[labelDip]),

--- a/meta/list_test.go
+++ b/meta/list_test.go
@@ -897,7 +897,9 @@ func TestList(t *testing.T) {
 					Dip:          -90.0,
 					Code:         "HHZ",
 					Flags:        "G",
+					Axial:        "HHZ",
 
+					axial:        "",
 					azimuth:      "0",
 					dip:          "-90",
 					samplingRate: "100",
@@ -909,7 +911,9 @@ func TestList(t *testing.T) {
 					Dip:          0.0,
 					Code:         "HNN",
 					Flags:        "G",
+					Axial:        "HN2",
 
+					axial:        "HN2",
 					azimuth:      "0",
 					dip:          "0",
 					samplingRate: "200",

--- a/meta/list_test.go
+++ b/meta/list_test.go
@@ -888,6 +888,35 @@ func TestList(t *testing.T) {
 			},
 		},
 		{
+			"testdata/labels.csv",
+			&LabelList{
+				Label{
+					Type:         "Broadband Seismometer",
+					SamplingRate: 100.0,
+					Azimuth:      0.0,
+					Dip:          -90.0,
+					Code:         "HHZ",
+					Flags:        "G",
+
+					azimuth:      "0",
+					dip:          "-90",
+					samplingRate: "100",
+				},
+				Label{
+					Type:         "Accelerometer",
+					SamplingRate: 200.0,
+					Azimuth:      0.0,
+					Dip:          0.0,
+					Code:         "HNN",
+					Flags:        "G",
+
+					azimuth:      "0",
+					dip:          "0",
+					samplingRate: "200",
+				},
+			},
+		},
+		{
 			"testdata/gauges.csv",
 			&GaugeList{
 				Gauge{

--- a/meta/testdata/labels.csv
+++ b/meta/testdata/labels.csv
@@ -1,0 +1,3 @@
+Type,Sampling Rate,Azimuth,Dip,Code,Flags
+Broadband Seismometer,100,0,-90,HHZ,G
+Accelerometer,200,0,0,HNN,G

--- a/meta/testdata/labels.csv
+++ b/meta/testdata/labels.csv
@@ -1,3 +1,3 @@
-Type,Sampling Rate,Azimuth,Dip,Code,Flags
-Broadband Seismometer,100,0,-90,HHZ,G
-Accelerometer,200,0,0,HNN,G
+Type,Sampling Rate,Azimuth,Dip,Code,Axial,Flags
+Broadband Seismometer,100,0,-90,HHZ,,G
+Accelerometer,200,0,0,HNN,HN2,G

--- a/response/README.md
+++ b/response/README.md
@@ -15,6 +15,7 @@ _Lists the equipment details useful for building response information._
 | _Azimuth_ | The internal _Sensor_ component azimuth relative to North.
 | _Dip_ | The internal _Sensor_ dip angle relative to the horizontal, with positive down.
 | _Code_ | The code used for the __StationXML__ Channel for the _Stream_ and _Sensor_ pair.
+| _Axial_ | An optional code to used for the __StationXML__ Channel when the sensor is aligned axially.
 | _Flags_ | Any specific _Sensor_ meta-data flags as expected by __StationXML__.
 
 The _Flags_ should be single characters arranged alphabetically into a single word.

--- a/response/README.md
+++ b/response/README.md
@@ -1,0 +1,27 @@
+## RESPONSE ##
+
+_Lists the equipment details useful for building response information._
+
+### FILES ###
+
+* `labels.csv` - Describes datalogger stream channel codes for given sensors.
+
+#### _LABELS_ ####
+
+| Field | Description |
+| --- | --- |
+| _Type_ | The _Sensor_ type of the recorded stream.
+| _Sampling Rate_ | The _Stream_ sampling rate, or sampling period if negative.
+| _Azimuth_ | The internal _Sensor_ component azimuth relative to North.
+| _Dip_ | The internal _Sensor_ dip angle relative to the horizontal, with positive down.
+| _Code_ | The code used for the __StationXML__ Channel for the _Stream_ and _Sensor_ pair.
+| _Flags_ | Any specific _Sensor_ meta-data flags as expected by __StationXML__.
+
+The _Flags_ should be single characters arranged alphabetically into a single word.
+
+### CHECKS ###
+
+Pre-commit checks will be made on these files to ensure:
+* No duplicated type, sampling rate, azimuth, and dip - these need to be globally unique
+* The code needs to be uppercase and have a length of three characters.
+* The flags characters need to be sorted into a single word sequence.

--- a/response/labels.csv
+++ b/response/labels.csv
@@ -1,13 +1,13 @@
-Type,Sampling Rate,Azimuth,Dip,Code,Flags
-Broadband Seismometer,100,0,-90,HHZ,G
-Broadband Seismometer,100,0,0,HHN,G
-Broadband Seismometer,100,90,0,HHE,G
-Short Period Seismometer,100,0,-90,EHZ,G
-Short Period Seismometer,100,0,0,EHN,G
-Short Period Seismometer,100,90,0,EHE,G
-Strong Motion Sensor,200,0,-90,HNZ,G
-Strong Motion Sensor,200,0,0,HNN,G
-Strong Motion Sensor,200,90,0,HNE,G
-Accelerometer,200,0,-90,HNZ,G
-Accelerometer,200,0,0,HNN,G
-Accelerometer,200,90,0,HNE,G
+Type,Sampling Rate,Azimuth,Dip,Code,Axial,Flags
+Broadband Seismometer,100,0,-90,HHZ,,G
+Broadband Seismometer,100,0,0,HHN,HH1,G
+Broadband Seismometer,100,90,0,HHE,HH2,G
+Short Period Seismometer,100,0,-90,EHZ,,G
+Short Period Seismometer,100,0,0,EHN,EH1,G
+Short Period Seismometer,100,90,0,EHE,EH2,G
+Strong Motion Sensor,200,0,-90,HNZ,,G
+Strong Motion Sensor,200,0,0,HNN,HN1,G
+Strong Motion Sensor,200,90,0,HNE,HN2,G
+Accelerometer,200,0,-90,HNZ,,G
+Accelerometer,200,0,0,HNN,HN1,G
+Accelerometer,200,90,0,HNE,HN2,G

--- a/response/labels.csv
+++ b/response/labels.csv
@@ -1,0 +1,13 @@
+Type,Sampling Rate,Azimuth,Dip,Code,Flags
+Broadband Seismometer,100,0,-90,HHZ,G
+Broadband Seismometer,100,0,0,HHN,G
+Broadband Seismometer,100,90,0,HHE,G
+Short Period Seismometer,100,0,-90,EHZ,G
+Short Period Seismometer,100,0,0,EHN,G
+Short Period Seismometer,100,90,0,EHE,G
+Strong Motion Sensor,200,0,-90,HNZ,G
+Strong Motion Sensor,200,0,0,HNN,G
+Strong Motion Sensor,200,90,0,HNE,G
+Accelerometer,200,0,-90,HNZ,G
+Accelerometer,200,0,0,HNN,G
+Accelerometer,200,90,0,HNE,G

--- a/tests/labels_test.go
+++ b/tests/labels_test.go
@@ -1,0 +1,70 @@
+package delta_test
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/GeoNet/delta/meta"
+)
+
+var testLabels = map[string]func([]meta.Label) func(t *testing.T){
+	"check for duplicated labels": func(labels []meta.Label) func(t *testing.T) {
+		return func(t *testing.T) {
+			for i := 0; i < len(labels); i++ {
+				for j := i + 1; j < len(labels); j++ {
+					if labels[i].Type != labels[j].Type {
+						continue
+					}
+					if labels[i].SamplingRate != labels[j].SamplingRate {
+						continue
+					}
+					if labels[i].Azimuth != labels[j].Azimuth {
+						continue
+					}
+					if labels[i].Dip != labels[j].Dip {
+						continue
+					}
+
+					t.Errorf("label overlap: %s (%g) at %g/%g", labels[i].Type, labels[i].SamplingRate, labels[i].Azimuth, labels[i].Dip)
+				}
+			}
+		}
+	},
+
+	"check for invalid codes": func(labels []meta.Label) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, l := range labels {
+				if s := strings.ToUpper(l.Code); s != l.Code {
+					t.Errorf("label code case issue: %s (%g) %s", l.Type, l.SamplingRate, l.Code)
+				}
+				if n := len(l.Code); n != 3 {
+					t.Errorf("label code len issue: %s (%g) %s", l.Type, l.SamplingRate, l.Code)
+				}
+			}
+		}
+	},
+	"check for invalid flags": func(labels []meta.Label) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, l := range labels {
+				f := []byte(l.Flags)
+				sort.Slice(f, func(i, j int) bool {
+					return f[i] < f[j]
+				})
+				if s := string(f); s != l.Flags {
+					t.Errorf("label flags sort issue: %s (%g) %s", l.Type, l.SamplingRate, l.Flags)
+				}
+			}
+		}
+	},
+}
+
+func TestLabels(t *testing.T) {
+
+	var labels meta.LabelList
+	loadListFile(t, "../response/labels.csv", &labels)
+
+	for k, fn := range testLabels {
+		t.Run(k, fn(labels))
+	}
+}


### PR DESCRIPTION
This is part of the stationxml work to bring as much ad hoc meta data into manageable tables.

This PR provides a list of stream channel codes and types used in _StationXML_ when describing a stream.

I've created a new directory where "response" specific tables may live, it's possible that the channels and calibrations files could live here too eventually.

I've added an Axial column, this is optional and will defer to the Code value if not given. This is used when an installation has been deemed to be "axial", that is not-aligned North/South but at some other axis.

I'm not exactly happy with the name, but I couldn't think of anything else (other than channels, which is taken).