### PR TITLE
heights positive

### DIFF
--- a/install/cameras.csv
+++ b/install/cameras.csv
@@ -1,51 +1,51 @@
 Make,Model,Serial,Mount,View,Dip,Azimuth,Height,North,East,Start Date,End Date,Notes
-Axis Communications AB,AXIS-221,00408C6DC9E1,WHOH,02,0,20,-3,0,0,2006-02-24T14:00:00Z,2018-04-19T00:00:00Z,Looking at White Island
-Mobotix AG,M12 3MP,0003c5041fc7,KMTP,01,0,280,-10,0,0,2009-03-03T02:00:00Z,2009-09-18T01:00:00Z,Bearing is magnetic.
+Axis Communications AB,AXIS-221,00408C6DC9E1,WHOH,02,0,20,3,0,0,2006-02-24T14:00:00Z,2018-04-19T00:00:00Z,Looking at White Island
+Mobotix AG,M12 3MP,0003c5041fc7,KMTP,01,0,280,10,0,0,2009-03-03T02:00:00Z,2009-09-18T01:00:00Z,Bearing is magnetic.
 Mobotix AG,M12 3MP,10.3.234.85,TEMO,01,0,180,0,0,0,2009-11-24T22:30:00Z,2012-04-02T22:45:00Z,TEMO (New Plymouth) looking at North Taranaki
 Mobotix AG,M12 3MP,10.3.234.85,TEMO,02,0,180,0,0,0,2012-04-03T00:15:00Z,2020-02-18T00:40:01Z,TEMO (New Plymouth) looking at North Taranaki
 Mobotix AG,M12 3MP,10.3.234.85,TEMO,02,0,180,0,3.7,0.8,2020-02-27T22:59:59Z,2020-07-22T01:09:59Z,TEMO (New Plymouth) looking at North Taranaki
 Mobotix AG,M12 3MP,10.4.156.174,MNTA,01,0,155,0,0,0,2009-08-21T00:00:02Z,2020-07-27T21:20:00Z,Mountain Air (Whakapapa) looking at North Ruapehu
 Mobotix AG,M12 3MP,10.4.156.174,DISC,01,6,144,0,0,0,2020-07-28T02:20:00Z,2021-02-04T21:10:00Z,Discovery Lodge looking at North Ruapehu
-Mobotix AG,M12 3MP,10.4.162.186,KMTP,01,0,238,-10,0,0,2009-09-18T01:15:00Z,2016-07-11T00:00:00Z,Camera mounted on top of middle pole
+Mobotix AG,M12 3MP,10.4.162.186,KMTP,01,0,238,10,0,0,2009-09-18T01:15:00Z,2016-07-11T00:00:00Z,Camera mounted on top of middle pole
 Mobotix AG,M12 3MP,10.4.189.198,WICF,01,0,0,0,0,0,2009-10-28T00:30:00Z,2016-06-01T22:40:00Z,
 Mobotix AG,M12 3MP,10.4.71.129,RIMK,01,0,270,0,0,0,2009-05-18T00:00:02Z,2010-04-01T00:00:00Z,
-Mobotix AG,M12 3MP,10.5.128.224,KAKA,01,0,0,-5,0,0,2011-09-05T00:01:00Z,2011-09-20T00:00:00Z,
+Mobotix AG,M12 3MP,10.5.128.224,KAKA,01,0,0,5,0,0,2011-09-05T00:01:00Z,2011-09-20T00:00:00Z,
 Mobotix AG,M12 3MP,10.5.158.204,MNTA,02,0,0,0,0,0,2011-09-07T12:00:00Z,2017-08-24T22:45:00Z,
 Mobotix AG,M12 3MP,10.5.160.96,MTSR,01,0,0,2,0,0,2011-09-08T00:10:00Z,2016-01-08T00:00:00Z,
-Mobotix AG,M12 3MP,10.5.186.107,KAKA,01,0,0,-5,0,0,2011-12-09T00:02:00Z,2012-03-05T00:00:00Z,"Replaces previous camera (SN 10.5.128.224, Asset 14136) replaced by manufacturer under warranty."
-Mobotix AG,M12 3MP,10.5.202.81,KAKA,01,0,0,-5,0,0,2012-03-05T01:05:00Z,2017-03-04T04:40:03Z,Kakaramea looking at Tongariro Massif
-Mobotix AG,M12 3MP,10.5.202.81,KAKA,02,0,0,-5,0,0,2017-03-04T04:50:03Z,2021-07-28T10:40:00Z,Kakaramea looking at Tongariro Massif
+Mobotix AG,M12 3MP,10.5.186.107,KAKA,01,0,0,5,0,0,2011-12-09T00:02:00Z,2012-03-05T00:00:00Z,"Replaces previous camera (SN 10.5.128.224, Asset 14136) replaced by manufacturer under warranty."
+Mobotix AG,M12 3MP,10.5.202.81,KAKA,01,0,0,5,0,0,2012-03-05T01:05:00Z,2017-03-04T04:40:03Z,Kakaramea looking at Tongariro Massif
+Mobotix AG,M12 3MP,10.5.202.81,KAKA,02,0,0,5,0,0,2017-03-04T04:50:03Z,2021-07-28T10:40:00Z,Kakaramea looking at Tongariro Massif
 Mobotix AG,M12 3MP,10.5.217.68,TOKR,01,0,100,0,0,0,2012-08-29T02:00:00Z,2017-10-12T00:20:00Z,Looking at Te Maari Craters
 Mobotix AG,M12 3MP,10.5.32.131,RIMK,01,0,270,0,0,0,2010-10-29T01:00:00Z,2017-09-24T00:00:00Z,
 Mobotix AG,M12 3MP,10.6.15.32,WINR,02,0,0,1.5,0,0,2013-04-23T01:00:00Z,9999-01-01T00:00:00Z,White Island North Rim looking into the crater
