### PR TITLE
add volcano camera config tools

### DIFF
--- a/cmd/camera-config/README.md
+++ b/cmd/camera-config/README.md
@@ -1,0 +1,26 @@
+# camera-config
+
+Provide configuration for labelling remote camera images.
+
+## output
+
+The output json file provides a lookup for each camera _view_ to allow a simple caption.
+
+Build a camera caption configuration from delta meta information
+
+## usage
+
+    ./camera-config [options]
+
+## options
+
+    -active
+        only output active camera information
+    -base string
+        base for custom delta files
+    -networks string
+        comma separated list of networks, an empty value matches all networks
+    -output string
+        where to store json formatted output
+    -verbose
+        make noise

--- a/cmd/camera-config/caption.go
+++ b/cmd/camera-config/caption.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+)
+
+type Caption struct {
+	Mount string `json:"mount"`
+	View  string `json:"view"`
+	Label string `json:"label"`
+}
+
+type Captions []Caption
+
+func (c Captions) EncodeFile(path string) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return c.Encode(file)
+}
+
+func (c Captions) Encode(wr io.Writer) error {
+	return json.NewEncoder(wr).Encode(c)
+}

--- a/cmd/camera-config/caption_test.go
+++ b/cmd/camera-config/caption_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCameras(t *testing.T) {
+
+	const res = `[{"mount":"CHTB","view":"01","label":"Christchurch East"},{"mount":"CHTB","view":"02","label":"Christchurch North East"}]`
+
+	captions := []Caption{
+		{
+			Mount: "CHTB",
+			View:  "01",
+			Label: "Christchurch East",
+		},
+		{
+			Mount: "CHTB",
+			View:  "02",
+			Label: "Christchurch North East",
+		},
+	}
+
+	var buf bytes.Buffer
+
+	if err := Captions(captions).Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if s := strings.TrimSpace(buf.String()); s != res {
+		t.Errorf("invalid camera encoding: %s", cmp.Diff(s, res))
+	}
+
+}

