### PR TITLE
add source to component table

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -329,6 +329,7 @@ the equivalent _Stream_ and allows for the response to be generated with the pro
 | _Model_         | Sensor model name
 | _Type_          | Sensor type
 | _Number_        | Sensor component offset
+| _Source_        | Sensor source as used for the matching streams 
 | _Subsource_     | Sensor component label
 | _Dip_           | Internal dip of the component relative to whole sensor
 | _Azimuth_       | Internal azimuth of the component relative to whole sensor

--- a/meta/component.go
+++ b/meta/component.go
@@ -11,6 +11,7 @@ const (
 	componentModel
 	componentType
 	componentNumber
+	componentSource
 	componentSubsource
 	componentDip
 	componentAzimuth
@@ -25,6 +26,7 @@ type Component struct {
 	Model        string
 	Type         string
 	Number       int
+	Source       string
 	Subsource    string
 	Dip          float64
 	Azimuth      float64
@@ -73,6 +75,7 @@ func (s ComponentList) encode() [][]string {
 		"Model",
 		"Type",
 		"Number",
+		"Source",
 		"Subsource",
 		"Dip",
 		"Azimuth",
@@ -87,6 +90,7 @@ func (s ComponentList) encode() [][]string {
 			strings.TrimSpace(v.Model),
 			strings.TrimSpace(v.Type),
 			strings.TrimSpace(v.number),
+			strings.TrimSpace(v.Source),
 			strings.TrimSpace(v.Subsource),
 			strings.TrimSpace(v.dip),
 			strings.TrimSpace(v.azimuth),
@@ -138,6 +142,7 @@ func (s *ComponentList) decode(data [][]string) error {
 			Model:        strings.TrimSpace(d[componentModel]),
 			Type:         strings.TrimSpace(d[componentType]),
 			Number:       number,
+			Source:       strings.TrimSpace(d[componentSource]),
 			Subsource:    strings.TrimSpace(d[componentSubsource]),
 			Dip:          dip,
 			Azimuth:      azimuth,

--- a/meta/testdata/components.csv
+++ b/meta/testdata/components.csv
@@ -1,4 +1,4 @@
-Make,Model,Type,Number,Subsource,Dip,Azimuth,Types,Sampling Rate,Response
-Guralp,Fortis,Accelerometer,0,Z,-90,0,G,10,sensor_guralp_fortis_response
-Guralp,Fortis,Accelerometer,1,N,0,0,G,,sensor_guralp_fortis_response
-Guralp,Fortis,Accelerometer,2,E,0,90,G,-10,sensor_guralp_fortis_response
+Make,Model,Type,Number,Source,Subsource,Dip,Azimuth,Types,Sampling Rate,Response
+Guralp,Fortis,Accelerometer,0,,Z,-90,0,G,10,sensor_guralp_fortis_response
+Guralp,Fortis,Accelerometer,1,,N,0,0,G,,sensor_guralp_fortis_response
+Guralp,Fortis,Accelerometer,2,,E,0,90,G,-10,sensor_guralp_fortis_response


### PR DESCRIPTION
On final testing of calibrations updates a problem was found for sensors which can generate more than one type of output. An example would be the mass position of a broadband sensor, or the temperature of a fluxgate magnetometer.

The issue is that the stream is defined as Location, Band, Source, Sampling Rate, whereas the component is defined as Number, Subsource which means when joined together there will be too many streams.

The solution is to add a _Source_ field to the component so that the streams can be matched correctly.