### PR TITLE
add delta set helper

### DIFF
--- a/delta.go
+++ b/delta.go
@@ -1,0 +1,42 @@
+package delta
+
+import (
+	"embed"
+	"io/fs"
+	"sync"
+
+	"github.com/GeoNet/delta/meta"
+)
+
+//go:embed assets/*.csv
+//go:embed install/*.csv
+//go:embed network/*.csv
+//go:embed environment/*.csv
+var files embed.FS
+
+// there can be but one
+var singleton struct {
+	once sync.Once
+	set  *meta.Set
+	err  error
+}
+
+// New returns a Set pointer based on the embeded csv files.
+// Multiple calls will return the same pointer and error as the first call.
+func New() (*meta.Set, error) {
+	singleton.once.Do(func() {
+		singleton.set, singleton.err = NewFS(files)
+	})
+	return singleton.set, singleton.err
+}
+
+// NewFS returns a Delta pointer based on a given FS structure.
+func NewFS(fs fs.FS) (*meta.Set, error) {
+
+	set, err := meta.NewSet(fs)
+	if err != nil {
+		return nil, err
+	}
+
+	return set, nil
+}

--- a/delta_test.go
+++ b/delta_test.go
@@ -1,0 +1,11 @@
+package delta
+
+import (
+	"testing"
+)
+
+func TestDelta(t *testing.T) {
+	if _, err := New(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/meta/generate/generate.go
+++ b/meta/generate/generate.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"io"
+	"strings"
+	"text/template"
+)
+
+var generateTemplate = `
+/*
+ *  WARNING: CODE GENERATED AUTOMATICALLY.
+ *
+ *  To update any changes, run "go generate" in the main project
+ *  directory and then commit this file.
+ *
+ *  THIS FILE SHOULD NOT BE EDITED BY HAND.
+ *
+ */
+
+package meta
+
+{{range $k, $v := .Fields -}}
+// {{title $k}} is a helper function to return a slice copy of {{$v.Key}} values.
+func (s Set) {{title $k}}() []{{$v.Key}} {
+	{{$k}} := make([]{{$v.Key}}, len(s.{{$k}}))
+        copy({{$k}}, s.{{$k}})
+        return {{$k}}
+}
+
+{{end -}}
+
+{{range $k, $v := .Lookup -}}
+// {{$v.Key}} is a helper function to return a {{$v.Key}} value and true if one exists.
+func (s Set) {{$v.Key}}({{join ", " $v.Fields}} string) ({{$v.Key}}, bool) {
+	for _, v := range s.{{$k}} {
+		{{range $f := $v.Fields -}}
+		if {{$f}} != v.{{title $f}} {
+			continue
+		}
+		{{end -}}
+		return v, true
+	}
+	return {{$v.Key}}{{"{}"}}, false
+}
+
+{{end -}}
+`
+
+type Generate struct {
+	Fields map[string]struct {
+		Key string //nolint:unused // used in template
+	}
+	Lookup map[string]struct {
+		Key    string   //nolint:unused // used in template
+		Fields []string //nolint:unused // used in template
+	}
+}
+
+func (g Generate) Write(w io.Writer) error {
+
+	t, err := template.New("generate").Funcs(
+		template.FuncMap{
+			"title": func(s string) string { return strings.Title(s) },
+			"join":  func(k string, s []string) string { return strings.Join(s, k) },
+		},
+	).Parse(generateTemplate)
+	if err != nil {
+		return err
+	}
+	if err := t.Execute(w, g); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/meta/generate/main.go
+++ b/meta/generate/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"log"
+	"os"
+)
+
+func main() {
+
+	generate := Generate{
+		Fields: map[string]struct {
+			Key string
+		}{
+			"assets":              {"Asset"},
+			"calibrations":        {"Calibration"},
+			"connections":         {"Connection"},
+			"constituents":        {"Constituent"},
+			"deployedDataloggers": {"DeployedDatalogger"},
+			"deployedReceivers":   {"DeployedReceiver"},
+			"doases":              {"InstalledDoas"},
+			"features":            {"Feature"},
+			"firmwareHistory":     {"FirmwareHistory"},
+			"gains":               {"Gain"},
+			"gauges":              {"Gauge"},
+			"installedAntennas":   {"InstalledAntenna"},
+			"installedCameras":    {"InstalledCamera"},
+			"installedMetSensors": {"InstalledMetSensor"},
+			"installedRadomes":    {"InstalledRadome"},
+			"installedRecorders":  {"InstalledRecorder"},
+			"installedSensors":    {"InstalledSensor"},
+			"marks":               {"Mark"},
+			"monuments":           {"Monument"},
+			"mounts":              {"Mount"},
+			"networks":            {"Network"},
+			"placenames":          {"Placename"},
+			"sessions":            {"Session"},
+			"sites":               {"Site"},
+			"stations":            {"Station"},
+			"streams":             {"Stream"},
+			"views":               {"View"},
+			"visibilities":        {"Visibility"},
+		},
+		Lookup: map[string]struct {
+			Key    string
+			Fields []string
+		}{
+			"assets":     {"Asset", []string{"make", "model", "serial"}},
+			"marks":      {"Mark", []string{"code"}},
+			"monuments":  {"Monument", []string{"mark"}},
+			"mounts":     {"Mount", []string{"code"}},
+			"networks":   {"Network", []string{"code"}},
+			"placenames": {"Placename", []string{"name"}},
+			"sites":      {"Site", []string{"station", "location"}},
+			"stations":   {"Station", []string{"code"}},
+			"views":      {"View", []string{"mount", "code"}},
+		},
+	}
+
+	if err := generate.Write(os.Stdout); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/meta/set.go
+++ b/meta/set.go
@@ -1,0 +1,176 @@
+package meta
+
+//go:generate bash -c "go run generate/*.go | gofmt -s > set_auto.go; test -s set_auto.go || rm set_auto.go"
+
+import (
+	"fmt"
+	"io/fs"
+	"sort"
+)
+
+const (
+	AssetFiles = "assets/*.csv"
+
+	MarksFile     = "network/marks.csv"
+	MonumentsFile = "network/monuments.csv"
+	MountsFile    = "network/mounts.csv"
+	NetworksFile  = "network/networks.csv"
+	SitesFile     = "network/sites.csv"
+	StationsFile  = "network/stations.csv"
+	ViewsFile     = "network/views.csv"
+
+	AntennasFile     = "install/antennas.csv"
+	CamerasFile      = "install/cameras.csv"
+	ConnectionsFile  = "install/connections.csv"
+	DataloggersFile  = "install/dataloggers.csv"
+	DoasesFile       = "install/doases.csv"
+	FirmwareFile     = "install/firmware.csv"
+	GainsFile        = "install/gains.csv"
+	CalibrationsFile = "install/calibrations.csv"
+	MetsensorsFile   = "install/metsensors.csv"
+	RadomesFile      = "install/radomes.csv"
+	ReceiversFile    = "install/receivers.csv"
+	RecordersFile    = "install/recorders.csv"
+	SensorsFile      = "install/sensors.csv"
+	SessionsFile     = "install/sessions.csv"
+	StreamsFile      = "install/streams.csv"
+
+	ConstituentsFile = "environment/constituents.csv"
+	FeaturesFile     = "environment/features.csv"
+	GaugesFile       = "environment/gauges.csv"
+	VisibilityFile   = "environment/visibility.csv"
+	PlacenamesFile   = "environment/placenames.csv"
+
+	ChannelsFile   = "install/channels.csv"
+	ComponentsFile = "install/components.csv"
+	CodenamesFile  = "install/codenames.csv"
+)
+
+// SetPathMap is used to manipulate the filepath inside the Set.
+type SetPathMap func(s string) string
+
+// Set allows for extracting and unmarshalling the base delta csv files,
+// optional SetPathMap functions can be given to alter the expected default
+// file paths prior to reading from the FS set. This is useful for testing
+// or using a non-standard file layout.
+type Set struct {
+	assets AssetList
+
+	marks     MarkList
+	monuments MonumentList
+	mounts    MountList
+	networks  NetworkList
+	sites     SiteList
+	stations  StationList
+	views     ViewList
+
+	installedAntennas   InstalledAntennaList
+	installedCameras    InstalledCameraList
+	connections         ConnectionList
+	deployedDataloggers DeployedDataloggerList
+	doases              InstalledDoasList
+	firmwareHistory     FirmwareHistoryList
+	gains               GainList
+	calibrations        CalibrationList
+	installedMetSensors InstalledMetSensorList
+	installedRadomes    InstalledRadomeList
+
+	installedSensors   InstalledSensorList
+	installedRecorders InstalledRecorderList
+	deployedReceivers  DeployedReceiverList
+	sessions           SessionList
+	streams            StreamList
+
+	constituents ConstituentList
+	features     FeatureList
+	gauges       GaugeList
+	visibilities VisibilityList
+	placenames   PlacenameList
+}
+
+func (s *Set) files() map[string]List {
+	return map[string]List{
+		AssetFiles: &s.assets,
+
+		MarksFile:     &s.marks,
+		MonumentsFile: &s.monuments,
+		MountsFile:    &s.mounts,
+		NetworksFile:  &s.networks,
+		SitesFile:     &s.sites,
+		StationsFile:  &s.stations,
+		ViewsFile:     &s.views,
+
+		AntennasFile:     &s.installedAntennas,
+		CamerasFile:      &s.installedCameras,
+		ConnectionsFile:  &s.connections,
+		DataloggersFile:  &s.deployedDataloggers,
+		DoasesFile:       &s.doases,
+		FirmwareFile:     &s.firmwareHistory,
+		GainsFile:        &s.gains,
+		CalibrationsFile: &s.calibrations,
+		MetsensorsFile:   &s.installedMetSensors,
+		RadomesFile:      &s.installedRadomes,
+		ReceiversFile:    &s.deployedReceivers,
+		RecordersFile:    &s.installedRecorders,
+		SensorsFile:      &s.installedSensors,
+		SessionsFile:     &s.sessions,
+		StreamsFile:      &s.streams,
+
+		ConstituentsFile: &s.constituents,
+		FeaturesFile:     &s.features,
+		GaugesFile:       &s.gauges,
+		VisibilityFile:   &s.visibilities,
+		PlacenamesFile:   &s.placenames,
+	}
+}
+
+// NewSet returns a Set pointer for the given FS and optional SetPathMap
+// functions to manipulate the internal csv file paths.
+func NewSet(fsys fs.FS, maps ...SetPathMap) (*Set, error) {
+	var set Set
+
+	for path, list := range set.files() {
+		switch path {
+		case AssetFiles:
+			for _, p := range maps {
+				path = p(path)
+			}
+			names, err := fs.Glob(fsys, path)
+			if err != nil {
+				return nil, fmt.Errorf("glob error %s: %w", path, err)
+			}
+			for _, name := range names {
+				var assets AssetList
+				data, err := fs.ReadFile(fsys, name)
+				if err != nil {
+					return nil, fmt.Errorf("read error %s: %w", path, err)
+				}
+				if err := UnmarshalList(data, &assets); err != nil {
+					return nil, fmt.Errorf("unmarshal error %s: %w", path, err)
+				}
+				set.assets = append(set.assets, assets...)
+			}
+			sort.Sort(set.assets)
+		default:
+			for _, p := range maps {
+				path = p(path)
+			}
+			names, err := fs.Glob(fsys, path)
+			if err != nil {
+				return nil, fmt.Errorf("glob error %s: %w", path, err)
+			}
+			for _, name := range names {
+				data, err := fs.ReadFile(fsys, name)
+				if err != nil {
+					return nil, fmt.Errorf("read error %s: %w", path, err)
+				}
+				if err := UnmarshalList(data, list); err != nil {
+					return nil, fmt.Errorf("unmarshal error %s: %w", path, err)
+				}
+			}
+			sort.Sort(list)
+		}
+	}
+
+	return &set, nil
+}

--- a/meta/set_auto.go
+++ b/meta/set_auto.go
@@ -1,0 +1,318 @@
+/*
+ *  WARNING: CODE GENERATED AUTOMATICALLY.
+ *
+ *  To update any changes, run "go generate" in the main project
+ *  directory and then commit this file.
+ *
+ *  THIS FILE SHOULD NOT BE EDITED BY HAND.
+ *
+ */
+
+package meta
+
+// Assets is a helper function to return a slice copy of Asset values.
+func (s Set) Assets() []Asset {
+	assets := make([]Asset, len(s.assets))
+	copy(assets, s.assets)
+	return assets
+}
+
+// Calibrations is a helper function to return a slice copy of Calibration values.
+func (s Set) Calibrations() []Calibration {
+	calibrations := make([]Calibration, len(s.calibrations))
+	copy(calibrations, s.calibrations)
+	return calibrations
+}
+
+// Connections is a helper function to return a slice copy of Connection values.
+func (s Set) Connections() []Connection {
+	connections := make([]Connection, len(s.connections))
+	copy(connections, s.connections)
+	return connections
+}
+
+// Constituents is a helper function to return a slice copy of Constituent values.
+func (s Set) Constituents() []Constituent {
+	constituents := make([]Constituent, len(s.constituents))
+	copy(constituents, s.constituents)
+	return constituents
+}
+
+// DeployedDataloggers is a helper function to return a slice copy of DeployedDatalogger values.
+func (s Set) DeployedDataloggers() []DeployedDatalogger {
+	deployedDataloggers := make([]DeployedDatalogger, len(s.deployedDataloggers))
+	copy(deployedDataloggers, s.deployedDataloggers)
+	return deployedDataloggers
+}
+
+// DeployedReceivers is a helper function to return a slice copy of DeployedReceiver values.
+func (s Set) DeployedReceivers() []DeployedReceiver {
+	deployedReceivers := make([]DeployedReceiver, len(s.deployedReceivers))
+	copy(deployedReceivers, s.deployedReceivers)
+	return deployedReceivers
+}
+
+// Doases is a helper function to return a slice copy of InstalledDoas values.
+func (s Set) Doases() []InstalledDoas {
+	doases := make([]InstalledDoas, len(s.doases))
+	copy(doases, s.doases)
+	return doases
+}
+
+// Features is a helper function to return a slice copy of Feature values.
+func (s Set) Features() []Feature {
+	features := make([]Feature, len(s.features))
+	copy(features, s.features)
+	return features
+}
+
+// FirmwareHistory is a helper function to return a slice copy of FirmwareHistory values.
+func (s Set) FirmwareHistory() []FirmwareHistory {
+	firmwareHistory := make([]FirmwareHistory, len(s.firmwareHistory))
+	copy(firmwareHistory, s.firmwareHistory)
+	return firmwareHistory
+}
+
+// Gains is a helper function to return a slice copy of Gain values.
+func (s Set) Gains() []Gain {
+	gains := make([]Gain, len(s.gains))
+	copy(gains, s.gains)
+	return gains
+}
+
+// Gauges is a helper function to return a slice copy of Gauge values.
+func (s Set) Gauges() []Gauge {
+	gauges := make([]Gauge, len(s.gauges))
+	copy(gauges, s.gauges)
+	return gauges
+}
+
+// InstalledAntennas is a helper function to return a slice copy of InstalledAntenna values.
+func (s Set) InstalledAntennas() []InstalledAntenna {
+	installedAntennas := make([]InstalledAntenna, len(s.installedAntennas))
+	copy(installedAntennas, s.installedAntennas)
+	return installedAntennas
+}
+
+// InstalledCameras is a helper function to return a slice copy of InstalledCamera values.
+func (s Set) InstalledCameras() []InstalledCamera {
+	installedCameras := make([]InstalledCamera, len(s.installedCameras))
+	copy(installedCameras, s.installedCameras)
+	return installedCameras
+}
+
+// InstalledMetSensors is a helper function to return a slice copy of InstalledMetSensor values.
+func (s Set) InstalledMetSensors() []InstalledMetSensor {
+	installedMetSensors := make([]InstalledMetSensor, len(s.installedMetSensors))
+	copy(installedMetSensors, s.installedMetSensors)
+	return installedMetSensors
+}
+
+// InstalledRadomes is a helper function to return a slice copy of InstalledRadome values.
+func (s Set) InstalledRadomes() []InstalledRadome {
+	installedRadomes := make([]InstalledRadome, len(s.installedRadomes))
+	copy(installedRadomes, s.installedRadomes)
+	return installedRadomes
+}
+
+// InstalledRecorders is a helper function to return a slice copy of InstalledRecorder values.
+func (s Set) InstalledRecorders() []InstalledRecorder {
+	installedRecorders := make([]InstalledRecorder, len(s.installedRecorders))
+	copy(installedRecorders, s.installedRecorders)
+	return installedRecorders
+}
+
+// InstalledSensors is a helper function to return a slice copy of InstalledSensor values.
+func (s Set) InstalledSensors() []InstalledSensor {
+	installedSensors := make([]InstalledSensor, len(s.installedSensors))
+	copy(installedSensors, s.installedSensors)
+	return installedSensors
+}
+
+// Marks is a helper function to return a slice copy of Mark values.
+func (s Set) Marks() []Mark {
+	marks := make([]Mark, len(s.marks))
+	copy(marks, s.marks)
+	return marks
+}
+
+// Monuments is a helper function to return a slice copy of Monument values.
+func (s Set) Monuments() []Monument {
+	monuments := make([]Monument, len(s.monuments))
+	copy(monuments, s.monuments)
+	return monuments
+}
+
+// Mounts is a helper function to return a slice copy of Mount values.
+func (s Set) Mounts() []Mount {
+	mounts := make([]Mount, len(s.mounts))
+	copy(mounts, s.mounts)
+	return mounts
+}
+
+// Networks is a helper function to return a slice copy of Network values.
+func (s Set) Networks() []Network {
+	networks := make([]Network, len(s.networks))
+	copy(networks, s.networks)
+	return networks
+}
+
+// Placenames is a helper function to return a slice copy of Placename values.
+func (s Set) Placenames() []Placename {
+	placenames := make([]Placename, len(s.placenames))
+	copy(placenames, s.placenames)
+	return placenames
+}
+
+// Sessions is a helper function to return a slice copy of Session values.
+func (s Set) Sessions() []Session {
+	sessions := make([]Session, len(s.sessions))
+	copy(sessions, s.sessions)
+	return sessions
+}
+
+// Sites is a helper function to return a slice copy of Site values.
+func (s Set) Sites() []Site {
+	sites := make([]Site, len(s.sites))
+	copy(sites, s.sites)
+	return sites
+}
+
+// Stations is a helper function to return a slice copy of Station values.
+func (s Set) Stations() []Station {
+	stations := make([]Station, len(s.stations))
+	copy(stations, s.stations)
+	return stations
+}
+
+// Streams is a helper function to return a slice copy of Stream values.
+func (s Set) Streams() []Stream {
+	streams := make([]Stream, len(s.streams))
+	copy(streams, s.streams)
+	return streams
+}
+
+// Views is a helper function to return a slice copy of View values.
+func (s Set) Views() []View {
+	views := make([]View, len(s.views))
+	copy(views, s.views)
+	return views
+}
+
+// Visibilities is a helper function to return a slice copy of Visibility values.
+func (s Set) Visibilities() []Visibility {
+	visibilities := make([]Visibility, len(s.visibilities))
+	copy(visibilities, s.visibilities)
+	return visibilities
+}
+
+// Asset is a helper function to return a Asset value and true if one exists.
+func (s Set) Asset(make, model, serial string) (Asset, bool) {
+	for _, v := range s.assets {
+		if make != v.Make {
+			continue
+		}
+		if model != v.Model {
+			continue
+		}
+		if serial != v.Serial {
+			continue
+		}
+		return v, true
+	}
+	return Asset{}, false
+}
+
+// Mark is a helper function to return a Mark value and true if one exists.
+func (s Set) Mark(code string) (Mark, bool) {
+	for _, v := range s.marks {
+		if code != v.Code {
+			continue
+		}
+		return v, true
+	}
+	return Mark{}, false
+}
+
+// Monument is a helper function to return a Monument value and true if one exists.
+func (s Set) Monument(mark string) (Monument, bool) {
+	for _, v := range s.monuments {
+		if mark != v.Mark {
+			continue
+		}
+		return v, true
+	}
+	return Monument{}, false
+}
+
+// Mount is a helper function to return a Mount value and true if one exists.
+func (s Set) Mount(code string) (Mount, bool) {
+	for _, v := range s.mounts {
+		if code != v.Code {
+			continue
+		}
+		return v, true
+	}
+	return Mount{}, false
+}
+
+// Network is a helper function to return a Network value and true if one exists.
+func (s Set) Network(code string) (Network, bool) {
+	for _, v := range s.networks {
+		if code != v.Code {
+			continue
+		}
+		return v, true
+	}
+	return Network{}, false
+}
+
+// Placename is a helper function to return a Placename value and true if one exists.
+func (s Set) Placename(name string) (Placename, bool) {
+	for _, v := range s.placenames {
+		if name != v.Name {
+			continue
+		}
+		return v, true
+	}
+	return Placename{}, false
+}
+
+// Site is a helper function to return a Site value and true if one exists.
+func (s Set) Site(station, location string) (Site, bool) {
+	for _, v := range s.sites {
+		if station != v.Station {
+			continue
+		}
+		if location != v.Location {
+			continue
+		}
+		return v, true
+	}
+	return Site{}, false
+}
+
+// Station is a helper function to return a Station value and true if one exists.
+func (s Set) Station(code string) (Station, bool) {
+	for _, v := range s.stations {
+		if code != v.Code {
+			continue
+		}
+		return v, true
+	}
+	return Station{}, false
+}
+
+// View is a helper function to return a View value and true if one exists.
+func (s Set) View(mount, code string) (View, bool) {
+	for _, v := range s.views {
+		if mount != v.Mount {
+			continue
+		}
+		if code != v.Code {
+			continue
+		}
+		return v, true
+	}
+	return View{}, false
+}

--- a/meta/set_test.go
+++ b/meta/set_test.go
@@ -1,0 +1,21 @@
+package meta
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSet(t *testing.T) {
+	_, err := NewSet(os.DirFS("testdata"), func(s string) string {
+		switch {
+		case filepath.Dir(s) == "assets":
+			return "assets.csv"
+		default:
+			return filepath.Base(s)
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This is an initial mechanism to gather all the various csv based files together into a single structure.

This is aimed at mainly two primary use cases:

- testing 
- CI/CD

The first testing phase allows building a standard call fingerprint for running a given test, e.g.

```golang
var testInstalledAntennas = map[string]func(*meta.Set) func(t *testing.T){
       "check antenna installation overlap": func(set *meta.Set) func(t *testing.T) {
                return func(t *testing.T) {
```

which makes table driven testing much easier (this will be a follow up bit of work).


and for the second part with CI/CD.

The program simply needs to be compiled to have access to the current set of files, basically due to the embedding the files live within the go binary which makes writing programs to build configuration simpler to operate.  As delta is a public repo it means this can all be handled within the go tools (rather than needing git checkout etcs.) 