--- a/cmd/camera-config/main.go
+++ b/cmd/camera-config/main.go
@@ -57,25 +57,25 @@ func main() {
 
 	var captions []Caption
 
-	for _, m := range set.Mounts() {
-		if _, ok := nets[m.Network]; len(nets) > 0 && !ok {
+	for _, mount := range set.Mounts() {
+		if _, ok := nets[mount.Network]; len(nets) > 0 && !ok {
 			continue
 		}
-		if t := time.Since(m.End); active && t > 0 {
+		if t := time.Since(mount.End); active && t > 0 {
 			continue
 		}
 
-		for _, v := range set.Views() {
-			if v.Mount != m.Code {
+		for _, view := range set.Views() {
+			if view.Mount != mount.Code {
 				continue
 			}
-			if t := time.Since(v.End); active && t > 0 {
+			if t := time.Since(view.End); active && t > 0 {
 				continue
 			}
 			captions = append(captions, Caption{
-				Mount: v.Mount,
-				View:  v.Code,
-				Label: v.Label,
+				Mount: view.Mount,
+				View:  view.Code,
+				Label: view.Label,
 			})
 		}
 	}

--- a/cmd/camera-config/main.go
+++ b/cmd/camera-config/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/GeoNet/delta"
+)
+
+func main() {
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "Build a camera caption configuration from delta meta information\n")
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "Usage:\n")
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "  %s [options]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "Options:\n")
+		fmt.Fprintf(os.Stderr, "\n")
+		flag.PrintDefaults()
+	}
+
+	var verbose bool
+	flag.BoolVar(&verbose, "verbose", false, "make noise")
+
+	var active bool
+	flag.BoolVar(&active, "active", false, "only output active camera information")
+
+	var base string
+	flag.StringVar(&base, "base", "", "optional base for custom delta files")
+
+	var networks string
+	flag.StringVar(&networks, "networks", "", "comma separated list of networks, an empty value matches all networks")
+
+	var output string
+	flag.StringVar(&output, "output", "", "where to store json formatted output")
+
+	flag.Parse()
+
+	nets := make(map[string]interface{})
+	for _, n := range strings.Split(networks, ",") {
+		if s := strings.TrimSpace(strings.ToUpper(n)); s != "" {
+			nets[s] = true
+		}
+	}
+
+	set, err := delta.NewBase(base)
+	if err != nil {
+		log.Fatalf("unable to build delta set for %s: %v", base, err)
+	}
+
+	var captions []Caption
+
+	for _, m := range set.Mounts() {
+		if _, ok := nets[m.Network]; len(nets) > 0 && !ok {
+			continue
+		}
+		if t := time.Since(m.End); active && t > 0 {
+			continue
+		}
+
+		for _, v := range set.Views() {
+			if v.Mount != m.Code {
+				continue
+			}
+			if t := time.Since(v.End); active && t > 0 {
+				continue
+			}
+			captions = append(captions, Caption{
+				Mount: v.Mount,
+				View:  v.Code,
+				Label: v.Label,
+			})
+		}
+	}
+
+	switch {
+	case output != "":
+		if err := Captions(captions).EncodeFile(output); err != nil {
+			log.Fatal(err)
+		}
+	default:
+		if err := Captions(captions).Encode(os.Stdout); err != nil {
+			log.Fatal(err)
+		}
+	}
+}

--- a/cmd/volcam-config/README.md
+++ b/cmd/volcam-config/README.md
@@ -1,0 +1,20 @@
+# camera-config
+
+Provide configuration for labelling remote camera images.
+
+## output
+
+The output json file provides a lookup for each camera _view_ to allow a simple caption.
+
+Build a camera caption configuration from delta meta information
+
+## usage
+
+    ./volcam-config [options]
+
+## options
+
+    -base string
+        delta config files, will prefix camera and mount file names
+    -output string
+        output config file

--- a/cmd/volcam-config/main.go
+++ b/cmd/volcam-config/main.go
@@ -65,76 +65,77 @@ func main() {
 	}
 
 	var volcs []Volcam
-	for _, l := range set.Views() {
-		if time.Since(l.Span.End) > 0 {
+	for _, view := range set.Views() {
+		if time.Since(view.Span.End) > 0 {
 			continue
 		}
 
-		for _, m := range set.Mounts() {
-			if time.Since(m.Span.End) > 0 {
+		for _, mount := range set.Mounts() {
+			if time.Since(mount.Span.End) > 0 {
 				continue
 			}
-			if m.Code != l.Mount {
+			if mount.Code != view.Mount {
 				continue
 			}
 
-			for _, v := range set.InstalledCameras() {
-				if time.Since(v.Span.End) > 0 {
+			for _, camera := range set.InstalledCameras() {
+				if time.Since(camera.Span.End) > 0 {
 					continue
 				}
 
-				if v.Mount != m.Code {
+				if camera.Mount != mount.Code {
 					continue
 				}
 
-				if v.View != l.Code {
+				if camera.View != view.Code {
 					continue
 				}
 
 				targets := make(map[string]string)
-				for k, v := range keywords {
-					n, ok := titles[k]
+				for id, vals := range keywords {
+					target, ok := titles[id]
 					if !ok {
 						continue
 					}
-					for _, w := range v {
-						if strings.Contains(l.Label, w) {
-							targets[k] = n
+					for _, val := range vals {
+						if strings.Contains(view.Label, val) {
+							targets[id] = target
 						}
-						if strings.Contains(l.Description, w) {
-							targets[k] = n
+						if strings.Contains(view.Description, val) {
+							targets[id] = target
 						}
 					}
 				}
+
 				var volcanoes []Volcano
-				for k, w := range targets {
+				for id, title := range targets {
 					volcanoes = append(volcanoes, Volcano{
-						Id:    k,
-						Title: w,
+						Id:    id,
+						Title: title,
 					})
 				}
 
 				volcs = append(volcs, Volcam{
-					Id:        strings.Join(strings.FieldsFunc(strings.ToLower(l.Label), letters), ""),
-					Mount:     v.Mount,
-					View:      v.View,
-					Title:     l.Label,
-					Latitude:  m.Latitude,
-					Longitude: m.Longitude,
+					Id:        strings.Join(strings.FieldsFunc(strings.ToLower(view.Label), letters), ""),
+					Mount:     camera.Mount,
+					View:      camera.View,
+					Title:     view.Label,
+					Latitude:  mount.Latitude,
+					Longitude: mount.Longitude,
 					Datum: func() string {
-						if m.Datum == "WGS84" {
+						if mount.Datum == "WGS84" {
 							return "EPSG:4326"
 						}
-						return m.Datum
+						return mount.Datum
 					}(),
 					Height: func() float64 {
-						if m.Elevation == 9999 {
+						if mount.Elevation == 9999 {
 							return 0
 						}
-						return m.Elevation
+						return mount.Elevation
 					}(),
-					Azimuth:   v.Azimuth,
-					Ground:    v.Offset.Vertical,
+					Azimuth:   camera.Azimuth,
+					Ground:    camera.Offset.Vertical,
 					Volcanoes: volcanoes,
 				})
 			}

--- a/cmd/volcam-config/main.go
+++ b/cmd/volcam-config/main.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/GeoNet/delta"
+)
+
+// will form the id and title for each camera
+var titles = map[string]string{
+	"ngauruhoe":       "Ngauruhoe",
+	"whiteisland":     "White Island",
+	"ruapehu":         "Ruapehu",
+	"taranakiegmont":  "Taranaki/Egmont",
+	"kermadecislands": "Kermadec Islands",
+	"tongariro":       "Tongariro",
+}
+
+// will be used to find volcanoes from captions
+var keywords = map[string][]string{
+	"ngauruhoe":       {"Ngauruhoe"},
+	"whiteisland":     {"White Island"},
+	"ruapehu":         {"Ruapehu"},
+	"taranakiegmont":  {"Taranaki"},
+	"kermadecislands": {"Raoul", "Kermadec Islands"},
+	"tongariro":       {"Tongariro"},
+}
+
+var letters = func(c rune) bool {
+	return !unicode.IsLetter(c)
+}
+
+func main() {
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "Build a volcam configuration file\n")
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "Usage:\n")
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "  %s [options]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "General Options:\n")
+		fmt.Fprintf(os.Stderr, "\n")
+		flag.PrintDefaults()
+	}
+
+	var base string
+	flag.StringVar(&base, "base", "", "delta config files, will prefix camera and mount file names")
+
+	var output string
+	flag.StringVar(&output, "output", "", "output config file")
+
+	flag.Parse()
+
+	set, err := delta.NewBase(base)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var volcs []Volcam
+	for _, l := range set.Views() {
+		if time.Since(l.Span.End) > 0 {
+			continue
+		}
+
+		for _, m := range set.Mounts() {
+			if time.Since(m.Span.End) > 0 {
+				continue
+			}
+			if m.Code != l.Mount {
+				continue
+			}
+
+			for _, v := range set.InstalledCameras() {
+				if time.Since(v.Span.End) > 0 {
+					continue
+				}
+
+				if v.Mount != m.Code {
+					continue
+				}
+
+				if v.View != l.Code {
+					continue
+				}
+
+				targets := make(map[string]string)
+				for k, v := range keywords {
+					n, ok := titles[k]
+					if !ok {
+						continue
+					}
+					for _, w := range v {
+						if strings.Contains(l.Label, w) {
+							targets[k] = n
+						}
+						if strings.Contains(l.Description, w) {
+							targets[k] = n
+						}
+					}
+				}
+				var volcanoes []Volcano
+				for k, w := range targets {
+					volcanoes = append(volcanoes, Volcano{
+						Id:    k,
+						Title: w,
+					})
+				}
+
+				volcs = append(volcs, Volcam{
+					Id:        strings.Join(strings.FieldsFunc(strings.ToLower(l.Label), letters), ""),
+					Mount:     v.Mount,
+					View:      v.View,
+					Title:     l.Label,
+					Latitude:  m.Latitude,
+					Longitude: m.Longitude,
+					Datum: func() string {
+						if m.Datum == "WGS84" {
+							return "EPSG:4326"
+						}
+						return m.Datum
+					}(),
+					Height: func() float64 {
+						if m.Elevation == 9999 {
+							return 0
+						}
+						return m.Elevation
+					}(),
+					Azimuth:   v.Azimuth,
+					Ground:    v.Offset.Vertical,
+					Volcanoes: volcanoes,
+				})
+			}
+		}
+	}
+
+	switch {
+	case output != "":
+		if err := Volcams(volcs).EncodeFile(output); err != nil {
+			log.Fatal(err)
+		}
+	default:
+		if err := Volcams(volcs).Encode(os.Stdout); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+}

--- a/cmd/volcam-config/volcam.go
+++ b/cmd/volcam-config/volcam.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"sort"
+)
+
+type Volcano struct {
+	Id    string `json:"id"`
+	Title string `json:"title"`
+}
+
+type Volcam struct {
+	Id        string    `json:"id"`
+	Mount     string    `json:"mount"`
+	View      string    `json:"view"`
+	Title     string    `json:"title"`
+	Latitude  float64   `json:"latitude"`
+	Longitude float64   `json:"longitude"`
+	Datum     string    `json:"datum"`
+	Azimuth   float64   `json:"azimuth"`
+	Height    float64   `json:"height"`
+	Ground    float64   `json:"ground"`
+	Volcanoes []Volcano `json:"volcanoes"`
+}
+
+type Volcams []Volcam
+
+func (v Volcams) EncodeFile(path string) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return v.Encode(file)
+}
+
+func (v Volcams) Encode(wr io.Writer) error {
+	for _, n := range v {
+		sort.Slice(n.Volcanoes, func(i, j int) bool {
+			return n.Volcanoes[i].Id < n.Volcanoes[j].Id
+		})
+	}
+	sort.Slice(v, func(i, j int) bool {
+		switch {
+		case v[i].Mount < v[j].Mount:
+			return true
+		case v[i].Mount > v[j].Mount:
+			return false
+		case v[i].View < v[j].View:
+			return true
+		default:
+			return false
+		}
+	})
+
+	if err := json.NewEncoder(wr).Encode(v); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/volcam-config/volcam_test.go
+++ b/cmd/volcam-config/volcam_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestVolcam(t *testing.T) {
+
+	const res = `[{"id":"raoulisland","mount":"RIMK","view":"01","title":"Raoul Island","latitude":-177.90724,"longitude":-29.267332,"datum":"EPSG:4326","azimuth":270,"height":490,"ground":0,"volcanoes":[{"id":"kermadecislands","title":"Kermadec Islands"}]}]`
+
+	volcs := []Volcam{
+		{
+			Id:        "raoulisland",
+			Mount:     "RIMK",
+			View:      "01",
+			Title:     "Raoul Island",
+			Latitude:  -177.90724,
+			Longitude: -29.267332,
+			Datum:     "EPSG:4326",
+			Azimuth:   270,
+			Height:    490,
+			Ground:    0,
+			Volcanoes: []Volcano{
+				{
+					Id:    "kermadecislands",
+					Title: "Kermadec Islands",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+
+	if err := Volcams(volcs).Encode(&buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if s := strings.TrimSpace(buf.String()); s != res {
+		t.Errorf("invalid volcam encoding: %s", cmp.Diff(s, res))
+	}
+
+}


### PR DESCRIPTION
This PR adds two config tools for camera images.

The first is used simply to caption an image if needed, it uses the mounts and views tables.

The second is related to volcams, so adds in some extra detail regarding actual volcano targets.