### PR TITLE
add citations code and add pages column

### DIFF
--- a/meta/citation.go
+++ b/meta/citation.go
@@ -1,0 +1,136 @@
+package meta
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	citationKey int = iota
+	citationAuthor
+	citationYear
+	citationTitle
+	citationPublished
+	citationVolume
+	citationPages
+	citationDoi
+	citationLink
+	citationRetrieved
+	citationLast
+)
+
+type Citation struct {
+	Key       string
+	Author    string
+	Year      int
+	Title     string
+	Published string
+	Volume    string
+	Pages     string
+	Doi       Doi
+	Link      string
+	Retrieved time.Time
+
+	year      string
+	doi       string
+	retrieved string
+}
+
+type CitationList []Citation
+
+func (c CitationList) Len() int           { return len(c) }
+func (c CitationList) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
+func (c CitationList) Less(i, j int) bool { return c[i].Key < c[j].Key }
+
+func (c CitationList) encode() [][]string {
+	data := [][]string{{"Key", "Author", "Year", "Title", "Published", "Volume", "Pages", "DOI", "Link", "Retrieved"}}
+	for _, v := range c {
+		data = append(data, []string{
+			v.Key,
+			v.Author,
+			v.year,
+			v.Title,
+			v.Published,
+			v.Volume,
+			v.Pages,
+			v.doi,
+			v.Link,
+			v.retrieved,
+		})
+	}
+	return data
+}
+
+func (c *CitationList) decode(data [][]string) error {
+	var citations []Citation
+
+	if !(len(data) > 1) {
+		return nil
+	}
+	for _, d := range data[1:] {
+		if len(d) != citationLast {
+			return fmt.Errorf("incorrect number of citation fields")
+		}
+
+		var year int
+		if s := strings.TrimSpace(d[citationYear]); s != "" {
+			i, err := strconv.Atoi(s)
+			if err != nil {
+				return err
+			}
+			year = i
+		}
+
+		var retrieved time.Time
+		if s := strings.TrimSpace(d[citationRetrieved]); s != "" {
+			t, err := time.Parse(DateTimeFormat, s)
+			if err != nil {
+				return err
+			}
+			retrieved = t
+		}
+
+		var doi Doi
+		if s := strings.TrimSpace(d[citationDoi]); s != "" {
+			if err := doi.UnmarshalText([]byte(s)); err != nil {
+				return err
+			}
+		}
+
+		citations = append(citations, Citation{
+			Key:       strings.TrimSpace(d[citationKey]),
+			Author:    strings.TrimSpace(d[citationAuthor]),
+			Year:      year,
+			Title:     strings.TrimSpace(d[citationTitle]),
+			Published: strings.TrimSpace(d[citationPublished]),
+			Volume:    strings.TrimSpace(d[citationVolume]),
+			Pages:     strings.TrimSpace(d[citationPages]),
+			Doi:       doi,
+			Link:      strings.TrimSpace(d[citationLink]),
+			Retrieved: retrieved,
+
+			year:      strings.TrimSpace(d[citationYear]),
+			doi:       strings.TrimSpace(d[citationDoi]),
+			retrieved: strings.TrimSpace(d[citationRetrieved]),
+		})
+	}
+
+	*c = CitationList(citations)
+
+	return nil
+}
+
+func LoadCitations(path string) ([]Citation, error) {
+	var c []Citation
+
+	if err := LoadList(path, (*CitationList)(&c)); err != nil {
+		return nil, err
+	}
+
+	sort.Sort(CitationList(c))
+
+	return c, nil
+}

--- a/meta/generate/main.go
+++ b/meta/generate/main.go
@@ -14,6 +14,7 @@ func main() {
 			"assets":              {"Asset"},
 			"calibrations":        {"Calibration"},
 			"connections":         {"Connection"},
+			"citations":           {"Citation"},
 			"constituents":        {"Constituent"},
 			"deployedDataloggers": {"DeployedDatalogger"},
 			"deployedReceivers":   {"DeployedReceiver"},

--- a/meta/list_test.go
+++ b/meta/list_test.go
@@ -1186,6 +1186,41 @@ func TestList(t *testing.T) {
 				},
 			},
 		},
