### PR TITLE
add polarity poc

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -18,6 +18,7 @@ Meta information for the GeoNet equipment network.
 * `dataloggers.csv` - Recording dataloggers
 * `connections.csv` - Datalogger and sensor connection details
 * `streams.csv` - Datalogger and recorder sampling configurations
+* `polarities.csv` - site specific polarity settings which indicate when a site may have reversed polarity, or otherwise
 * `gains.csv` - site specific settings applied to individual datalogger and sensor that may impact overall sensitivities
 * `calibrations.csv` - Individual sensor sensitivity values that can be used rather than default values.
 * `components.csv` - Individual sensor elements including measurement position and responses.
@@ -226,6 +227,47 @@ A list of _datalogger_ sampling configurations for a given _station_ and recordi
 The band and source codes are representitives of the FDSN channel naming convention as found at:
 
 [FDSN Source Identifiers: Channel codes](http://docs.fdsn.org/projects/source-identifiers/en/v1.0/channel-codes.html)
+
+#### _POLARITIES_ ####
+
+Site specific times when the recorded values may have a reversed, or otherwise, polarity.
+This is often difficult to track with the known instrument responses and installation details as it can
+often be caused by in-field wiring or cabling changes from the expected standard.
+
+There is also the possibility that there may be conflicting information or studies, where this is
+the case the _Primary_ field can be used to indicate which one should be used for downstream processing.
+
+To reduce the number valid _Method_ entries these are defined as a set of "known" values, and an "unknown" one.
+Where possibly the code should be updated to add any standard polarity detection methods, there is also
+room to provide a reference citation for any associated studies.
+
+
+| Field | Description | Units |
+| --- | --- | --- |
+| _Station_ | Recording _Station_|
+| _Location_ | Recording location _Site_|
+| _Sublocation_ | Recording location _Sublocation_|
+| _Subsource_ | Recording location _Subsource_|
+| _Primary_ | Whether the entry takes precedence| _"yes"_, _"no"_, or blank.
+| _Reversed_ | Whether the stream in the time window should be considered reversed or not| _"yes"_ or _"no"_
+| _Method_ | How this information was obtained| _"study"_, _"compass"_, or _"unknown"_
+| _Citation_ | A reference citation for the method if appropriate| _"key"_
+| _Start_ | Time window start time|
+| _Stop_ | Time window stop time|
+
+Notes:
+
+- For the _Subsource_, this can either be individual entries (e.g., "Z", "N"), or multiple entries ("ZNE"), or it can be empty, which will be interpreted as all subsource values.
+(The subsource is the last character in the standard SEED channel naming convention, e.g. EHZ).
+
+- If a citation is given the actual reference information should be given in the _citations.csv_ file.
+
+- An empty, or blank, _Method_ is treated as _unknown_.
+
+Example:
+
+    Station,Location,Sublocation,Subsource,Primary,Reversed,Method,Citation,Start Date,End Date
+    WEL,10,,Z,,true,compass,,2022-07-28T01:59:00Z,9999-01-01T00:00:00Z
 
 #### _GAINS_ ####
  

--- a/meta/testdata/polarities.csv
+++ b/meta/testdata/polarities.csv
@@ -1,0 +1,4 @@
+Station,Location,Sublocation,Subsource,Primary,Reversed,Method,Citation,Start Date,End Date
+WEL,10,,Z,,true,compass,,2022-07-28T01:59:00Z,9999-01-01T00:00:00Z
+WEL,11,,,,true,,,2022-07-28T01:59:00Z,2023-01-01T00:00:00Z
+WEL,11,,,,false,unknown,,2023-01-01T00:00:00Z,9999-01-01T00:00:00Z


### PR DESCRIPTION
This is following on from instrument response work, and trying to avoid hidden logic in the instrument meta data generation.

This table is basically attempting to identify times when a recorded signal may be reversed from what is expected. How this information is gleaned is left as a reference where not straight forward.

I haven't added the full range of methods yet. I haven't decided whether to (a) build this into the code directly, or (b) create a table (perhaps in the references section) which can define methods of doing things. This can be extended to other tables or processes.

Just wanting feedback, on whether this covers the bases, whether there's something missing or otherwise. The code is there to implement this (as a proof of concept) but it doesn't need to be part of this initial documentation PR.

Views on the "method" table would be useful.