-Mobotix AG,M15,10.13.10.47,WHOH,02,0,19,-4,0,0,2013-08-07T00:00:00Z,9999-01-01T00:00:00Z,Whakatane looking at White Island
+Mobotix AG,M15,10.13.10.47,WHOH,02,0,19,4,0,0,2013-08-07T00:00:00Z,9999-01-01T00:00:00Z,Whakatane looking at White Island
 Mobotix AG,M15,10.13.68.240,WIWR,01,0,0,1.5,0,0,2013-12-10T00:00:00Z,2016-09-14T00:00:00Z,
 Mobotix AG,M15,10.13.68.240,MNTA,02,0,0,0,0,0,2017-09-12T00:00:00Z,2019-05-22T21:50:00Z,Mountain Air (Whakapapa) looking at Ngauruhoe
-Mobotix AG,M15,10.14.178.98,RIMK,01,-23.5,270,-1.5,0,0,2017-09-24T00:00:00Z,2021-02-12T23:10:01Z,Mt Moumoukai (Raoul Island) looking at Green Lake
+Mobotix AG,M15,10.14.178.98,RIMK,01,-23.5,270,1.5,0,0,2017-09-24T00:00:00Z,2021-02-12T23:10:01Z,Mt Moumoukai (Raoul Island) looking at Green Lake
 Mobotix AG,M15,10.16.105.12,PIHA,01,0,0,2,0,0,2015-05-28T00:01:00Z,2019-03-04T20:30:00Z,
 Mobotix AG,M15,10.16.105.12,MNTA,02,0,87,4,0,0,2019-05-23T00:00:00Z,2020-07-27T21:20:00Z,Mountain Air (Whakapapa) looking at Ngauruhoe
 Mobotix AG,M15,10.16.105.12,DISC,02,14,86,4,0,0,2020-07-28T23:40:00Z,2022-10-19T21:10:01Z,Discovery Lodge looking at Ngauruhoe
 Mobotix AG,M15,10.17.107.14,MTSR,01,12.5,0,2,0,0,2016-02-02T02:00:00Z,2022-09-23T01:20:00Z,Mangateitei looking at South Ruapehu
-Mobotix AG,M15,10.18.101.137,KMTP,01,10,290,-2.5,0,0,2016-07-11T00:03:00Z,2019-06-02T23:40:00Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
-Mobotix AG,M15,10.18.101.137,KMTP,01,-8,290,-2.5,0,0,2019-06-02T23:50:00Z,2019-06-19T22:00:00Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe: knocked off-alignment by ice
-Mobotix AG,M15,10.18.101.137,KMTP,01,10,290,-2.5,0,0,2019-06-19T22:00:00Z,2019-07-06T21:10:00Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
-Mobotix AG,M15,10.18.101.137,KMTP,01,4,290,-2.5,0,0,2019-07-06T21:20:00Z,2019-07-08T00:40:00Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
-Mobotix AG,M15,10.18.101.137,KMTP,01,0.5,290,-2.5,0,0,2019-07-08T00:50:00Z,2019-11-27T20:50:00Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
-Mobotix AG,M15,10.18.101.137,KMTP,01,9.5,290,-2.5,0,0,2019-11-27T21:00:00Z,2020-05-07T00:19:59Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
+Mobotix AG,M15,10.18.101.137,KMTP,01,10,290,2.5,0,0,2016-07-11T00:03:00Z,2019-06-02T23:40:00Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
+Mobotix AG,M15,10.18.101.137,KMTP,01,-8,290,2.5,0,0,2019-06-02T23:50:00Z,2019-06-19T22:00:00Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe: knocked off-alignment by ice
+Mobotix AG,M15,10.18.101.137,KMTP,01,10,290,2.5,0,0,2019-06-19T22:00:00Z,2019-07-06T21:10:00Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
+Mobotix AG,M15,10.18.101.137,KMTP,01,4,290,2.5,0,0,2019-07-06T21:20:00Z,2019-07-08T00:40:00Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
+Mobotix AG,M15,10.18.101.137,KMTP,01,0.5,290,2.5,0,0,2019-07-08T00:50:00Z,2019-11-27T20:50:00Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
+Mobotix AG,M15,10.18.101.137,KMTP,01,9.5,290,2.5,0,0,2019-11-27T21:00:00Z,2020-05-07T00:19:59Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
 Mobotix AG,M15,10.18.101.33,WIWR,01,0,0,1.5,0,0,2016-10-03T06:14:00Z,9999-01-01T00:00:00Z,White Island West Rim looking into the crater
 Mobotix AG,M15,10.18.168.61,WICF,01,0,0,0,0,0,2016-06-01T23:40:00Z,9999-01-01T00:00:00Z,White Island Factory looking across the crater floor