+		{
+			"testdata/citations.csv",
+			&CitationList{
+				Citation{
+					Key:       "fry2020",
+					Author:    "Fry, B., S.-J. McCurrach, K. Gledhill, W. Power, M. Williams, M. Angove, D. Arcas, and C. Moore",
+					Title:     "Sensor network warns of stealth tsunamis",
+					Published: "Eos",
+					Volume:    "101",
+					Doi:       MustDoi("https://doi.org/10.1029/2020EO144274"),
+
+					doi:  "https://doi.org/10.1029/2020EO144274",
+					year: "2020",
+				},
+				Citation{
+					Key:       "key2002",
+					Author:    "A Writer",
+					Title:     "A test",
+					Year:      2002,
+					Published: "Journal of test",
+					Volume:    "1",
+					Pages:     "1-2",
+					Doi:       MustDoi("https://doi.org/10.21420/8TCZ-TV02"),
+					Link:      "http://example.com",
+					Retrieved: time.Date(2021, time.January, 12, 0, 0, 0, 0, time.UTC),
+
+					doi:       "https://doi.org/10.21420/8TCZ-TV02",
+					year:      "2002",
+					retrieved: "2021-01-12T00:00:00Z",
+				},
+				Citation{
+					Key: "unknown",
+				},
+			},
+		},
 	}
 
 	for _, tt := range listtests {

--- a/meta/set.go
+++ b/meta/set.go
@@ -44,6 +44,8 @@ const (
 	ChannelsFile   = "install/channels.csv"
 	ComponentsFile = "install/components.csv"
 	CodenamesFile  = "install/codenames.csv"
+
+	CitationsFile = "references/citations.csv"
 )
 
 // SetPathMap is used to manipulate the filepath inside the Set.
@@ -86,6 +88,7 @@ type Set struct {
 	gauges       GaugeList
 	visibilities VisibilityList
 	placenames   PlacenameList
+	citations    CitationList
 }
 
 func (s *Set) files() map[string]List {
@@ -121,6 +124,7 @@ func (s *Set) files() map[string]List {
 		GaugesFile:       &s.gauges,
 		VisibilityFile:   &s.visibilities,
 		PlacenamesFile:   &s.placenames,
+		CitationsFile:    &s.citations,
 	}
 }
 

--- a/meta/set_auto.go
+++ b/meta/set_auto.go
@@ -24,6 +24,13 @@ func (s Set) Calibrations() []Calibration {
 	return calibrations
 }
 
+// Citations is a helper function to return a slice copy of Citation values.
+func (s Set) Citations() []Citation {
+	citations := make([]Citation, len(s.citations))
+	copy(citations, s.citations)
+	return citations
+}
+
 // Connections is a helper function to return a slice copy of Connection values.
 func (s Set) Connections() []Connection {
 	connections := make([]Connection, len(s.connections))

--- a/meta/testdata/citations.csv
+++ b/meta/testdata/citations.csv
@@ -1,0 +1,4 @@
+Key,Author,Year,Title,Published,Volume,Pages,DOI,Link,Retrieved
+fry2020,"Fry, B., S.-J. McCurrach, K. Gledhill, W. Power, M. Williams, M. Angove, D. Arcas, and C. Moore",2020,Sensor network warns of stealth tsunamis,Eos,101,,https://doi.org/10.1029/2020EO144274,,
+key2002,A Writer,2002,A test,Journal of test,1,1-2,https://doi.org/10.21420/8TCZ-TV02,http://example.com,2021-01-12T00:00:00Z
+unknown,,,,,,,,,

--- a/references/README.md
+++ b/references/README.md
@@ -21,14 +21,15 @@ All fields, other than Key, are optional and can be left blank.
 | _Title_ | The title of the reference in a natural format
 | _Published_ | Where reference was published if appropriate and known
 | _Volume_ | Series information for published reference if relavent
+| _Pages_ | Optional page information for the published reference
 | _DOI_ | The reference DOI (_Digital Object Identifier_) if known
 | _Link_ | A URL link to the reference if available
 | _Retrieved_ | The last time a valid URL was retrieved
 
 #### EXAMPLE #####
 
-    Key,Author,Year,Title,Published,Volume,DOI,Link,Retrieved
-    Fry2020,"Fry, B., S.-J. McCurrach, K. Gledhill, W. Power, M. Williams, M. Angove, D. Arcas, and C. Moore",2020,Sensor network warns of stealth tsunamis,Eos,101,https://doi.org/10.1029/2020EO144274,,
+    Key,Author,Year,Title,Published,Volume,Pages,DOI,Link,Retrieved
+    Fry2020,"Fry, B., S.-J. McCurrach, K. Gledhill, W. Power, M. Williams, M. Angove, D. Arcas, and C. Moore",2020,Sensor network warns of stealth tsunamis,Eos,101,,https://doi.org/10.1029/2020EO144274,,
 
 ### NOTES ###
 

--- a/references/citations.csv
+++ b/references/citations.csv
@@ -1,2 +1,3 @@
-Key,Author,Year,Title,Published,Volume,DOI,Link,Retrieved
-Fry2020,"Fry, B., S.-J. McCurrach, K. Gledhill, W. Power, M. Williams, M. Angove, D. Arcas, and C. Moore",2020,Sensor network warns of stealth tsunamis,Eos,101,https://doi.org/10.1029/2020EO144274,,
+Key,Author,Year,Title,Published,Volume,Pages,DOI,Link,Retrieved
+Fry2020,"Fry, B., S.-J. McCurrach, K. Gledhill, W. Power, M. Williams, M. Angove, D. Arcas, and C. Moore",2020,Sensor network warns of stealth tsunamis,Eos,101,,https://doi.org/10.1029/2020EO144274,,
+Kaiser2017,"Kaiser, A., Van Houtte, C., Perrin, N., Wotherspoon, L., and G. McVerry",2017,Site characterisation of GeoNet stations for the New Zealand Strong Motion Database,Bulletin of the New Zealand Society for Earthquake Engineering,50(1),39–49,https://doi.org/10.5459/bnzsee.50.1.39-49,,

--- a/tests/citations_test.go
+++ b/tests/citations_test.go
@@ -1,0 +1,34 @@
+package delta_test
+
+import (
+	"testing"
+
+	"github.com/GeoNet/delta"
+	"github.com/GeoNet/delta/meta"
+)
+
+var citationChecks = map[string]func(*meta.Set) func(t *testing.T){
+	"check for duplicate citations": func(set *meta.Set) func(t *testing.T) {
+		return func(t *testing.T) {
+			citations := make(map[string]interface{})
+			for _, c := range set.Citations() {
+				if _, ok := citations[c.Key]; ok {
+					t.Errorf("citation %s is duplicated", c.Key)
+				}
+				citations[c.Key] = true
+			}
+		}
+	},
+}
+
+func TestCitations(t *testing.T) {
+
+	set, err := delta.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for k, v := range citationChecks {
+		t.Run(k, v(set))
+	}
+}

--- a/tests/consistency_test.go
+++ b/tests/consistency_test.go
@@ -70,6 +70,7 @@ func TestConsistency(t *testing.T) {
 		"constituents": {f: "../environment/constituents.csv", l: &meta.ConstituentList{}},
 		"features":     {f: "../environment/features.csv", l: &meta.FeatureList{}},
 		"visibility":   {f: "../environment/visibility.csv", l: &meta.VisibilityList{}},
+		"citations":    {f: "../references/citations.csv", l: &meta.CitationList{}},
 	}
 
 	for f, v := range files {


### PR DESCRIPTION
This PR adds the code to read and write citation files.

I've added a "Pages" column mainly as it appears this is a source of an extra comma in the Volume which would then require quoting. To avoid this any page information will naturally flow with a comma following the Volume details.