### PR TITLE
update meta tests

### DIFF
--- a/meta/calibrations_test.go
+++ b/meta/calibrations_test.go
@@ -1,0 +1,33 @@
+package meta
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCalibrationList(t *testing.T) {
+	t.Run("check calibrations", testListFunc("testdata/calibrations.csv", &CalibrationList{
+		Calibration{
+			Install: Install{
+				Equipment: Equipment{
+					Make:   "Acme",
+					Model:  "ACME01",
+					Serial: "257",
+				},
+				Span: Span{
+					Start: time.Date(2021, time.July, 1, 0, 0, 0, 0, time.UTC),
+					End:   time.Date(9999, time.January, 1, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			ScaleFactor: 2000.169 / 2.0,
+			ScaleBias:   1.0,
+			Frequency:   10.0,
+			Number:      0,
+
+			number:    "0",
+			factor:    "2000.169/2.0",
+			bias:      "1.0",
+			frequency: "10.0",
+		},
+	}))
+}

--- a/meta/channels_test.go
+++ b/meta/channels_test.go
@@ -1,0 +1,41 @@
+package meta
+
+import (
+	"testing"
+)
+
+func TestChannelList(t *testing.T) {
+	t.Run("check channels", testListFunc("testdata/channels.csv", &ChannelList{
+		Channel{
+			Make:         "Nanometrics",
+			Model:        "Centaur CTR4-6S",
+			Type:         "Datalogger",
+			SamplingRate: 200,
+			Response:     "datalogger_nanometrics_centaur_200_response",
+
+			samplingRate: "200",
+		},
+		Channel{
+			Make:         "Quanterra",
+			Model:        "Q330HR/6",
+			Type:         "Datalogger",
+			Number:       0,
+			SamplingRate: 200,
+			Response:     "datalogger_quanterra_q330_highgain_200_response",
+
+			number:       "0",
+			samplingRate: "200",
+		},
+		Channel{
+			Make:         "Quanterra",
+			Model:        "Q330HR/6",
+			Type:         "Datalogger",
+			Number:       3,
+			SamplingRate: 200,
+			Response:     "datalogger_quanterra_q330_200_response",
+
+			number:       "3",
+			samplingRate: "200",
+		},
+	}))
+}

--- a/meta/citations_test.go
+++ b/meta/citations_test.go
@@ -1,0 +1,41 @@
+package meta
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCitationList(t *testing.T) {
+	t.Run("check citations", testListFunc("testdata/citations.csv", &CitationList{
+		Citation{
+			Key:       "fry2020",
+			Author:    "Fry, B., S.-J. McCurrach, K. Gledhill, W. Power, M. Williams, M. Angove, D. Arcas, and C. Moore",
+			Title:     "Sensor network warns of stealth tsunamis",
+			Published: "Eos",
+			Volume:    "101",
+			Doi:       MustDoi("https://doi.org/10.1029/2020EO144274"),
+
+			doi:  "https://doi.org/10.1029/2020EO144274",
+			year: "2020",
+		},
+		Citation{
+			Key:       "key2002",
+			Author:    "A Writer",
+			Title:     "A test",
+			Year:      2002,
+			Published: "Journal of test",
+			Volume:    "1",
+			Pages:     "1-2",
+			Doi:       MustDoi("https://doi.org/10.21420/8TCZ-TV02"),
+			Link:      "http://example.com",
+			Retrieved: time.Date(2021, time.January, 12, 0, 0, 0, 0, time.UTC),
+
+			doi:       "https://doi.org/10.21420/8TCZ-TV02",
+			year:      "2002",
+			retrieved: "2021-01-12T00:00:00Z",
+		},
+		Citation{
+			Key: "unknown",
+		},
+	}))
+}

--- a/meta/components_test.go
+++ b/meta/components_test.go
@@ -1,0 +1,59 @@
+package meta
+
+import (
+	"testing"
+)
+
+func TestComponentList(t *testing.T) {
+	t.Run("check components", testListFunc("testdata/components.csv", &ComponentList{
+		Component{
+			Make:         "Guralp",
+			Model:        "Fortis",
+			Type:         "Accelerometer",
+			Number:       0,
+			Subsource:    "Z",
+			Dip:          -90.0,
+			Azimuth:      0.0,
+			Types:        "G",
+			Response:     "sensor_guralp_fortis_response",
+			SamplingRate: 10,
+
+			number:       "0",
+			dip:          "-90",
+			azimuth:      "0",
+			samplingRate: "10",
+		},
+		Component{
+			Make:      "Guralp",
+			Model:     "Fortis",
+			Type:      "Accelerometer",
+			Number:    1,
+			Subsource: "N",
+			Dip:       0.0,
+			Azimuth:   0.0,
+			Types:     "G",
+			Response:  "sensor_guralp_fortis_response",
+
+			number:  "1",
+			dip:     "0",
+			azimuth: "0",
+		},
+		Component{
+			Make:         "Guralp",
+			Model:        "Fortis",
+			Type:         "Accelerometer",
+			Number:       2,
+			Subsource:    "E",
+			Dip:          0.0,
+			Azimuth:      90.0,
+			Types:        "G",
+			SamplingRate: 1 / 10,
+			Response:     "sensor_guralp_fortis_response",
+
+			number:       "2",
+			dip:          "0",
+			azimuth:      "90",
+			samplingRate: "-10",
+		},
+	}))
+}

--- a/meta/gains_test.go
+++ b/meta/gains_test.go
@@ -1,0 +1,28 @@
+package meta
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGainList(t *testing.T) {
+	t.Run("check gains", testListFunc("testdata/gains.csv", &GainList{
+		Gain{
+			Span: Span{
+				Start: time.Date(2021, time.July, 1, 0, 0, 0, 0, time.UTC),
+				End:   time.Date(9999, time.January, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Scale: Scale{
+				Factor: 1298.169,
+				Bias:   11865.556,
+
+				factor: "1298.169",
+				bias:   "11865.556",
+			},
+			Station:     "SBAM",
+			Location:    "50",
+			Sublocation: "01",
+			Subsource:   "XZ",
+		},
+	}))
+}

--- a/meta/list_test.go
+++ b/meta/list_test.go
@@ -2,11 +2,55 @@ package meta
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
+
+func testListFunc(path string, list List) func(t *testing.T) {
+	return func(t *testing.T) {
+		res, err := MarshalList(list)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Run("compare raw list file: "+path, func(t *testing.T) {
+			check, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(res) != string(check) {
+				t.Errorf("unexpected %s content -got/+exp\n%s", path, cmp.Diff(res, check))
+			}
+		})
+		t.Run("check encode/decode list file: "+path, func(t *testing.T) {
+			if err := UnmarshalList(res, list); err != nil {
+				t.Fatal(err)
+			}
+			check, err := MarshalList(list)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(res) != string(check) {
+				t.Errorf("unexpected %s content -got/+exp\n%s", path, cmp.Diff(res, check))
+			}
+		})
+		t.Run("check list file: "+path, func(t *testing.T) {
+			if err := LoadList(path, list); err != nil {
+				t.Fatal(err)
+			}
+			check, err := MarshalList(list)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(res) != string(check) {
+				t.Errorf("unexpected %s content -got/+exp\n%s", path, cmp.Diff(res, check))
+			}
+		})
+	}
+}
 
 func TestList(t *testing.T) {
 
@@ -1025,203 +1069,6 @@ func TestList(t *testing.T) {
 					},
 					Mount: "TOD02",
 					View:  "01",
-				},
-			},
-		},
-		{
-			"testdata/calibrations.csv",
-			&CalibrationList{
-				Calibration{
-					Install: Install{
-						Equipment: Equipment{
-							Make:   "Acme",
-							Model:  "ACME01",
-							Serial: "257",
-						},
-						Span: Span{
-							Start: time.Date(2021, time.July, 1, 0, 0, 0, 0, time.UTC),
-							End:   time.Date(9999, time.January, 1, 0, 0, 0, 0, time.UTC),
-						},
-					},
-					ScaleFactor: 2000.169 / 2.0,
-					ScaleBias:   1.0,
-					Frequency:   10.0,
-					Number:      0,
-
-					number:    "0",
-					factor:    "2000.169/2.0",
-					bias:      "1.0",
-					frequency: "10.0",
-				},
-			},
-		},
-		{
-			"testdata/gains.csv",
-			&GainList{
-				Gain{
-					Span: Span{
-						Start: time.Date(2021, time.July, 1, 0, 0, 0, 0, time.UTC),
-						End:   time.Date(9999, time.January, 1, 0, 0, 0, 0, time.UTC),
-					},
-					Scale: Scale{
-						Factor: 1298.169,
-						Bias:   11865.556,
-
-						factor: "1298.169",
-						bias:   "11865.556",
-					},
-					Station:     "SBAM",
-					Location:    "50",
-					Sublocation: "01",
-					Subsource:   "XZ",
-				},
-			},
-		},
-		{
-			"testdata/placenames.csv",
-			&PlacenameList{
-				Placename{
-					Name:      "Ashburton",
-					Latitude:  -43.9,
-					Longitude: 171.75,
-					Level:     1,
-
-					latitude:  "-43.9",
-					longitude: "171.75",
-				},
-				Placename{
-					Name:      "Auckland",
-					Latitude:  -36.85,
-					Longitude: 174.767,
-					Level:     0,
-
-					latitude:  "-36.85",
-					longitude: "174.767",
-				},
-			},
-		},
-		{
-			"testdata/components.csv",
-			&ComponentList{
-				Component{
-					Make:         "Guralp",
-					Model:        "Fortis",
-					Type:         "Accelerometer",
-					Number:       0,
-					Subsource:    "Z",
-					Dip:          -90.0,
-					Azimuth:      0.0,
-					Types:        "G",
-					Response:     "sensor_guralp_fortis_response",
-					SamplingRate: 10,
-
-					number:       "0",
-					dip:          "-90",
-					azimuth:      "0",
-					samplingRate: "10",
-				},
-				Component{
-					Make:      "Guralp",
-					Model:     "Fortis",
-					Type:      "Accelerometer",
-					Number:    1,
-					Subsource: "N",
-					Dip:       0.0,
-					Azimuth:   0.0,
-					Types:     "G",
-					Response:  "sensor_guralp_fortis_response",
-
-					number:  "1",
-					dip:     "0",
-					azimuth: "0",
-				},
-				Component{
-					Make:         "Guralp",
-					Model:        "Fortis",
-					Type:         "Accelerometer",
-					Number:       2,
-					Subsource:    "E",
-					Dip:          0.0,
-					Azimuth:      90.0,
-					Types:        "G",
-					SamplingRate: 1 / 10,
-					Response:     "sensor_guralp_fortis_response",
-
-					number:       "2",
-					dip:          "0",
-					azimuth:      "90",
-					samplingRate: "-10",
-				},
-			},
-		},
-		{
-			"testdata/channels.csv",
-			&ChannelList{
-				Channel{
-					Make:         "Nanometrics",
-					Model:        "Centaur CTR4-6S",
-					Type:         "Datalogger",
-					SamplingRate: 200,
-					Response:     "datalogger_nanometrics_centaur_200_response",
-
-					samplingRate: "200",
-				},
-				Channel{
-					Make:         "Quanterra",
-					Model:        "Q330HR/6",
-					Type:         "Datalogger",
-					Number:       0,
-					SamplingRate: 200,
-					Response:     "datalogger_quanterra_q330_highgain_200_response",
-
-					number:       "0",
-					samplingRate: "200",
-				},
-				Channel{
-					Make:         "Quanterra",
-					Model:        "Q330HR/6",
-					Type:         "Datalogger",
-					Number:       3,
-					SamplingRate: 200,
-					Response:     "datalogger_quanterra_q330_200_response",
-
-					number:       "3",
-					samplingRate: "200",
-				},
-			},
-		},
-		{
-			"testdata/citations.csv",
-			&CitationList{
-				Citation{
-					Key:       "fry2020",
-					Author:    "Fry, B., S.-J. McCurrach, K. Gledhill, W. Power, M. Williams, M. Angove, D. Arcas, and C. Moore",
-					Title:     "Sensor network warns of stealth tsunamis",
-					Published: "Eos",
-					Volume:    "101",
-					Doi:       MustDoi("https://doi.org/10.1029/2020EO144274"),
-
-					doi:  "https://doi.org/10.1029/2020EO144274",
-					year: "2020",
-				},
-				Citation{
-					Key:       "key2002",
-					Author:    "A Writer",
-					Title:     "A test",
-					Year:      2002,
-					Published: "Journal of test",
-					Volume:    "1",
-					Pages:     "1-2",
-					Doi:       MustDoi("https://doi.org/10.21420/8TCZ-TV02"),
-					Link:      "http://example.com",
-					Retrieved: time.Date(2021, time.January, 12, 0, 0, 0, 0, time.UTC),
-
-					doi:       "https://doi.org/10.21420/8TCZ-TV02",
-					year:      "2002",
-					retrieved: "2021-01-12T00:00:00Z",
-				},
-				Citation{
-					Key: "unknown",
 				},
 			},
 		},

--- a/meta/placenames_test.go
+++ b/meta/placenames_test.go
@@ -30,3 +30,27 @@ func TestPlacenames(t *testing.T) {
 		}
 	}
 }
+
+func TestPlacenameList(t *testing.T) {
+
+	t.Run("check placenames", testListFunc("testdata/placenames.csv", &PlacenameList{
+		Placename{
+			Name:      "Ashburton",
+			Latitude:  -43.9,
+			Longitude: 171.75,
+			Level:     1,
+
+			latitude:  "-43.9",
+			longitude: "171.75",
+		},
+		Placename{
+			Name:      "Auckland",
+			Latitude:  -36.85,
+			Longitude: 174.767,
+			Level:     0,
+
+			latitude:  "-36.85",
+			longitude: "174.767",
+		},
+	}))
+}


### PR DESCRIPTION
This is a general tidy up of the meta module testing mechanism, but so far only related to the recent updates associated with the stationxml revamp.

The main problem was the conflicts being generated in the `list_test.go` as new code is added or removed.  The changes simply add a function to replicate the existing tests (written prior to the t.Run mechanism) into a function which can be called on any given List.

This reduces changes to the main `list_test.go` file and separates each new table struct into individual files which should reduce the conflict potential.

There is no actual code "meta" code change here, just a reworking of the existing tests.