-Mobotix AG,M15,10.20.210.120,KMTP,01,9.5,290,-2.5,0,0,2020-05-07T00:20:00Z,2022-04-12T07:40:01Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
+Mobotix AG,M15,10.20.210.120,KMTP,01,9.5,290,2.5,0,0,2020-05-07T00:20:00Z,2022-04-12T07:40:01Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
 Mobotix AG,M15,10.20.245.115,TOKR,01,0,0,0,0,0,2018-05-03T00:00:00Z,9999-01-01T00:00:00Z,Karewerewa looking at TeMaari
 Mobotix AG,M15,10.7.46.153,TOKR,01,0,0,0,0,0,2017-10-12T00:40:00Z,2018-05-02T23:55:00Z,
 Mobotix AG,M16,10.26.194.146,MTSR,01,12.5,37,2,0,0,2022-09-23T02:40:00Z,9999-01-01T00:00:00Z,Mangateitei looking at South Ruapehu
-Mobotix AG,M16,10.26.194.151,RIMK,01,-16.8,270,-1.5,0,0,2021-02-13T01:05:23Z,9999-01-01T00:00:00Z,Mt Moumoukai (Raoul Island) looking at Green Lake
-Mobotix AG,M16,10.26.196.188,KMTP,01,9.5,290,-2.5,0,0,2022-05-05T01:12:50Z,2022-07-31T10:55:00Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
-Mobotix AG,M16,10.26.196.191,KAKA,01,5.6,192,-1.5,0,0,2021-08-01T23:35:11Z,9999-01-01T00:00:00Z,Kakaramea looking at Tongariro Massif
+Mobotix AG,M16,10.26.194.151,RIMK,01,-16.8,270,1.5,0,0,2021-02-13T01:05:23Z,9999-01-01T00:00:00Z,Mt Moumoukai (Raoul Island) looking at Green Lake
+Mobotix AG,M16,10.26.196.188,KMTP,01,9.5,290,2.5,0,0,2022-05-05T01:12:50Z,2022-07-31T10:55:00Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
+Mobotix AG,M16,10.26.196.191,KAKA,01,5.6,192,1.5,0,0,2021-08-01T23:35:11Z,9999-01-01T00:00:00Z,Kakaramea looking at Tongariro Massif
 Mobotix AG,M16,10.26.62.41,TEMO,02,0,187,0,3.7,0.8,2020-08-28T01:13:59Z,9999-01-01T00:00:00Z,TEMO (New Plymouth) looking at North Taranaki
 Mobotix AG,M16,10.26.62.43,TEMO,02,0,187,0,3.7,0.8,2020-07-22T01:10:00Z,2020-08-27T23:40:01Z,TEMO (New Plymouth) looking at North Taranaki
 Mobotix AG,M16,10.26.62.43,DISC,01,16,148,0,0,0,2021-02-05T04:54:00Z,9999-01-01T00:00:00Z,Discovery Lodge (Whakapapa) looking at North Ruapehu
 Mobotix AG,M16,10.28.95.175,DISC,02,14,84,4,0,0,2022-10-19T22:29:59Z,9999-01-01T00:00:00Z,Discovery Lodge looking at Ngauruhoe
-Mobotix AG,M16B,10.27.173.237,KMTP,01,9.5,290,-2.5,0,0,2022-08-04T00:44:00Z,9999-01-01T00:00:00Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
+Mobotix AG,M16B,10.27.173.237,KMTP,01,9.5,290,2.5,0,0,2022-08-04T00:44:00Z,9999-01-01T00:00:00Z,Tai Ping looking at East Ruapehu & South East Ngauruhoe
 Mobotix AG,M24M-Secure,10.9.190.163,CHTB,03,0,315,0,0,0,2011-11-28T00:00:00Z,2019-02-24T21:00:00Z,
 Mobotix AG,M24M-Secure,10.9.190.76,CHTB,02,0,45,0,0,0,2011-11-28T00:00:03Z,2019-02-24T21:00:00Z,
 Mobotix AG,M24M-Secure,10.9.246.200,CHTB,01,0,90,0,0,0,2011-11-28T00:00:03Z,2019-02-24T21:00:00Z,


### PR DESCRIPTION
Delta install/README.md says for cameras.csv 

Height | Installed camera vertical offset | metres positive upwards
-- | -- | --

But we had a mixture of positive and negative values, negative implying below the reference elevation which is normally the ground surface so below ground! Negative values come from a misunderstanding that the height in this file is the same as depth for seismic sensors, but it isn't.

All negative values replaced by the equivalent positive value.

