### PR TITLE
update meta polarity tests

### DIFF
--- a/meta/polarity_test.go
+++ b/meta/polarity_test.go
@@ -1,0 +1,46 @@
+package meta
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPolarities(t *testing.T) {
+
+	t.Run("check polarities", testListFunc("testdata/polarities.csv", &PolarityList{
+		Polarity{
+			Station:   "WEL",
+			Location:  "10",
+			Subsource: "Z",
+			Primary:   true,
+			Reversed:  true,
+			Method:    "compass",
+			Span: Span{
+				Start: time.Date(2022, 7, 28, 1, 59, 0, 0, time.UTC),
+				End:   time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			reversed: "true",
+		},
+		Polarity{
+			Station:  "WEL",
+			Location: "11",
+			Reversed: true,
+			Span: Span{
+				Start: time.Date(2022, 7, 28, 1, 59, 0, 0, time.UTC),
+				End:   time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			reversed: "true",
+		},
+		Polarity{
+			Station:  "WEL",
+			Location: "11",
+			Method:   "unknown",
+			Span: Span{
+				Start: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				End:   time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			primary:  "false",
+			reversed: "false",
+		},
+	}))
+}

--- a/meta/testdata/polarities.csv
+++ b/meta/testdata/polarities.csv
@@ -1,4 +1,4 @@
 Station,Location,Sublocation,Subsource,Primary,Reversed,Method,Citation,Start Date,End Date
-WEL,10,,Z,,true,compass,,2022-07-28T01:59:00Z,9999-01-01T00:00:00Z
+WEL,10,,Z,true,true,compass,,2022-07-28T01:59:00Z,9999-01-01T00:00:00Z
 WEL,11,,,,true,,,2022-07-28T01:59:00Z,2023-01-01T00:00:00Z
-WEL,11,,,,false,unknown,,2023-01-01T00:00:00Z,9999-01-01T00:00:00Z
+WEL,11,,,false,false,unknown,,2023-01-01T00:00:00Z,9999-01-01T00:00:00Z


### PR DESCRIPTION
This PR adds in a base meta polarity test, based on #1502 it also updates the actual test data to match the new tests.