### PR TITLE
add doi decoding code

### DIFF
--- a/meta/doi.go
+++ b/meta/doi.go
@@ -1,0 +1,57 @@
+package meta
+
+import (
+	"bytes"
+	"errors"
+	"regexp"
+)
+
+const doiMatch = `^((?:https?://)?(?:[^/\s]+\.)*doi\.org/10|10|DOI:10)\.([^\s]+)+$`
+
+var doiRe = regexp.MustCompile(doiMatch)
+
+var ErrInvalidDOI = errors.New("invalid DOI reference")
+
+type Doi string
+
+// NewDoi returns a Doi value from a string after checking.
+func NewDoi(doi string) (Doi, error) {
+	var d Doi
+	if err := d.UnmarshalText([]byte(doi)); err != nil {
+		return "", err
+	}
+	return d, nil
+}
+
+// MustDoi returns a Doi value, or panics. This is useful for testing with known values.
+func MustDoi(doi string) Doi {
+	d, err := NewDoi(doi)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}
+
+func (d Doi) String() string {
+	return string(d)
+}
+
+func (d Doi) Equal(doi Doi) bool {
+	return bytes.Equal([]byte(d), []byte(doi))
+}
+
+// UnmarshalText implements the TextUnmarshaler interface.
+func (d *Doi) UnmarshalText(data []byte) error {
+	if !doiRe.Match(data) {
+		return ErrInvalidDOI
+	}
+
+	*d = Doi(data)
+
+	return nil
+}
+
+// MarshalText implements the TextMarshaler interface.
+func (d Doi) MarshalText() ([]byte, error) {
+	return []byte(d), nil
+}

--- a/meta/doi_test.go
+++ b/meta/doi_test.go
@@ -1,0 +1,50 @@
+package meta
+
+import (
+	"testing"
+)
+
+func TestDOI(t *testing.T) {
+
+	good := []string{
+		"http://doi.org/10.21420/8TCZ-TV02",
+		"http://doi.org/10.1029/2020EO144274",
+		"https://doi.org/10.21420/8TCZ-TV02",
+		"https://doi.org/10.1029/2020EO144274",
+		"doi.org/10.21420/8TCZ-TV02",
+		"doi.org/10.1029/2020EO144274",
+		"10.21420/8TCZ-TV02",
+		"10.1029/2020EO144274",
+		"DOI:10.21420/8TCZ-TV02",
+		"DOI:10.1029/2020EO144274",
+	}
+
+	for _, v := range good {
+		d, err := NewDoi(v)
+		if err != nil {
+			t.Errorf("unable to pass doi %s: %v", v, err)
+		}
+		if q := d.String(); q != v {
+			t.Errorf("unexpected doi check, expected %q, got %q", v, q)
+
+		}
+	}
+
+	bad := []string{
+		"",
+		"//doi.org/10.21420/8TCZ-TV02",
+		"http://xdoi.org/10.1029/2020EO144274",
+		"xdoi.org/10.21420/8TCZ-TV02",
+		"doi.org /10.1029/2020EO144274",
+		"10.21420/ 8TCZ-TV02",
+		"1029/2020EO144274",
+		"8TCZ-TV02",
+	}
+
+	for _, v := range bad {
+		if _, err := NewDoi(v); err == nil {
+			t.Errorf("able to pass bad doi %s", v)
+		}
+	}
+
+}


### PR DESCRIPTION
This PR adds a small function which can validate DOI entries, it is currently intended for the references tables, but could also be used if DOI values are added into the main tables at some point. 