### PR TITLE
add channel and component to set

### DIFF
--- a/meta/generate/main.go
+++ b/meta/generate/main.go
@@ -40,6 +40,8 @@ func main() {
 			"streams":             {"Stream"},
 			"views":               {"View"},
 			"visibilities":        {"Visibility"},
+			"channels":            {"Channel"},
+			"components":          {"Component"},
 		},
 		Lookup: map[string]struct {
 			Key    string

--- a/meta/set.go
+++ b/meta/set.go
@@ -77,6 +77,9 @@ type Set struct {
 	installedMetSensors InstalledMetSensorList
 	installedRadomes    InstalledRadomeList
 
+	channels   ChannelList
+	components ComponentList
+
 	installedSensors   InstalledSensorList
 	installedRecorders InstalledRecorderList
 	deployedReceivers  DeployedReceiverList
@@ -118,6 +121,9 @@ func (s *Set) files() map[string]List {
 		SensorsFile:      &s.installedSensors,
 		SessionsFile:     &s.sessions,
 		StreamsFile:      &s.streams,
+
+		ChannelsFile:   &s.channels,
+		ComponentsFile: &s.components,
 
 		ConstituentsFile: &s.constituents,
 		FeaturesFile:     &s.features,

--- a/meta/set_auto.go
+++ b/meta/set_auto.go
@@ -24,11 +24,25 @@ func (s Set) Calibrations() []Calibration {
 	return calibrations
 }
 
+// Channels is a helper function to return a slice copy of Channel values.
+func (s Set) Channels() []Channel {
+	channels := make([]Channel, len(s.channels))
+	copy(channels, s.channels)
+	return channels
+}
+
 // Citations is a helper function to return a slice copy of Citation values.
 func (s Set) Citations() []Citation {
 	citations := make([]Citation, len(s.citations))
 	copy(citations, s.citations)
 	return citations
+}
+
+// Components is a helper function to return a slice copy of Component values.
+func (s Set) Components() []Component {
+	components := make([]Component, len(s.components))
+	copy(components, s.components)
+	return components
 }
 
 // Connections is a helper function to return a slice copy of Connection values.


### PR DESCRIPTION
This PR adds the new channel and component tables to the `Set` struct and updates the auto generated code to match.