### PR TITLE
replace ioutil module

### DIFF
--- a/meta/list_test.go
+++ b/meta/list_test.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -1082,7 +1081,7 @@ func TestList(t *testing.T) {
 
 		t.Log("Compare raw list file: " + tt.f)
 		{
-			b, err := ioutil.ReadFile(tt.f)
+			b, err := os.ReadFile(tt.f)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/resp/generate/main.go
+++ b/resp/generate/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -32,7 +31,7 @@ func main() {
 
 	if err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if !info.IsDir() && filepath.Ext(path) == ".yaml" {
-			b, err := ioutil.ReadFile(path)
+			b, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}

--- a/tests/consistency_test.go
+++ b/tests/consistency_test.go
@@ -3,7 +3,7 @@ package delta_test
 import (
 	"bytes"
 	"encoding/csv"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -25,7 +25,7 @@ var testConsistency = map[string]func(path string, list meta.List) func(t *testi
 	"check file consistency": func(path string, list meta.List) func(t *testing.T) {
 		return func(t *testing.T) {
 
-			raw, err := ioutil.ReadFile(path)
+			raw, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatalf("unable to read %s file: %v", path, err)
 			}

--- a/tools/altus/altus_test.go
+++ b/tools/altus/altus_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -10,7 +10,7 @@ import (
 func TestBuild(t *testing.T) {
 
 	// load in the test data and convert to stationxml indented text
-	b1, err := ioutil.ReadFile("./testdata/altus.xml")
+	b1, err := os.ReadFile("./testdata/altus.xml")
 	if err != nil {
 		t.Fatalf("error: unable to load test altus file: %v", err)
 	}

--- a/tools/altus/main.go
+++ b/tools/altus/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -63,7 +62,7 @@ func main() {
 		if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil {
 			log.Fatalf("error: unable to create directory %s: %v", filepath.Dir(output), err)
 		}
-		if err := ioutil.WriteFile(output, res, 0644); err != nil {
+		if err := os.WriteFile(output, res, 0600); err != nil {
 			log.Fatalf("error: unable to write file %s: %v", output, err)
 		}
 	default:

--- a/tools/amplitude/amplitude_test.go
+++ b/tools/amplitude/amplitude_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -10,7 +10,7 @@ import (
 func TestBuild(t *testing.T) {
 
 	// load in the test data and convert to stationxml indented text
-	b1, err := ioutil.ReadFile("./testdata/amplitude.xml")
+	b1, err := os.ReadFile("./testdata/amplitude.xml")
 	if err != nil {
 		t.Fatalf("error: unable to load test amplitudes file: %v", err)
 	}

--- a/tools/amplitude/config.go
+++ b/tools/amplitude/config.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v2"
 )
@@ -51,7 +51,7 @@ type ConfigSite struct {
 func loadConfig(config string) (map[string]Config, error) {
 
 	cfgs := make(map[string]Config)
-	b, err := ioutil.ReadFile(config)
+	b, err := os.ReadFile(config)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/amplitude/main.go
+++ b/tools/amplitude/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -62,7 +61,7 @@ func main() {
 		if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil {
 			log.Fatalf("error: unable to create directory %s: %v", filepath.Dir(output), err)
 		}
-		if err := ioutil.WriteFile(output, res, 0644); err != nil {
+		if err := os.WriteFile(output, res, 0600); err != nil {
 			log.Fatalf("error: unable to write file %s: %v", output, err)
 		}
 	default:

--- a/tools/caps/main.go
+++ b/tools/caps/main.go
@@ -7,7 +7,6 @@ build template files for configuring a caps system based on site details
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -55,7 +54,7 @@ func (s Station) Store(path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(path, []byte(contents), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
 		return err
 	}
 	return nil

--- a/tools/caps/station_test.go
+++ b/tools/caps/station_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,7 +21,7 @@ func TestBuilder(t *testing.T) {
 
 	for k, s := range stns {
 		t.Run("check "+k, func(t *testing.T) {
-			d, err := ioutil.TempDir(os.TempDir(), "test")
+			d, err := os.MkdirTemp(os.TempDir(), "test")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -32,7 +31,7 @@ func TestBuilder(t *testing.T) {
 				t.Fatalf("unable to store key output %s: %v", d, err)
 			}
 
-			all, err := ioutil.ReadFile(filepath.Join(d, k))
+			all, err := os.ReadFile(filepath.Join(d, k))
 			if err != nil {
 				t.Fatalf("unable to read temp key file %s: %v", d, err)
 			}

--- a/tools/chart/chart_test.go
+++ b/tools/chart/chart_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -10,7 +10,7 @@ import (
 func TestBuild_Tsunami(t *testing.T) {
 
 	// load in the test data and convert to stationxml indented text
-	b1, err := ioutil.ReadFile("./testdata/tsunami-gauge.xml")
+	b1, err := os.ReadFile("./testdata/tsunami-gauge.xml")
 	if err != nil {
 		t.Fatalf("error: unable to load test amplitudes file: %v", err)
 	}

--- a/tools/chart/config.go
+++ b/tools/chart/config.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -191,7 +191,7 @@ func (c Options) Channels() []string {
 
 func ReadPlots(path string) (*Plots, error) {
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/chart/main.go
+++ b/tools/chart/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -135,7 +134,7 @@ func main() {
 			if err := os.MkdirAll(filepath.Dir(outfile), 0755); err != nil {
 				log.Fatalf("error: unable to create directory %s: %v", filepath.Dir(output), err)
 			}
-			if err := ioutil.WriteFile(outfile, res, 0644); err != nil {
+			if err := os.WriteFile(outfile, res, 0600); err != nil {
 				log.Fatalf("error: unable to write file %s: %v", outfile, err)
 			}
 		}

--- a/tools/cusp/cusp_test.go
+++ b/tools/cusp/cusp_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -10,7 +10,7 @@ import (
 func TestBuild(t *testing.T) {
 
 	// load in the test data and convert to stationxml indented text
-	b1, err := ioutil.ReadFile("./testdata/cusp.xml")
+	b1, err := os.ReadFile("./testdata/cusp.xml")
 	if err != nil {
 		t.Fatalf("error: unable to load test cusp file: %v", err)
 	}

--- a/tools/cusp/main.go
+++ b/tools/cusp/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -121,7 +120,7 @@ func main() {
 		if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil {
 			log.Fatalf("error: unable to create directory %s: %v", filepath.Dir(output), err)
 		}
-		if err := ioutil.WriteFile(output, res, 0644); err != nil {
+		if err := os.WriteFile(output, res, 0600); err != nil {
 			log.Fatalf("error: unable to write file %s: %v", output, err)
 		}
 	default:

--- a/tools/gloria/main.go
+++ b/tools/gloria/main.go
@@ -6,7 +6,6 @@ import (
 	"github.com/GeoNet/delta/meta"
 	"github.com/GeoNet/kit/gloria_pb"
 	"github.com/golang/protobuf/proto"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -260,7 +259,7 @@ contact information can be found at www.geonet.org.nz`
 			fmt.Fprintf(os.Stderr, "error: unable to create dir: %v\n", err)
 			os.Exit(-1)
 		}
-		if err := ioutil.WriteFile(pbfile, b, 0644); err != nil {
+		if err := os.WriteFile(pbfile, b, 0600); err != nil {
 			fmt.Fprintf(os.Stderr, "error: unable to write file: %v\n", err)
 			os.Exit(-1)
 		}
@@ -273,7 +272,7 @@ contact information can be found at www.geonet.org.nz`
 		fmt.Fprintf(os.Stderr, "error: unable to marshal marks index protobuf: %v\n", err)
 		os.Exit(-1)
 	}
-	if err := ioutil.WriteFile(filepath.Join(output, "mark-index.pb"), b, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(output, "mark-index.pb"), b, 0600); err != nil {
 		fmt.Fprintf(os.Stderr, "error: unable to write file: %v\n", err)
 		os.Exit(-1)
 	}

--- a/tools/impact/impact_test.go
+++ b/tools/impact/impact_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -12,7 +12,7 @@ import (
 func TestBuild_Network(t *testing.T) {
 
 	// load in the test data and convert to stationxml indented text
-	b1, err := ioutil.ReadFile("./testdata/impact.json")
+	b1, err := os.ReadFile("./testdata/impact.json")
 	if err != nil {
 		t.Fatalf("error: unable to load test amplitudes file: %v", err)
 	}

--- a/tools/impact/main.go
+++ b/tools/impact/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -54,7 +53,7 @@ func main() {
 		if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil {
 			log.Fatalf("error: unable to create directory %s: %v", filepath.Dir(output), err)
 		}
-		if err := ioutil.WriteFile(output, res, 0644); err != nil {
+		if err := os.WriteFile(output, res, 0600); err != nil {
 			log.Fatalf("error: unable to write file %s: %v", output, err)
 		}
 	}

--- a/tools/pod/main.go
+++ b/tools/pod/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/xml"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -50,7 +49,7 @@ func main() {
 			log.Printf("processing StationXML file: %s", f)
 		}
 
-		x, err := ioutil.ReadFile(f)
+		x, err := os.ReadFile(f)
 		if err != nil {
 			log.Fatalf("unable to read StationXML file: %s [%v]", f, err)
 		}

--- a/tools/pod/pod.go
+++ b/tools/pod/pod.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -63,7 +62,7 @@ func (p *Pod) Header() error {
 	if err := os.MkdirAll(filepath.Dir(header), 0755); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(header, []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
+	if err := os.WriteFile(header, []byte(strings.Join(lines, "\n")+"\n"), 0600); err != nil {
 		return err
 	}
 
@@ -86,7 +85,7 @@ func (p *Pod) Station(net *stationxml.Network, sta *stationxml.Station) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(b50, []byte(Blockette{
+	if err := os.WriteFile(b50, []byte(Blockette{
 		Type: 50,
 		Content: StationIdentifier{
 			Station:   sta.Code,
@@ -111,7 +110,7 @@ func (p *Pod) Station(net *stationxml.Network, sta *stationxml.Station) error {
 			}(),
 			Network: net.Code,
 		}.String(),
-	}.String()+"\n"), 0644); err != nil {
+	}.String()+"\n"), 0600); err != nil {
 		return err
 	}
 
@@ -138,7 +137,7 @@ func (p *Pod) Station(net *stationxml.Network, sta *stationxml.Station) error {
 	if err := os.MkdirAll(filepath.Dir(b51), 0755); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(b51, []byte(Blockettes(comments).Encode()+"\n"), 0644); err != nil {
+	if err := os.WriteFile(b51, []byte(Blockettes(comments).Encode()+"\n"), 0600); err != nil {
 		return err
 	}
 
@@ -160,7 +159,7 @@ func (p *Pod) Station(net *stationxml.Network, sta *stationxml.Station) error {
 		if err := os.MkdirAll(filepath.Dir(b52), 0755); err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(b52, []byte(Blockettes(v).Encode()+"\n"), 0644); err != nil {
+		if err := os.WriteFile(b52, []byte(Blockettes(v).Encode()+"\n"), 0600); err != nil {
 			return err
 		}
 	}
@@ -176,7 +175,7 @@ func (p *Pod) Station(net *stationxml.Network, sta *stationxml.Station) error {
 		if err := os.MkdirAll(filepath.Dir(b59), 0755); err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(b59, []byte(Blockettes(v).Encode()+"\n"), 0644); err != nil {
+		if err := os.WriteFile(b59, []byte(Blockettes(v).Encode()+"\n"), 0600); err != nil {
 			return err
 		}
 	}

--- a/tools/rinexml/main.go
+++ b/tools/rinexml/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -488,7 +487,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "error: unable to create dir: %v\n", err)
 			os.Exit(-1)
 		}
-		if err := ioutil.WriteFile(xmlfile, s, 0644); err != nil {
+		if err := os.WriteFile(xmlfile, s, 0600); err != nil {
 			fmt.Fprintf(os.Stderr, "error: unable to write file: %v\n", err)
 			os.Exit(-1)
 		}
@@ -505,7 +504,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "error: unable to create dir: %v\n", err)
 		os.Exit(-1)
 	}
-	if err := ioutil.WriteFile(xmlfile, s, 0644); err != nil {
+	if err := os.WriteFile(xmlfile, s, 0600); err != nil {
 		fmt.Fprintf(os.Stderr, "error: unable to write file: %v\n", err)
 		os.Exit(-1)
 	}
@@ -521,7 +520,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "error: unable to create dir: %v\n", err)
 		os.Exit(-1)
 	}
-	if err := ioutil.WriteFile(xmlfile, s, 0644); err != nil {
+	if err := os.WriteFile(xmlfile, s, 0600); err != nil {
 		fmt.Fprintf(os.Stderr, "error: unable to write file: %v\n", err)
 		os.Exit(-1)
 	}

--- a/tools/sc3/autopick_test.go
+++ b/tools/sc3/autopick_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,7 +45,7 @@ func TestAutoPick(t *testing.T) {
 
 	for k, p := range picks {
 		t.Run("check "+k, func(t *testing.T) {
-			d, err := ioutil.TempDir(os.TempDir(), "test")
+			d, err := os.MkdirTemp(os.TempDir(), "test")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -56,7 +55,7 @@ func TestAutoPick(t *testing.T) {
 				t.Fatalf("unable to store key output %s: %v", k, err)
 			}
 
-			key, err := ioutil.ReadFile(filepath.Join(d, k))
+			key, err := os.ReadFile(filepath.Join(d, k))
 			if err != nil {
 				t.Fatalf("unable to read temp key file %s: %v", d, err)
 			}

--- a/tools/sc3/global_test.go
+++ b/tools/sc3/global_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -55,7 +54,7 @@ func TestGlobal(t *testing.T) {
 
 	for k, g := range globals {
 		t.Run("check "+k, func(t *testing.T) {
-			d, err := ioutil.TempDir(os.TempDir(), "test")
+			d, err := os.MkdirTemp(os.TempDir(), "test")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -65,7 +64,7 @@ func TestGlobal(t *testing.T) {
 				t.Fatalf("unable to store key output %s: %v", k, err)
 			}
 
-			key, err := ioutil.ReadFile(filepath.Join(d, k))
+			key, err := os.ReadFile(filepath.Join(d, k))
 			if err != nil {
 				t.Fatalf("unable to read temp key file %s: %v", d, err)
 			}

--- a/tools/sc3/profile.go
+++ b/tools/sc3/profile.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -31,7 +30,7 @@ func Store(profile Profiler, path string) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(name, res.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(name, res.Bytes(), 0600); err != nil {
 		return err
 	}
 

--- a/tools/sc3/station_test.go
+++ b/tools/sc3/station_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -63,7 +62,7 @@ func TestStation(t *testing.T) {
 
 	for k, s := range stations {
 		t.Run("check "+k, func(t *testing.T) {
-			d, err := ioutil.TempDir(os.TempDir(), "test")
+			d, err := os.MkdirTemp(os.TempDir(), "test")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -73,7 +72,7 @@ func TestStation(t *testing.T) {
 				t.Fatalf("unable to store key output %s: %v", k, err)
 			}
 
-			key, err := ioutil.ReadFile(filepath.Join(d, k))
+			key, err := os.ReadFile(filepath.Join(d, k))
 			if err != nil {
 				t.Fatalf("unable to read temp key file %s: %v", d, err)
 			}

--- a/tools/sit/main.go
+++ b/tools/sit/main.go
@@ -7,7 +7,6 @@ import (
 	"github.com/GeoNet/delta/meta"
 	"github.com/GeoNet/kit/sit_delta_pb"
 	"github.com/golang/protobuf/proto"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -436,13 +435,13 @@ func main() {
 			fmt.Fprintf(os.Stderr, "error: unable to create dir: %v\n", err)
 			os.Exit(-1)
 		}
-		if err := ioutil.WriteFile(pbfile, b, 0644); err != nil {
+		if err := os.WriteFile(pbfile, b, 0600); err != nil {
 			fmt.Fprintf(os.Stderr, "error: unable to write file: %v\n", err)
 			os.Exit(-1)
 		}
 		if verbose {
 			out_json, _ := json.MarshalIndent(site_pb, "", "  ")
-			err = ioutil.WriteFile(filepath.Join(output, strings.ToUpper(s)+".json"), []byte(out_json), 0644)
+			err = os.WriteFile(filepath.Join(output, strings.ToUpper(s)+".json"), []byte(out_json), 0600)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "error: unable to write debug json: %v\n", err)
 			}

--- a/tools/sitelogs/generate/main.go
+++ b/tools/sitelogs/generate/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -18,7 +17,7 @@ func main() {
 
 	flag.Parse()
 
-	b, err := ioutil.ReadFile(config)
+	b, err := os.ReadFile(config)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tools/sitelogs/main.go
+++ b/tools/sitelogs/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math"
 	"os"
@@ -647,7 +646,7 @@ func main() {
 		if err := os.MkdirAll(filepath.Dir(xmlfile), 0755); err != nil {
 			log.Fatalf("error: unable to create dir: %v", err)
 		}
-		if err := ioutil.WriteFile(xmlfile, current, 0644); err != nil {
+		if err := os.WriteFile(xmlfile, current, 0600); err != nil {
 			log.Fatalf("error: unable to write file: %v", err)
 		}
 

--- a/tools/sitelogs/sitelog_test.go
+++ b/tools/sitelogs/sitelog_test.go
@@ -1,9 +1,8 @@
 package main
 
 import (
-	//	"bytes"
 	"encoding/xml"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -12,7 +11,7 @@ import (
 func TestSitelog_Read(t *testing.T) {
 
 	// read in a raw file
-	raw, err := ioutil.ReadFile("testdata/yald_20200929.xml")
+	raw, err := os.ReadFile("testdata/yald_20200929.xml")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/sitelogs/txt_file.go
+++ b/tools/sitelogs/txt_file.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/xml"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -44,7 +43,7 @@ func readLastSiteLog(dir, code string) (*SiteLog, error) {
 	})
 
 	if n := len(files); n > 0 {
-		raw, err := ioutil.ReadFile(files[n-1])
+		raw, err := os.ReadFile(files[n-1])
 		if err != nil {
 			return nil, err
 		}

--- a/tools/spectra/config.go
+++ b/tools/spectra/config.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v2"
 )
@@ -51,7 +51,7 @@ type ConfigSite struct {
 func loadConfig(config string) (map[string]Config, error) {
 
 	cfgs := make(map[string]Config)
-	b, err := ioutil.ReadFile(config)
+	b, err := os.ReadFile(config)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/spectra/main.go
+++ b/tools/spectra/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -63,7 +62,7 @@ func main() {
 		if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil {
 			log.Fatalf("error: unable to create directory %s: %v", filepath.Dir(output), err)
 		}
-		if err := ioutil.WriteFile(output, res, 0644); err != nil {
+		if err := os.WriteFile(output, res, 0600); err != nil {
 			log.Fatalf("error: unable to write file %s: %v", output, err)
 		}
 	default:

--- a/tools/spectra/spectra_test.go
+++ b/tools/spectra/spectra_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -10,7 +10,7 @@ import (
 func TestBuild(t *testing.T) {
 
 	// load in the test data and convert to stationxml indented text
-	b1, err := ioutil.ReadFile("./testdata/spectra.xml")
+	b1, err := os.ReadFile("./testdata/spectra.xml")
 	if err != nil {
 		t.Fatalf("error: unable to load test spectras file: %v", err)
 	}

--- a/tools/stationxml/build_test.go
+++ b/tools/stationxml/build_test.go
@@ -2,17 +2,18 @@ package main
 
 import (
 	"encoding/xml"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/ozym/fdsn/stationxml"
 )
 
 func TestBuilder(t *testing.T) {
 
 	// load in the test data and convert to stationxml indented text
-	raw, err := ioutil.ReadFile("./testdata/test.xml")
+	raw, err := os.ReadFile("./testdata/test.xml")
 	if err != nil {
 		t.Fatalf("error: unable to load test stationxml file: %v", err)
 	}

--- a/tools/stationxml/main.go
+++ b/tools/stationxml/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -124,7 +123,7 @@ func main() {
 		if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil {
 			log.Fatalf("error: unable to create directory %s: %v", filepath.Dir(output), err)
 		}
-		if err := ioutil.WriteFile(output, res, 0644); err != nil {
+		if err := os.WriteFile(output, res, 0600); err != nil {
 			log.Fatalf("error: unable to write file %s: %v", output, err)
 		}
 	}

--- a/tools/tide/main.go
+++ b/tools/tide/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"text/template"
@@ -155,7 +154,7 @@ func main() {
 
 	// process each template given on the command line
 	for _, t := range flag.Args() {
-		conf, err := ioutil.ReadFile(t)
+		conf, err := os.ReadFile(t)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "problem reading template file %s: %v\n", t, err)
 			os.Exit(1)


### PR DESCRIPTION
This PR replaces the deprecated ioutil module, as well as fixing the linting warning about the mode, i.e. 0644 -> 0600.