### PR TITLE
update tests to remove exec call, replace with cmp

### DIFF
--- a/tools/altus/altus_test.go
+++ b/tools/altus/altus_test.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"io/ioutil"
-	"os"
-	"os/exec"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestBuild(t *testing.T) {
@@ -27,43 +27,6 @@ func TestBuild(t *testing.T) {
 
 	// compare stored with computed
 	if string(b1) != string(b2) {
-		t.Error("**** altus xml mismatch ****")
-
-		f1, err := ioutil.TempFile(os.TempDir(), "tmp")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.Remove(f1.Name())
-		if _, err := f1.Write(b1); err != nil {
-			t.Fatal(err)
-		}
-
-		f2, err := ioutil.TempFile(os.TempDir(), "tmp")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.Remove(f2.Name())
-		if _, err := f2.Write(b2); err != nil {
-			t.Fatal(err)
-		}
-
-		cmd := exec.Command("diff", "-c", f1.Name(), f2.Name())
-		stdout, err := cmd.StdoutPipe()
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = cmd.Start()
-		if err != nil {
-			t.Fatal(err)
-		}
-		diff, err := ioutil.ReadAll(stdout)
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Error(string(diff))
-
-		if err := cmd.Wait(); err != nil {
-			t.Fatal(err)
-		}
+		t.Errorf("unexpected content -got/+exp\n%s", cmp.Diff(string(b1), string(b2)))
 	}
 }

--- a/tools/amplitude/amplitude_test.go
+++ b/tools/amplitude/amplitude_test.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"io/ioutil"
-	"os"
-	"os/exec"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestBuild(t *testing.T) {
@@ -32,42 +32,6 @@ func TestBuild(t *testing.T) {
 
 	// compare stored with computed
 	if string(b1) != string(b2) {
-		t.Error("**** amplitudes xml mismatch ****")
-
-		f1, err := ioutil.TempFile(os.TempDir(), "tmp")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.Remove(f1.Name())
-		if _, err := f1.Write(b1); err != nil {
-			t.Fatal(err)
-		}
-
-		f2, err := ioutil.TempFile(os.TempDir(), "tmp")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.Remove(f2.Name())
-		if _, err := f2.Write(b2); err != nil {
-			t.Fatal(err)
-		}
-
-		cmd := exec.Command("diff", "-c", f1.Name(), f2.Name())
-		stdout, err := cmd.StdoutPipe()
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = cmd.Start()
-		if err != nil {
-			t.Fatal(err)
-		}
-		diff, err := ioutil.ReadAll(stdout)
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Error(string(diff))
-		if err := cmd.Wait(); err != nil {
-			t.Fatal(err)
-		}
+		t.Errorf("unexpected content -got/+exp\n%s", cmp.Diff(string(b1), string(b2)))
 	}
 }

--- a/tools/chart/chart_test.go
+++ b/tools/chart/chart_test.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"io/ioutil"
-	"os"
-	"os/exec"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestBuild_Tsunami(t *testing.T) {
@@ -41,42 +41,6 @@ func TestBuild_Tsunami(t *testing.T) {
 
 	// compare stored with computed
 	if string(b1) != string(b2) {
-		t.Error("**** tsunami xml mismatch ****")
-
-		f1, err := ioutil.TempFile(os.TempDir(), "tmp")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.Remove(f1.Name())
-		if _, err := f1.Write(b1); err != nil {
-			t.Fatal(err)
-		}
-
-		f2, err := ioutil.TempFile(os.TempDir(), "tmp")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.Remove(f2.Name())
-		if _, err := f2.Write(b2); err != nil {
-			t.Fatal(err)
-		}
-
-		cmd := exec.Command("diff", "-c", f1.Name(), f2.Name())
-		stdout, err := cmd.StdoutPipe()
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = cmd.Start()
-		if err != nil {
-			t.Fatal(err)
-		}
-		diff, err := ioutil.ReadAll(stdout)
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Error(string(diff))
-		if err := cmd.Wait(); err != nil {
-			t.Fatal(err)
-		}
+		t.Errorf("unexpected content -got/+exp\n%s", cmp.Diff(string(b1), string(b2)))
 	}
 }

--- a/tools/cusp/cusp_test.go
+++ b/tools/cusp/cusp_test.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"io/ioutil"
-	"os"
-	"os/exec"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestBuild(t *testing.T) {
@@ -27,43 +27,6 @@ func TestBuild(t *testing.T) {
 
 	// compare stored with computed
 	if string(b1) != string(b2) {
-		t.Error("**** cusp xml mismatch ****")
-
-		f1, err := ioutil.TempFile(os.TempDir(), "tmp")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.Remove(f1.Name())
-		if _, err := f1.Write(b1); err != nil {
-			t.Fatal(err)
-		}
-
-		f2, err := ioutil.TempFile(os.TempDir(), "tmp")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.Remove(f2.Name())
-		if _, err := f2.Write(b2); err != nil {
-			t.Fatal(err)
-		}
-
-		cmd := exec.Command("diff", "-c", f1.Name(), f2.Name())
-		stdout, err := cmd.StdoutPipe()
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = cmd.Start()
-		if err != nil {
-			t.Fatal(err)
-		}
-		diff, err := ioutil.ReadAll(stdout)
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Error(string(diff))
-
-		if err := cmd.Wait(); err != nil {
-			t.Fatal(err)
-		}
+		t.Errorf("unexpected content -got/+exp\n%s", cmp.Diff(string(b1), string(b2)))
 	}
 }

--- a/tools/impact/impact_test.go
+++ b/tools/impact/impact_test.go
@@ -3,10 +3,10 @@ package main
 import (
 	"encoding/json"
 	"io/ioutil"
-	"os"
-	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestBuild_Network(t *testing.T) {
@@ -29,42 +29,6 @@ func TestBuild_Network(t *testing.T) {
 
 	// compare stored with computed
 	if strings.TrimSpace(string(b1)) != strings.TrimSpace(string(b2)) {
-		t.Error("**** impact json mismatch ****")
-
-		f1, err := ioutil.TempFile(os.TempDir(), "tmp")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.Remove(f1.Name())
-		if _, err := f1.Write(b1); err != nil {
-			t.Fatal(err)
-		}
-
-		f2, err := ioutil.TempFile(os.TempDir(), "tmp")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.Remove(f2.Name())
-		if _, err := f2.Write(b2); err != nil {
-			t.Fatal(err)
-		}
-
-		cmd := exec.Command("diff", "-c", f1.Name(), f2.Name())
-		stdout, err := cmd.StdoutPipe()
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = cmd.Start()
-		if err != nil {
-			t.Fatal(err)
-		}
-		diff, err := ioutil.ReadAll(stdout)
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Error(string(diff))
-		if err := cmd.Wait(); err != nil {
-			t.Fatal(err)
-		}
+		t.Errorf("unexpected content -got/+exp\n%s", cmp.Diff(string(b1), string(b2)))
 	}
 }

--- a/tools/rinexml/site_test.go
+++ b/tools/rinexml/site_test.go
@@ -2,11 +2,10 @@ package main
 
 import (
 	"encoding/xml"
-	"io/ioutil"
-	"os"
-	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestSiteXML_Marshal(t *testing.T) {
@@ -167,44 +166,7 @@ func TestSiteXML_Marshal(t *testing.T) {
 
 		// compare stored with computed
 		if string(s) != test.s {
-			t.Error("**** rinexml mismatch ****")
-
-			f1, err := ioutil.TempFile(os.TempDir(), "tmp")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.Remove(f1.Name())
-			if _, err := f1.Write(s); err != nil {
-				t.Fatal(err)
-			}
-
-			f2, err := ioutil.TempFile(os.TempDir(), "tmp")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.Remove(f2.Name())
-			if _, err := f2.Write([]byte(test.s)); err != nil {
-				t.Fatal(err)
-			}
-
-			cmd := exec.Command("diff", "-c", f1.Name(), f2.Name())
-			stdout, err := cmd.StdoutPipe()
-			if err != nil {
-				t.Fatal(err)
-			}
-			err = cmd.Start()
-			if err != nil {
-				t.Fatal(err)
-			}
-			diff, err := ioutil.ReadAll(stdout)
-			if err != nil {
-				t.Fatal(err)
-			}
-			t.Error(string(diff))
-
-			if err := cmd.Wait(); err != nil {
-				t.Fatal(err)
-			}
+			t.Errorf("unexpected content -got/+exp\n%s", cmp.Diff(string(s), test.s))
 		}
 
 	}

--- a/tools/spectra/spectra_test.go
+++ b/tools/spectra/spectra_test.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"io/ioutil"
-	"os"
-	"os/exec"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestBuild(t *testing.T) {
@@ -32,44 +32,6 @@ func TestBuild(t *testing.T) {
 
 	// compare stored with computed
 	if string(b1) != string(b2) {
-		t.Error("**** spectras xml mismatch ****")
-
-		f1, err := ioutil.TempFile(os.TempDir(), "tmp")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.Remove(f1.Name())
-		if _, err := f1.Write(b1); err != nil {
-			t.Fatal(err)
-		}
-
-		f2, err := ioutil.TempFile(os.TempDir(), "tmp")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.Remove(f2.Name())
-		if _, err := f2.Write(b2); err != nil {
-			t.Fatal(err)
-		}
-
-		cmd := exec.Command("diff", "-c", f1.Name(), f2.Name())
-		stdout, err := cmd.StdoutPipe()
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = cmd.Start()
-		if err != nil {
-			t.Fatal(err)
-		}
-		diff, err := ioutil.ReadAll(stdout)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		t.Error(string(diff))
-
-		if err := cmd.Wait(); err != nil {
-			t.Fatal(err)
-		}
+		t.Errorf("unexpected content -got/+exp\n%s", cmp.Diff(string(b1), string(b2)))
 	}
 }

--- a/tools/stationxml/build_test.go
+++ b/tools/stationxml/build_test.go
@@ -3,10 +3,9 @@ package main
 import (
 	"encoding/xml"
 	"io/ioutil"
-	"os"
-	"os/exec"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/ozym/fdsn/stationxml"
 )
 
@@ -58,43 +57,6 @@ func TestBuilder(t *testing.T) {
 
 	// compare stored with computed
 	if string(b1) != string(b2) {
-		t.Error("**** stationxml mismatch ****")
-
-		f1, err := ioutil.TempFile(os.TempDir(), "tmp")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.Remove(f1.Name())
-		if _, err := f1.Write(b1); err != nil {
-			t.Fatal(err)
-		}
-
-		f2, err := ioutil.TempFile(os.TempDir(), "tmp")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.Remove(f2.Name())
-		if _, err := f2.Write(b2); err != nil {
-			t.Fatal(err)
-		}
-
-		cmd := exec.Command("diff", "-c", f1.Name(), f2.Name())
-		stdout, err := cmd.StdoutPipe()
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = cmd.Start()
-		if err != nil {
-			t.Fatal(err)
-		}
-		diff, err := ioutil.ReadAll(stdout)
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Error(string(diff))
-
-		if err := cmd.Wait(); err != nil {
-			t.Fatal(err)
-		}
+		t.Errorf("unexpected content -got/+exp\n%s", cmp.Diff(string(b1), string(b2)))
 	}
 }


### PR DESCRIPTION
This is a bit of housework prior to go 1.19 update.

It replaces the original exec to diff checks with the use of the google cmp module.