### PR TITLE
Nanometrics Trillium Horizon TH120-2 response added

### DIFF
--- a/resp/auto.go
+++ b/resp/auto.go
@@ -699,6 +699,14 @@ var SensorModels map[string]SensorModel = map[string]SensorModel{
 		Vendor:       "",
 		Components:   []SensorComponent{{Azimuth: 0, Dip: -90}, {Azimuth: 0, Dip: 0}, {Azimuth: 90, Dip: 0}},
 	},
+	"Trillium Horizon TH120-2": {
+		Name:         "Trillium Horizon TH120-2",
+		Type:         "Broadband Seismometer",
+		Description:  "Trillium Horizon 120",
+		Manufacturer: "Nanometrics Inc.",
+		Vendor:       "",
+		Components:   []SensorComponent{{Azimuth: 0, Dip: -90}, {Azimuth: 0, Dip: 0}, {Azimuth: 90, Dip: 0}},
+	},
 }
 
 var Responses []Response = []Response{
@@ -3129,6 +3137,35 @@ var Responses []Response = []Response{
 						Type:   "paz",
 						Lookup: "TRILLIUM-HORIZON-120",
 						Filter: "TRILLIUM-HORIZON-TH120-1",
+						StageSet: PAZ{
+							Name:  "TRILLIUM-HORIZON-120",
+							Code:  PZFunctionLaplaceRadiansPerSecond,
+							Type:  "Laplace transform analog stage response, in rad/sec.",
+							Notes: "derived from IRIS NRL Trillium Horizon 120",
+							Poles: []complex128{(-0.036614 + 0.037059i), (-0.036614 - 0.037059i), (-32.55 + 0i), (-142 + 0i), (-364 + 404i), (-364 - 404i), (-1260 + 0i), (-4900 + 5200i), (-4900 - 5200i), (-7100 + 1700i), (-7100 - 1700i)},
+							Zeros: []complex128{(0 + 0i), (0 + 0i), (-31.63 + 0i), (-160 + 0i), (-350 + 0i), (-3177 + 0i)},
+						},
+						Frequency:  1,
+						SampleRate: 0,
+						Decimate:   0,
+						Gain:       1202.5,
+						//Scale: 1,
+						Correction:  0,
+						Delay:       0,
+						InputUnits:  "m/s",
+						OutputUnits: "V",
+					},
+				},
+				Channels: "ZNE",
+				Reversed: false,
+			}, {
+				SensorList: []string{"Trillium Horizon TH120-2"},
+				FilterList: []string{"TRILLIUM-HORIZON-TH120-2"},
+				Stages: []ResponseStage{
+					{
+						Type:   "paz",
+						Lookup: "TRILLIUM-HORIZON-120",
+						Filter: "TRILLIUM-HORIZON-TH120-2",
 						StageSet: PAZ{
 							Name:  "TRILLIUM-HORIZON-120",
 							Code:  PZFunctionLaplaceRadiansPerSecond,
@@ -5673,6 +5710,35 @@ var Responses []Response = []Response{
 						Type:   "paz",
 						Lookup: "TRILLIUM-HORIZON-120",
 						Filter: "TRILLIUM-HORIZON-TH120-1",
+						StageSet: PAZ{
+							Name:  "TRILLIUM-HORIZON-120",
+							Code:  PZFunctionLaplaceRadiansPerSecond,
+							Type:  "Laplace transform analog stage response, in rad/sec.",
+							Notes: "derived from IRIS NRL Trillium Horizon 120",
+							Poles: []complex128{(-0.036614 + 0.037059i), (-0.036614 - 0.037059i), (-32.55 + 0i), (-142 + 0i), (-364 + 404i), (-364 - 404i), (-1260 + 0i), (-4900 + 5200i), (-4900 - 5200i), (-7100 + 1700i), (-7100 - 1700i)},
+							Zeros: []complex128{(0 + 0i), (0 + 0i), (-31.63 + 0i), (-160 + 0i), (-350 + 0i), (-3177 + 0i)},
+						},
+						Frequency:  1,
+						SampleRate: 0,
+						Decimate:   0,
+						Gain:       1202.5,
+						//Scale: 1,
+						Correction:  0,
+						Delay:       0,
+						InputUnits:  "m/s",
+						OutputUnits: "V",
+					},
+				},
+				Channels: "ZNE",
+				Reversed: false,
+			}, {
+				SensorList: []string{"Trillium Horizon TH120-2"},
+				FilterList: []string{"TRILLIUM-HORIZON-TH120-2"},
+				Stages: []ResponseStage{
+					{
+						Type:   "paz",
+						Lookup: "TRILLIUM-HORIZON-120",
+						Filter: "TRILLIUM-HORIZON-TH120-2",
 						StageSet: PAZ{
 							Name:  "TRILLIUM-HORIZON-120",
 							Code:  PZFunctionLaplaceRadiansPerSecond,

--- a/resp/auto.go
+++ b/resp/auto.go
@@ -3130,42 +3130,13 @@ var Responses []Response = []Response{
 				Channels: "Z12",
 				Reversed: false,
 			}, {
-				SensorList: []string{"Trillium Horizon TH120-1"},
+				SensorList: []string{"Trillium Horizon TH120-1", "Trillium Horizon TH120-2"},
 				FilterList: []string{"TRILLIUM-HORIZON-TH120-1"},
 				Stages: []ResponseStage{
 					{
 						Type:   "paz",
 						Lookup: "TRILLIUM-HORIZON-120",
 						Filter: "TRILLIUM-HORIZON-TH120-1",
-						StageSet: PAZ{
-							Name:  "TRILLIUM-HORIZON-120",
-							Code:  PZFunctionLaplaceRadiansPerSecond,
-							Type:  "Laplace transform analog stage response, in rad/sec.",
-							Notes: "derived from IRIS NRL Trillium Horizon 120",
-							Poles: []complex128{(-0.036614 + 0.037059i), (-0.036614 - 0.037059i), (-32.55 + 0i), (-142 + 0i), (-364 + 404i), (-364 - 404i), (-1260 + 0i), (-4900 + 5200i), (-4900 - 5200i), (-7100 + 1700i), (-7100 - 1700i)},
-							Zeros: []complex128{(0 + 0i), (0 + 0i), (-31.63 + 0i), (-160 + 0i), (-350 + 0i), (-3177 + 0i)},
-						},
-						Frequency:  1,
-						SampleRate: 0,
-						Decimate:   0,
-						Gain:       1202.5,
-						//Scale: 1,
-						Correction:  0,
-						Delay:       0,
-						InputUnits:  "m/s",
-						OutputUnits: "V",
-					},
-				},
-				Channels: "ZNE",
-				Reversed: false,
-			}, {
-				SensorList: []string{"Trillium Horizon TH120-2"},
-				FilterList: []string{"TRILLIUM-HORIZON-TH120-2"},
-				Stages: []ResponseStage{
-					{
-						Type:   "paz",
-						Lookup: "TRILLIUM-HORIZON-120",
-						Filter: "TRILLIUM-HORIZON-TH120-2",
 						StageSet: PAZ{
 							Name:  "TRILLIUM-HORIZON-120",
 							Code:  PZFunctionLaplaceRadiansPerSecond,
@@ -5703,42 +5674,13 @@ var Responses []Response = []Response{
 				Channels: "Z12",
 				Reversed: false,
 			}, {
-				SensorList: []string{"Trillium Horizon TH120-1"},
+				SensorList: []string{"Trillium Horizon TH120-1", "Trillium Horizon TH120-2"},
 				FilterList: []string{"TRILLIUM-HORIZON-TH120-1"},
 				Stages: []ResponseStage{
 					{
 						Type:   "paz",
 						Lookup: "TRILLIUM-HORIZON-120",
 						Filter: "TRILLIUM-HORIZON-TH120-1",
-						StageSet: PAZ{
-							Name:  "TRILLIUM-HORIZON-120",
-							Code:  PZFunctionLaplaceRadiansPerSecond,
-							Type:  "Laplace transform analog stage response, in rad/sec.",
-							Notes: "derived from IRIS NRL Trillium Horizon 120",
-							Poles: []complex128{(-0.036614 + 0.037059i), (-0.036614 - 0.037059i), (-32.55 + 0i), (-142 + 0i), (-364 + 404i), (-364 - 404i), (-1260 + 0i), (-4900 + 5200i), (-4900 - 5200i), (-7100 + 1700i), (-7100 - 1700i)},
-							Zeros: []complex128{(0 + 0i), (0 + 0i), (-31.63 + 0i), (-160 + 0i), (-350 + 0i), (-3177 + 0i)},
-						},
-						Frequency:  1,
-						SampleRate: 0,
-						Decimate:   0,
-						Gain:       1202.5,
-						//Scale: 1,
-						Correction:  0,
-						Delay:       0,
-						InputUnits:  "m/s",
-						OutputUnits: "V",
-					},
-				},
-				Channels: "ZNE",
-				Reversed: false,
-			}, {
-				SensorList: []string{"Trillium Horizon TH120-2"},
-				FilterList: []string{"TRILLIUM-HORIZON-TH120-2"},
-				Stages: []ResponseStage{
-					{
-						Type:   "paz",
-						Lookup: "TRILLIUM-HORIZON-120",
-						Filter: "TRILLIUM-HORIZON-TH120-2",
 						StageSet: PAZ{
 							Name:  "TRILLIUM-HORIZON-120",
 							Code:  PZFunctionLaplaceRadiansPerSecond,

--- a/resp/auto/sensor_Nanometrics-Inc_Trillium-Horizon-TH120-2.xml
+++ b/resp/auto/sensor_Nanometrics-Inc_Trillium-Horizon-TH120-2.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <InstrumentSensitivity>
+    <Value>1202.5</Value>
+    <Frequency>1</Frequency>
+    <InputUnits>
+      <Name>m/s</Name>
+    </InputUnits>
+    <OutputUnits>
+      <Name>V</Name>
+    </OutputUnits>
+  </InstrumentSensitivity>
+  <Stage number="1">
+    <PolesZeros resourceId="PolesZeros#TRILLIUM-HORIZON-TH120-2">
+      <InputUnits>
+        <Name>m/s</Name>
+      </InputUnits>
+      <OutputUnits>
+        <Name>V</Name>
+      </OutputUnits>
+      <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+      <NormalizationFactor>8.318711284686068e+17</NormalizationFactor>
+      <NormalizationFrequency>1</NormalizationFrequency>
+      <Zero number="11">
+        <Real>0</Real>
+        <Imaginary>0</Imaginary>
+      </Zero>
+      <Zero number="12">
+        <Real>0</Real>
+        <Imaginary>0</Imaginary>
+      </Zero>
+      <Zero number="13">
+        <Real>-31.63</Real>
+        <Imaginary>0</Imaginary>
+      </Zero>
+      <Zero number="14">
+        <Real>-160</Real>
+        <Imaginary>0</Imaginary>
+      </Zero>
+      <Zero number="15">
+        <Real>-350</Real>
+        <Imaginary>0</Imaginary>
+      </Zero>
+      <Zero number="16">
+        <Real>-3177</Real>
+        <Imaginary>0</Imaginary>
+      </Zero>
+      <Pole>
+        <Real>-0.036614</Real>
+        <Imaginary>0.037059</Imaginary>
+      </Pole>
+      <Pole number="1">
+        <Real>-0.036614</Real>
+        <Imaginary>-0.037059</Imaginary>
+      </Pole>
+      <Pole number="2">
+        <Real>-32.55</Real>
+        <Imaginary>0</Imaginary>
+      </Pole>
+      <Pole number="3">
+        <Real>-142</Real>
+        <Imaginary>0</Imaginary>
+      </Pole>
+      <Pole number="4">
+        <Real>-364</Real>
+        <Imaginary>404</Imaginary>
+      </Pole>
+      <Pole number="5">
+        <Real>-364</Real>
+        <Imaginary>-404</Imaginary>
+      </Pole>
+      <Pole number="6">
+        <Real>-1260</Real>
+        <Imaginary>0</Imaginary>
+      </Pole>
+      <Pole number="7">
+        <Real>-4900</Real>
+        <Imaginary>5200</Imaginary>
+      </Pole>
+      <Pole number="8">
+        <Real>-4900</Real>
+        <Imaginary>-5200</Imaginary>
+      </Pole>
+      <Pole number="9">
+        <Real>-7100</Real>
+        <Imaginary>1700</Imaginary>
+      </Pole>
+      <Pole number="10">
+        <Real>-7100</Real>
+        <Imaginary>-1700</Imaginary>
+      </Pole>
+    </PolesZeros>
+    <StageGain>
+      <Value>1202.5</Value>
+      <Frequency>1</Frequency>
+    </StageGain>
+  </Stage>
+</Response>

--- a/resp/auto/sensor_Nanometrics-Inc_Trillium-Horizon-TH120-2.xml
+++ b/resp/auto/sensor_Nanometrics-Inc_Trillium-Horizon-TH120-2.xml
@@ -11,7 +11,7 @@
     </OutputUnits>
   </InstrumentSensitivity>
   <Stage number="1">
-    <PolesZeros resourceId="PolesZeros#TRILLIUM-HORIZON-TH120-2">
+    <PolesZeros resourceId="PolesZeros#TRILLIUM-HORIZON-TH120-1">
       <InputUnits>
         <Name>m/s</Name>
       </InputUnits>

--- a/resp/responses/configurations/broadband.yaml
+++ b/resp/responses/configurations/broadband.yaml
@@ -183,14 +183,9 @@ response:
       reversed: false
     - sensors:
       - Trillium Horizon TH120-1
-      filters:
-      - TRILLIUM-HORIZON-TH120-1
-      channels: ZNE
-      reversed: false
-    - sensors:
       - Trillium Horizon TH120-2
       filters:
-      - TRILLIUM-HORIZON-TH120-2
+      - TRILLIUM-HORIZON-TH120-1
       channels: ZNE
       reversed: false
     - sensors:
@@ -472,14 +467,9 @@ response:
       reversed: false
     - sensors:
       - Trillium Horizon TH120-1
-      filters:
-      - TRILLIUM-HORIZON-TH120-1
-      channels: ZNE
-      reversed: false
-    - sensors:
       - Trillium Horizon TH120-2
       filters:
-      - TRILLIUM-HORIZON-TH120-2
+      - TRILLIUM-HORIZON-TH120-1
       channels: ZNE
       reversed: false
     - sensors:

--- a/resp/responses/configurations/broadband.yaml
+++ b/resp/responses/configurations/broadband.yaml
@@ -188,6 +188,12 @@ response:
       channels: ZNE
       reversed: false
     - sensors:
+      - Trillium Horizon TH120-2
+      filters:
+      - TRILLIUM-HORIZON-TH120-2
+      channels: ZNE
+      reversed: false
+    - sensors:
       - CMG-3TB-GN
       filters:
       - CMG-3TB-GN
@@ -468,6 +474,12 @@ response:
       - Trillium Horizon TH120-1
       filters:
       - TRILLIUM-HORIZON-TH120-1
+      channels: ZNE
+      reversed: false
+    - sensors:
+      - Trillium Horizon TH120-2
+      filters:
+      - TRILLIUM-HORIZON-TH120-2
       channels: ZNE
       reversed: false
     - sensors:

--- a/resp/responses/sensors/nanometrics.yaml
+++ b/resp/responses/sensors/nanometrics.yaml
@@ -291,18 +291,6 @@ filter:
     delay: 0
     inputunits: m/s
     outputunits: V
-  TRILLIUM-HORIZON-TH120-2:
-  - type: paz
-    lookup: TRILLIUM-HORIZON-120
-    frequency: 1
-    samplerate: 0
-    decimate: 0
-    gain: 1202.5
-    scale: 1
-    correction: 0
-    delay: 0
-    inputunits: m/s
-    outputunits: V
   TRILLIUM-BOREHOLE-T120-BH1:
   - type: paz
     lookup: TRILLIUM-120QA

--- a/resp/responses/sensors/nanometrics.yaml
+++ b/resp/responses/sensors/nanometrics.yaml
@@ -72,6 +72,18 @@ sensor-model:
       dip: 0
     - azimuth: 90
       dip: 0
+  Trillium Horizon TH120-2:
+    type: Broadband Seismometer
+    description: Trillium Horizon 120
+    manufacturer: "Nanometrics Inc."
+    vendor: ""
+    components:
+    - azimuth: 0
+      dip: -90
+    - azimuth: 0
+      dip: 0
+    - azimuth: 90
+      dip: 0
   Trillium 360:
     type: Broadband Seismometer
     description: Trillium Vault 360
@@ -268,6 +280,18 @@ filter:
     inputunits: m/s
     outputunits: V
   TRILLIUM-HORIZON-TH120-1:
+  - type: paz
+    lookup: TRILLIUM-HORIZON-120
+    frequency: 1
+    samplerate: 0
+    decimate: 0
+    gain: 1202.5
+    scale: 1
+    correction: 0
+    delay: 0
+    inputunits: m/s
+    outputunits: V
+  TRILLIUM-HORIZON-TH120-2:
   - type: paz
     lookup: TRILLIUM-HORIZON-120
     frequency: 1


### PR DESCRIPTION
This response is a replica of the original Nanometrics Trillium Horizon TH120-1. We are only adding it for naming clarity in delta so anyone out of the loop will realize the response is identical between both models (TH120-1 & TH120-2) and won't get into a panic thinking an unapproved sensor has been deployed from this point forwards.

If there is a better way to indicate and create awareness to people that the TH120-1 and TH120-2 are the same thing then I'm all ears and you can delete this PR.

More details as per linked ticket:

Model TH120-2
18437-02
ASM19106 rev. 10