### PR TITLE
rename calibration component to number

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -256,7 +256,7 @@ For the component, sensitivity, and frequency either a value can be given direct
 | _Make_ | Sensor make
 | _Model_ | Sensor model name
 | _Serial_ | Sensor serial number
-| _Component_ | The sensor component, as defined in the response configuration or elsewhere, which overrides the default values, a blank value is interpreted as the first sensor component, or __"pin"__ zero.
+| _Number_ | The sensor component or datalogger digitiser channel, as defined in the response configuration or elsewhere, which overrides the default values, a blank value is interpreted as the first sensor component, or __"pin"__ zero.
 | _Scale Factor_ | Sensitivity, or scale factor, that the input signal is generally multiplied by to convert to Volts, or for polynomial responses the value used to convert Volts into the signal units. A blank value is expected to be read as __1.0__, an explicit value of zero is required to be entered if intended.
 | _Scale Bias_ | An offset, or scale bias, for polynomial responses that is added to the converted volts to give the signal values. If this field is blank it should be assumed that the value is __0.0__.
 | _Frequency_ | Frequency at which the calibration value is correct for if appropriate.

--- a/install/calibrations.csv
+++ b/install/calibrations.csv
@@ -1,1 +1,1 @@
-Make,Model,Serial,Component,Scale Factor,Scale Bias,Frequency,Start Date,End Date
+Make,Model,Serial,Number,Scale Factor,Scale Bias,Frequency,Start Date,End Date

--- a/internal/metadb/calibrations.go
+++ b/internal/metadb/calibrations.go
@@ -44,7 +44,7 @@ func (m *MetaDB) Calibration(model, serial string, comp int, at time.Time) (*met
 		if g.Serial != serial {
 			continue
 		}
-		if g.Component != comp {
+		if g.Number != comp {
 			continue
 		}
 		if g.Start.After(at) {

--- a/meta/calibration.go
+++ b/meta/calibration.go
@@ -14,7 +14,7 @@ const (
 	calibrationMake = iota
 	calibrationModel
 	calibrationSerial
-	calibrationComponent
+	calibrationNumber
 	calibrationScaleFactor
 	calibrationScaleBias
 	calibrationFrequency
@@ -28,21 +28,20 @@ const (
 type Calibration struct {
 	Install
 
-	component string
-	factor    string
-	bias      string
-	frequency string
-
 	ScaleFactor float64
 	ScaleBias   float64
 	Frequency   float64
+	Number      int
 
-	Component int
+	factor    string
+	bias      string
+	frequency string
+	number    string
 }
 
 // Id returns a unique string which can be used for sorting or checking.
 func (c Calibration) Id() string {
-	return strings.Join([]string{c.Make, c.Model, c.Serial, strconv.Itoa(c.Component)}, ":")
+	return strings.Join([]string{c.Make, c.Model, c.Serial, strconv.Itoa(c.Number)}, ":")
 }
 
 // Less returns whether one Calibration sorts before another.
@@ -52,7 +51,7 @@ func (s Calibration) Less(calibration Calibration) bool {
 		return true
 	case calibration.Install.Less(s.Install):
 		return false
-	case s.Component < calibration.Component:
+	case s.Number < calibration.Number:
 		return true
 	default:
 		return false
@@ -71,7 +70,7 @@ func (c CalibrationList) encode() [][]string {
 		"Make",
 		"Model",
 		"Serial",
-		"Component",
+		"Number",
 		"Scale Factor",
 		"Scale Bias",
 		"Frequency",
@@ -84,7 +83,7 @@ func (c CalibrationList) encode() [][]string {
 			strings.TrimSpace(v.Make),
 			strings.TrimSpace(v.Model),
 			strings.TrimSpace(v.Serial),
-			strconv.Itoa(v.Component),
+			strconv.Itoa(v.Number),
 			strings.TrimSpace(v.factor),
 			strings.TrimSpace(v.bias),
 			strings.TrimSpace(v.frequency),
@@ -136,7 +135,7 @@ func (c *CalibrationList) decode(data [][]string) error {
 				return err
 			}
 
-			comp, err := c.toInt(d[calibrationComponent], 0)
+			number, err := c.toInt(d[calibrationNumber], 0)
 			if err != nil {
 				return err
 			}
@@ -163,13 +162,13 @@ func (c *CalibrationList) decode(data [][]string) error {
 						End:   end,
 					},
 				},
-				Component: comp,
+				Number: number,
 
 				ScaleFactor: factor,
 				ScaleBias:   bias,
 				Frequency:   freq,
 
-				component: strings.TrimSpace(d[calibrationComponent]),
+				number:    strings.TrimSpace(d[calibrationNumber]),
 				factor:    strings.TrimSpace(d[calibrationScaleFactor]),
 				bias:      strings.TrimSpace(d[calibrationScaleBias]),
 				frequency: strings.TrimSpace(d[calibrationFrequency]),

--- a/meta/list_test.go
+++ b/meta/list_test.go
@@ -1046,9 +1046,9 @@ func TestList(t *testing.T) {
 					ScaleFactor: 2000.169 / 2.0,
 					ScaleBias:   1.0,
 					Frequency:   10.0,
-					Component:   0,
+					Number:      0,
 
-					component: "0",
+					number:    "0",
 					factor:    "2000.169/2.0",
 					bias:      "1.0",
 					frequency: "10.0",

--- a/meta/testdata/calibrations.csv
+++ b/meta/testdata/calibrations.csv
@@ -1,2 +1,2 @@
-Make,Model,Serial,Component,Scale Factor,Scale Bias,Frequency,Start Date,End Date
+Make,Model,Serial,Number,Scale Factor,Scale Bias,Frequency,Start Date,End Date
 Acme,ACME01,257,0,2000.169/2.0,1.0,10.0,2021-07-01T00:00:00Z,9999-01-01T00:00:00Z

--- a/tests/calibrations_test.go
+++ b/tests/calibrations_test.go
@@ -32,8 +32,8 @@ var testCalibrations = map[string]func([]meta.Calibration) func(t *testing.T){
 							continue
 						}
 
-						t.Errorf("calibration %s/%s has component \"%d\" overlap between %s and %s",
-							v[i].Model, v[i].Serial, v[i].Component,
+						t.Errorf("calibration %s/%s has number \"%d\" overlap between %s and %s",
+							v[i].Model, v[i].Serial, v[i].Number,
 							v[i].Start.Format(meta.DateTimeFormat),
 							v[i].End.Format(meta.DateTimeFormat))
 					}


### PR DESCRIPTION
In line with other changes to channels and components, this PR updates the `calibration` table to use `Number` rather than `component`. The main reason for this is that a calibration can be added for a datalogger as well as a sensor, in which case a datalogger component has no real meaning. 