### PR TITLE
add citations poc

### DIFF
--- a/references/README.md
+++ b/references/README.md
@@ -16,9 +16,9 @@ All fields, other than Key, are optional and can be left blank.
 | Field | Description |
 | --- | --- |
 | _Key_ | The citation key used where appropriate
-| _Author_ | Reference author or authors in a natural format, with quotes needed as required
+| _Author_ | Reference author or authors in a natural format
 | _Year_ | Reference year, if appropriate
-| _Title_ | The title of the reference in a natural format, with quotes as required
+| _Title_ | The title of the reference in a natural format
 | _Published_ | Where reference was published if appropriate and known
 | _Volume_ | Series information for published reference if relavent
 | _DOI_ | The reference DOI (_Digital Object Identifier_) if known
@@ -27,4 +27,5 @@ All fields, other than Key, are optional and can be left blank.
 
 ### NOTES ###
 
-Dates should be given as in _ISO 8601_ (i.e. `2016-09-18T02:24:26Z`), future dates should be given in the form: `9999-01-01T00:00:00Z`.
+- Dates should be given as in _ISO 8601_ (i.e. `2016-09-18T02:24:26Z`)
+- When entering a field value which has a comma, the field should be enclosed within double quotes. (e.g. "Last, F., Name ...")

--- a/references/README.md
+++ b/references/README.md
@@ -1,0 +1,30 @@
+## REFERENCES ##
+
+_Reference citations and external source information._
+
+### FILES ###
+
+Reference information for the GeoNet sensor networks.
+ 
+* `citations.csv` - Reference citations
+
+#### _CITATIONS_ ####
+
+A list of _reference_ citations to published or otherwise information.
+All fields, other than Key, are optional and can be left blank.
+
+| Field | Description |
+| --- | --- |
+| _Key_ | The citation key used where appropriate
+| _Author_ | Reference author or authors in a natural format, with quotes needed as required
+| _Year_ | Reference year, if appropriate
+| _Title_ | The title of the reference in a natural format, with quotes as required
+| _Published_ | Where reference was published if appropriate and known
+| _Volume_ | Series information for published reference if relavent
+| _DOI_ | The reference DOI (_Digital Object Identifier_) if known
+| _Link_ | A URL link to the reference if available
+| _Retrieved_ | The last time a valid URL was retrieved
+
+### NOTES ###
+
+Dates should be given as in _ISO 8601_ (i.e. `2016-09-18T02:24:26Z`), future dates should be given in the form: `9999-01-01T00:00:00Z`.

--- a/references/README.md
+++ b/references/README.md
@@ -25,7 +25,12 @@ All fields, other than Key, are optional and can be left blank.
 | _Link_ | A URL link to the reference if available
 | _Retrieved_ | The last time a valid URL was retrieved
 
+#### EXAMPLE #####
+
+    Key,Author,Year,Title,Published,Volume,DOI,Link,Retrieved
+    Fry2020,"Fry, B., S.-J. McCurrach, K. Gledhill, W. Power, M. Williams, M. Angove, D. Arcas, and C. Moore",2020,Sensor network warns of stealth tsunamis,Eos,101,https://doi.org/10.1029/2020EO144274,,
+
 ### NOTES ###
 
 - Dates should be given as in _ISO 8601_ (i.e. `2016-09-18T02:24:26Z`)
-- When entering a field value which has a comma, the field should be enclosed within double quotes. (e.g. "Last, F., Name ...")
+- Any field entries with commas should be enclosed within double quotes. (e.g. "Last, F., Name ...")

--- a/references/citations.csv
+++ b/references/citations.csv
@@ -1,0 +1,2 @@
+Key,Author,Year,Title,Published,Volume,DOI,Link,Retrieved
+Fry2020,"Fry, B., S.-J. McCurrach, K. Gledhill, W. Power, M. Williams, M. Angove, D. Arcas, and C. Moore",2020,Sensor network warns of stealth tsunamis,Eos,101,https://doi.org/10.1029/2020EO144274,,


### PR DESCRIPTION
The work on polarities has indicated that there will be a need for some mechanism for citing references or other associated external information.

To this end, I've made an example "citations.csv" formatted table. I've placed it under the `references` folder for want of anything else.  I haven't used the word "reference" in the names as this clashes with the use of this term for defining where something is, i.e. with reference to this point.

I've also started looking at adding a DOI mechanism. This may be expanded as needed or appropriate to other tables. especially the network table.

This mechanism should also be able to present "web" type links so, other than the key, all fields should be optional.

I haven't defined a "key" style, but the constraints are that it be unique, and the table will be sorted based on this value. I was thinking of a short style, or "<author><year><series>" where author can be a lowercase or abbreviated name, the year is optional and the series (e.g. "a", "b", "c") may be able to distinguish multiple publications in a given year.

This is aimed as a starting point of discussion. the code has been written as a proof of concept but not included.
