### PR TITLE
add stationxml response decoding and snippet tests

### DIFF
--- a/internal/stationxml/response.go
+++ b/internal/stationxml/response.go
@@ -83,9 +83,7 @@ func NewResponse(opts ...ResponseOpt) *Response {
 		GainFactor:  1.0,
 		Preamp:      1.0,
 	}
-	for _, opt := range opts {
-		opt(&r)
-	}
+	r.Config(opts...)
 	return &r
 }
 

--- a/internal/stationxml/response.go
+++ b/internal/stationxml/response.go
@@ -1,0 +1,468 @@
+package stationxml
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var ErrInvalidResponse = errors.New("attempt to correct the wrong type of response, biases require a polynomial response")
+
+type ResponseOpt func(*Response)
+
+// Response is used for building an instrument response based on sensor and datalogger pairs. It makes no assumption about
+// the StationXML version, ideally it should encompass all required elements. The conversion from a bas Response to a
+// particular version is done via encoding interfaces.
+type Response struct {
+	Prefix       string
+	Serial       string
+	Frequency    float64
+	ScaleFactor  float64
+	ScaleBias    float64
+	GainFactor   float64
+	GainBias     float64
+	GainAbsolute float64
+	Preamp       float64
+
+	sensor     *ResponseType
+	datalogger *ResponseType
+
+	stages []ResponseStageType
+}
+
+// Prefix sets the label used to prefix Response element names.
+func Prefix(prefix string) ResponseOpt {
+	return func(r *Response) {
+		r.Prefix = prefix
+	}
+}
+
+// Serial sets the label used to prefix Response equipment labels.
+func Serial(serial string) ResponseOpt {
+	return func(r *Response) {
+		r.Serial = serial
+	}
+}
+
+// Frequency is used to set the overall reference frequency for the Response.
+func Frequency(frequency float64) ResponseOpt {
+	return func(r *Response) {
+		r.Frequency = frequency
+	}
+}
+
+// Calibration is used to set a initial sensor reference gain, this overrides the default values.
+func Calibration(factor, bias float64) ResponseOpt {
+	return func(r *Response) {
+		r.ScaleFactor = factor
+		r.ScaleBias = bias
+	}
+}
+
+// Gain is used to adjusts the installed sensor gains, this is in addition to the default values.
+func Gain(factor, bias, absolute float64) ResponseOpt {
+	return func(r *Response) {
+		r.GainFactor = factor
+		r.GainBias = bias
+		r.GainAbsolute = absolute
+	}
+}
+
+// Preamp is used to adjusts the datalogger gains, this is in addition to the default values.
+func Preamp(preamp float64) ResponseOpt {
+	return func(r *Response) {
+		r.Preamp = preamp
+	}
+}
+
+// NewResponse builds a Response with the given options.
+func NewResponse(opts ...ResponseOpt) *Response {
+	r := Response{
+		ScaleFactor: 1.0,
+		GainFactor:  1.0,
+		Preamp:      1.0,
+	}
+	for _, opt := range opts {
+		opt(&r)
+	}
+	return &r
+}
+
+// Config can be used to set extra Response options.
+func (r *Response) Config(opts ...ResponseOpt) {
+	for _, opt := range opts {
+		opt(r)
+	}
+}
+
+// SetPrefix sets the label used to prefix Response element names.
+func (r *Response) SetPrefix(prefix string) {
+	Prefix(prefix)(r)
+}
+
+// SetSerial sets the label used to prefix Response equipment labels.
+func (r *Response) SetSerial(serial string) {
+	Serial(serial)(r)
+}
+
+// SetFrequency is used to set the overall reference frequency for the Response.
+func (r *Response) SetFrequency(frequency float64) {
+	Frequency(frequency)(r)
+}
+
+// SetCalibration is used to set a initial sensor reference gain, this overrides the default values.
+func (r *Response) SetCalibration(scale, bias float64) {
+	Calibration(scale, bias)(r)
+}
+
+// SetGain is used to adjusts the installed sensor gains, this is in addition to the default values.
+func (r *Response) SetGain(scale, bias, absolute float64) {
+	Gain(scale, bias, absolute)(r)
+}
+
+// SetPreamp is used to adjusts the datalogger gains, this is in addition to the default values.
+func (r *Response) SetPreamp(preamp float64) {
+	Preamp(preamp)(r)
+}
+
+// Polynomial finds the PolynomialType in the Response if one is present.
+func (r *Response) Polynomial() *PolynomialType {
+	for _, s := range r.stages {
+		if s.Polynomial == nil {
+			continue
+		}
+		return s.Polynomial
+	}
+	return nil
+}
+
+// SetSensor takes an XML encoded ResponseType that represents a Sensor and adds it to the Response.
+func (r *Response) SetSensor(data []byte) error {
+
+	var sensor ResponseType
+	if err := xml.Unmarshal(data, &sensor); err != nil {
+		return err
+	}
+
+	switch {
+	case sensor.InstrumentSensitivity != nil:
+		// check biases, as these imply a polynomial response
+		if r.ScaleBias != 0.0 || r.GainBias != 0.0 || r.GainAbsolute != 0.0 {
+			return ErrInvalidResponse
+		}
+		// a simple scaling of the overall sensitivity
+		sensor.InstrumentSensitivity.Value *= (r.ScaleFactor * r.GainFactor)
+		// look for the first stage with a gain
+		for i := range sensor.Stages {
+			stage := sensor.Stages[i]
+			if stage.StageGain == nil {
+				continue
+			}
+			// update the first one found, and ignore the rest
+			stage.StageGain.Value *= (r.ScaleFactor * r.GainFactor)
+			break
+		}
+	case sensor.InstrumentPolynomial != nil:
+		// First adjust for any calibrations, these are simply replacing the first two coefficients
+		if r.ScaleFactor != 1.0 || r.ScaleBias != 0.0 {
+			for i := range sensor.Stages {
+				stage := sensor.Stages[i]
+
+				// there can only be one
+				if stage.Polynomial == nil {
+					continue
+				}
+
+				// ignore changes in units, or changes in bounds
+				switch c := len(stage.Polynomial.Coefficients); {
+				case c > 1:
+					stage.Polynomial.Coefficients[1] = PolynomialCoefficient{
+						Number: stage.Polynomial.Coefficients[1].Number,
+						Value:  r.ScaleFactor,
+					}
+					stage.Polynomial.Coefficients[0] = PolynomialCoefficient{
+						Number: stage.Polynomial.Coefficients[0].Number,
+						Value:  r.ScaleBias,
+					}
+				case c > 0:
+					stage.Polynomial.Coefficients[0] = PolynomialCoefficient{
+						Number: stage.Polynomial.Coefficients[0].Number,
+						Value:  r.ScaleBias,
+					}
+				}
+
+				// update the overall instrument polynomial
+				sensor.InstrumentPolynomial.Coefficients = append([]PolynomialCoefficient{}, stage.Polynomial.Coefficients...)
+			}
+		}
+
+		// Second adjust for any gains, these will update the first two coefficents
+		if r.GainFactor != 1.0 || r.GainBias != 0.0 || r.GainAbsolute != 0.0 {
+			for i := range sensor.Stages {
+				stage := sensor.Stages[i]
+
+				// there can only be one
+				if stage.Polynomial == nil {
+					continue
+				}
+
+				// ignore changes in units, or changes in bounds
+				switch c := len(stage.Polynomial.Coefficients); {
+				case c > 1:
+					stage.Polynomial.Coefficients[0] = PolynomialCoefficient{
+						Number: stage.Polynomial.Coefficients[0].Number,
+						Value: stage.Polynomial.Coefficients[0].Value*r.GainFactor +
+							stage.Polynomial.Coefficients[1].Value*r.GainBias + r.GainAbsolute,
+					}
+					stage.Polynomial.Coefficients[1] = PolynomialCoefficient{
+						Number: stage.Polynomial.Coefficients[1].Number,
+						Value:  stage.Polynomial.Coefficients[1].Value * r.GainFactor,
+					}
+				case c > 0:
+					stage.Polynomial.Coefficients[0] = PolynomialCoefficient{
+						Number: stage.Polynomial.Coefficients[0].Number,
+						Value:  stage.Polynomial.Coefficients[0].Value*r.GainFactor + r.GainAbsolute,
+					}
+				}
+
+				// update the overall instrument polynomial
+				sensor.InstrumentPolynomial.Coefficients = append([]PolynomialCoefficient{}, stage.Polynomial.Coefficients...)
+			}
+		}
+	default:
+		return nil
+	}
+
+	r.sensor = &sensor
+
+	return nil
+}
+
+// SetDatalogger takes an XML encoded ResponseType that represents a Datalogger and adds it to the Response.
+func (r *Response) SetDatalogger(data []byte) error {
+
+	var datalogger ResponseType
+	if err := xml.Unmarshal(data, &datalogger); err != nil {
+		return err
+	}
+
+	if datalogger.InstrumentSensitivity == nil {
+		return nil
+	}
+
+	// a preamp has been given, prepend an appropriate stage
+	if r.Preamp != 1.0 && r.Preamp != 0.0 {
+		datalogger.Stages = append([]ResponseStageType{{
+			//TODO: technically the poles and zeros are not required, but kept to allow acceptance checks
+			PolesZeros: &PolesZerosType{
+				InputUnits:             datalogger.InstrumentSensitivity.InputUnits,
+				OutputUnits:            datalogger.InstrumentSensitivity.InputUnits,
+				PzTransferFunctionType: LaplaceRadiansSecondPzTransferFunction,
+				NormalizationFactor:    1.0,
+				NormalizationFrequency: r.Frequency,
+			},
+			StageGain: &StageGain{
+				Value:     r.Preamp,
+				Frequency: r.Frequency,
+			},
+		}}, datalogger.Stages...)
+	}
+
+	r.datalogger = &datalogger
+
+	return nil
+}
+
+// Derived returns a ResponseType when there is only a single set of derived Response stages.
+func (r *Response) Derived(data []byte) (*ResponseType, error) {
+
+	var derived ResponseType
+	if err := xml.Unmarshal(data, &derived); err != nil {
+		return nil, err
+	}
+
+	// must have at least an instrument sensitivity or polynomial
+	if derived.InstrumentSensitivity == nil && derived.InstrumentPolynomial == nil {
+		return nil, nil
+	}
+
+	var stages []ResponseStageType
+	for n, s := range derived.Stages {
+		stage, err := s.Clone()
+		if err != nil {
+			return nil, err
+		}
+
+		if stage.PolesZeros != nil {
+			stage.PolesZeros.Name = fmt.Sprintf("%sstage_%d", r.Prefix, n+1)
+		}
+		if stage.Coefficients != nil {
+			stage.Coefficients.Name = fmt.Sprintf("%sstage_%d", r.Prefix, n+1)
+		}
+		if stage.Polynomial != nil {
+			stage.Polynomial.Name = fmt.Sprintf("%sstage_%d", r.Prefix, n+1)
+		}
+		stage.Number = n + 1
+
+		stages = append(stages, stage)
+	}
+
+	derived.Stages = stages
+
+	return &derived, nil
+}
+
+// Coeffs returns a slice of PolynomialCoeffiencent values present in the Response.
+func (r *Response) Coeffs() []PolynomialCoefficient {
+	var coeffs []PolynomialCoefficient
+
+	if p := r.Polynomial(); p != nil && len(p.Coefficients) > 0 {
+		coeffs = append(coeffs, PolynomialCoefficient{
+			Number: len(coeffs) + 1,
+			Value:  p.Coefficients[0].Value,
+		})
+	}
+
+	if p := r.Polynomial(); p != nil && len(p.Coefficients) > 1 {
+		if scale := r.Scale(); scale != 0.0 {
+			coeffs = append(coeffs, PolynomialCoefficient{
+				Number: len(coeffs) + 1,
+				Value:  p.Coefficients[1].Value / scale,
+			})
+		}
+	}
+
+	return coeffs
+}
+
+// Scale calculates the overall response scale factor.
+func (r *Response) Scale() float64 {
+	scale := 1.0
+	for _, s := range r.stages {
+		if s.StageGain == nil || s.StageGain.Value == 0.0 {
+			continue
+		}
+		scale *= s.StageGain.Value
+	}
+	return scale
+}
+
+// Normalise adjusts the labels and stage gains of a Response.
+func (r *Response) Normalise() error {
+	var stages []ResponseStageType
+	for n, s := range append(r.sensor.Stages, r.datalogger.Stages...) {
+
+		stage, err := s.Clone()
+		if err != nil {
+			return err
+		}
+
+		if stage.PolesZeros != nil {
+			stage.PolesZeros.Name = fmt.Sprintf("%sstage_%d", r.Prefix, n+1)
+			for i := range stage.PolesZeros.Zeros {
+				stage.PolesZeros.Zeros[i].Number = i + 1
+			}
+			for i := range stage.PolesZeros.Poles {
+				stage.PolesZeros.Poles[i].Number = i + 1
+			}
+		}
+		if stage.Coefficients != nil {
+			stage.Coefficients.Name = fmt.Sprintf("%sstage_%d", r.Prefix, n+1)
+			for i := range stage.Coefficients.Numerators {
+				stage.Coefficients.Numerators[i].Number = i + 1
+			}
+			for i := range stage.Coefficients.Denominators {
+				stage.Coefficients.Denominators[i].Number = i + 1
+			}
+		}
+		if stage.Polynomial != nil {
+			stage.Polynomial.Name = fmt.Sprintf("%sstage_%d", r.Prefix, n+1)
+			for i := range stage.Polynomial.Coefficients {
+				stage.Polynomial.Coefficients[i].Number = i + 1
+			}
+		}
+
+		stage.Number = n + 1
+
+		if stage.StageGain != nil {
+			scale := stage.StageGain.Value
+			if stage.PolesZeros != nil {
+				g, z := stage.PolesZeros.Gain(r.Frequency), stage.PolesZeros.Gain(stage.PolesZeros.NormalizationFrequency)
+				stage.PolesZeros.NormalizationFactor = 1.0 / g
+				stage.PolesZeros.NormalizationFrequency = r.Frequency
+				scale /= (z / g)
+			}
+			stage.StageGain = &StageGain{
+				Value:     scale,
+				Frequency: r.Frequency,
+			}
+		}
+		stages = append(stages, stage)
+	}
+
+	r.stages = stages
+
+	return nil
+}
+
+// ResponseType builds a combined ResponseType from a Response.
+func (r *Response) ResponseType() (*ResponseType, error) {
+
+	if err := r.Normalise(); err != nil {
+		return nil, err
+	}
+
+	resp := ResponseType{
+		InstrumentSensitivity: func() *InstrumentSensitivity {
+			if r.sensor.InstrumentSensitivity != nil {
+				return &InstrumentSensitivity{
+					InputUnits:  r.sensor.InstrumentSensitivity.InputUnits,
+					OutputUnits: r.datalogger.InstrumentSensitivity.OutputUnits,
+					Frequency:   r.Frequency,
+					Value:       r.Scale(),
+				}
+			}
+			return nil
+		}(),
+		InstrumentPolynomial: func() *InstrumentPolynomial {
+			if poly := r.Polynomial(); poly != nil {
+				return &InstrumentPolynomial{
+					ResourceId:              "Instrument" + poly.ResourceId + ":" + r.Serial,
+					Name:                    strings.TrimRight(r.Prefix, "."),
+					InputUnits:              poly.InputUnits,
+					OutputUnits:             r.datalogger.InstrumentSensitivity.OutputUnits,
+					ApproximationType:       poly.ApproximationType,
+					FrequencyLowerBound:     poly.FrequencyLowerBound,
+					FrequencyUpperBound:     poly.FrequencyUpperBound,
+					ApproximationLowerBound: poly.ApproximationLowerBound,
+					ApproximationUpperBound: poly.ApproximationUpperBound,
+					MaximumError:            poly.MaximumError,
+					Coefficients:            r.Coeffs(),
+				}
+			}
+			return nil
+		}(),
+		Stages: r.stages,
+
+		// used for polynomial calculations
+		frequency: r.Frequency,
+	}
+
+	return &resp, nil
+}
+
+// Marshal generates an XML encoded version of the Response as a ResponseType.
+func (r *Response) Marshal() ([]byte, error) {
+	resp, err := r.ResponseType()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := xml.Marshal(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/internal/stationxml/response_type.go
+++ b/internal/stationxml/response_type.go
@@ -1,0 +1,284 @@
+package stationxml
+
+import (
+	"bytes"
+	"encoding/gob"
+	"encoding/xml"
+	"math"
+	"math/cmplx"
+)
+
+const LaplaceRadiansSecondPzTransferFunction = "LAPLACE (RADIANS/SECOND)"
+
+type Float struct {
+	Value float64 `xml:",chardata"`
+}
+
+type Units struct {
+	Name        string `xml:"Name"`
+	Description string `xml:"Description,omitempty"`
+}
+
+type ApproximationBound struct {
+	Value float64 `xml:",chardata"`
+}
+
+type NumeratorCoefficient struct {
+	I     int     `xml:"i,attr"`
+	Value float64 `xml:",chardata"`
+}
+
+type PolynomialCoefficient struct {
+	Number int     `xml:"number,attr"`
+	Value  float64 `xml:",chardata"`
+}
+
+type CoefficientNumerator struct {
+	Number int     `xml:"number,attr"`
+	Value  float64 `xml:",chardata"`
+}
+
+type CoefficientDenominator struct {
+	Number int     `xml:"number,attr"`
+	Value  float64 `xml:",chardata"`
+}
+
+type PoleZero struct {
+	Number int `xml:"number,attr"`
+
+	Real      Float `xml:"Real"`
+	Imaginary Float `xml:"Imaginary"`
+}
+
+type CoefficientsType struct {
+	ResourceId  string `xml:"resourceId,attr,omitempty"`
+	Name        string `xml:"name,attr,omitempty"`
+	Description string `xml:"description,attr,omitempty"`
+
+	InputUnits             Units  `xml:"InputUnits"`
+	OutputUnits            Units  `xml:"OutputUnits"`
+	CfTransferFunctionType string `xml:"CfTransferFunctionType"`
+
+	Numerators   []CoefficientNumerator   `xml:"Numerator,omitempty"`
+	Denominators []CoefficientDenominator `xml:"Denominator,omitempty"`
+}
+
+type DecimationType struct {
+	InputSampleRate float64 `xml:"InputSampleRate"`
+	Factor          int     `xml:"Factor"`
+	Offset          int     `xml:"Offset"`
+	Delay           float64 `xml:"Delay"`
+	Correction      float64 `xml:"Correction"`
+}
+
+type FirType struct {
+	ResourceId  string `xml:"resourceId,attr"`
+	Name        string `xml:"name,attr,omitempty"`
+	Description string `xml:"description,attr,omitempty"`
+
+	InputUnits  Units  `xml:"InputUnits"`
+	OutputUnits Units  `xml:"OutputUnits"`
+	Symmetry    string `xml:"Symmetry"`
+
+	NumeratorCoefficients []NumeratorCoefficient `xml:"NumeratorCoefficient"`
+}
+
+type PolesZerosType struct {
+	ResourceId  string `xml:"resourceId,attr"`
+	Name        string `xml:"name,attr,omitempty"`
+	Description string `xml:"description,attr,omitempty"`
+
+	InputUnits  Units `xml:"InputUnits"`
+	OutputUnits Units `xml:"OutputUnits"`
+
+	PzTransferFunctionType string  `xml:"PzTransferFunctionType"`
+	NormalizationFactor    float64 `xml:"NormalizationFactor"`
+	NormalizationFrequency float64 `xml:"NormalizationFrequency"`
+
+	Zeros []PoleZero `xml:"Zero"`
+	Poles []PoleZero `xml:"Pole"`
+}
+
+// Gain ccalculates the poles and zeros response gain at a given frequency
+func (pz PolesZerosType) Gain(freq float64) float64 {
+
+	var w complex128
+	switch pz.PzTransferFunctionType {
+	case LaplaceRadiansSecondPzTransferFunction:
+		w = complex(0.0, 2.0*math.Pi*freq)
+	default:
+		w = complex(0.0, freq)
+	}
+
+	h := complex(float64(1.0), float64(0.0))
+
+	for _, zero := range pz.Zeros {
+		h *= (w - complex(zero.Real.Value, zero.Imaginary.Value))
+	}
+
+	for _, pole := range pz.Poles {
+		h /= (w - complex(pole.Real.Value, pole.Imaginary.Value))
+	}
+
+	return cmplx.Abs(h)
+}
+
+type PolynomialType struct {
+	ResourceId  string `xml:"resourceId,attr,omitempty"`
+	Name        string `xml:"name,attr,omitempty"`
+	Description string `xml:"description,attr,omitempty"`
+
+	InputUnits  Units `xml:"InputUnits"`
+	OutputUnits Units `xml:"OutputUnits"`
+
+	ApproximationType       string             `xml:"ApproximationType"`
+	FrequencyLowerBound     float64            `xml:"FrequencyLowerBound"`
+	FrequencyUpperBound     float64            `xml:"FrequencyUpperBound"`
+	ApproximationLowerBound ApproximationBound `xml:"ApproximationLowerBound"`
+	ApproximationUpperBound ApproximationBound `xml:"ApproximationUpperBound"`
+	MaximumError            float64            `xml:"MaximumError"`
+
+	Coefficients []PolynomialCoefficient `xml:"Coefficient,omitempty"`
+}
+
+func (p PolynomialType) Value(input float64) float64 {
+	var value float64
+	for n, c := range p.Coefficients {
+		value += c.Value * math.Pow(input, float64(n))
+	}
+	return value
+}
+
+type StageGain struct {
+	Value     float64 `xml:"Value"`
+	Frequency float64 `xml:"Frequency"`
+}
+
+type ResponseStageType struct {
+	Number int `xml:"number,attr"`
+
+	Coefficients *CoefficientsType `xml:"Coefficients,omitempty"`
+	Decimation   *DecimationType   `xml:"Decimation,omitempty"`
+	FIR          *FirType          `xml:"FIR,omitempty"`
+	PolesZeros   *PolesZerosType   `xml:"PolesZeros,omitempty"`
+	Polynomial   *PolynomialType   `xml:"Polynomial,omitempty"`
+
+	StageGain *StageGain `xml:"StageGain,omitempty"`
+}
+
+// clone two responses to avoid shared backing arrays
+func (r *ResponseStageType) Clone() (ResponseStageType, error) {
+
+	var buff bytes.Buffer
+
+	if err := gob.NewEncoder(&buff).Encode(r); err != nil {
+		return ResponseStageType{}, err
+	}
+
+	var c ResponseStageType
+	if err := gob.NewDecoder(&buff).Decode(&c); err != nil {
+		return ResponseStageType{}, err
+	}
+
+	return c, nil
+}
+
+type InstrumentSensitivity struct {
+	Value       float64 `xml:"Value"`
+	Frequency   float64 `xml:"Frequency"`
+	InputUnits  Units   `xml:"InputUnits"`
+	OutputUnits Units   `xml:"OutputUnits"`
+}
+
+type InstrumentPolynomial struct {
+	ResourceId  string `xml:"resourceId,attr,omitempty"`
+	Name        string `xml:"name,attr"`
+	Description string `xml:"description,attr,omitempty"`
+
+	InputUnits  Units `xml:"InputUnits"`
+	OutputUnits Units `xml:"OutputUnits"`
+
+	ApproximationType       string             `xml:"ApproximationType"`
+	FrequencyLowerBound     float64            `xml:"FrequencyLowerBound"`
+	FrequencyUpperBound     float64            `xml:"FrequencyUpperBound"`
+	ApproximationLowerBound ApproximationBound `xml:"ApproximationLowerBound"`
+	ApproximationUpperBound ApproximationBound `xml:"ApproximationUpperBound"`
+	MaximumError            float64            `xml:"MaximumError"`
+
+	Coefficients []PolynomialCoefficient `xml:"Coefficient,omitempty"`
+}
+
+// ResponseType is a struct that mimics the StationXML ResponseType element, but is not constrained to a particular version.
+type ResponseType struct {
+	XMLName    xml.Name `xml:"Response"`
+	ResourceId string   `xml:"resourceId,attr,omitempty"`
+
+	InstrumentSensitivity *InstrumentSensitivity `xml:"InstrumentSensitivity,omitempty"`
+	InstrumentPolynomial  *InstrumentPolynomial  `xml:"InstrumentPolynomial,omitempty"`
+
+	Stages []ResponseStageType `xml:"Stage,omitempty"`
+
+	// used for instrument polynomial calculations
+	frequency float64
+}
+
+func NewResponseType(data []byte) (*ResponseType, error) {
+	var s ResponseType
+	if err := s.Unmarshal(data); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func (r *ResponseType) Scale() float64 {
+	scale := 1.0
+	for _, s := range r.Stages {
+		if s.StageGain == nil || s.StageGain.Value == 0.0 {
+			continue
+		}
+		scale *= s.StageGain.Value
+	}
+	return scale
+}
+
+func (r *ResponseType) PolynomialType() *PolynomialType {
+	for _, s := range r.Stages {
+		if s.Polynomial == nil {
+			continue
+		}
+		return s.Polynomial
+	}
+	return nil
+}
+
+func (r *ResponseType) PolynomialCoefficients() []PolynomialCoefficient {
+	var coeffs []PolynomialCoefficient
+
+	if p := r.PolynomialType(); p != nil && len(p.Coefficients) > 0 {
+		coeffs = append(coeffs, p.Coefficients[0])
+	}
+
+	if p := r.PolynomialType(); p != nil && len(p.Coefficients) > 1 {
+		if scale := r.Scale(); scale != 0.0 {
+			coeffs = append(coeffs, PolynomialCoefficient{
+				Number: 1,
+				Value:  p.Coefficients[1].Value / scale,
+			})
+		}
+	}
+
+	return coeffs
+}
+
+func (r *ResponseType) Unmarshal(data []byte) error {
+	return xml.Unmarshal(data, r)
+}
+
+func (r ResponseType) Marshal() ([]byte, error) {
+	body, err := xml.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	head := []byte(xml.Header)
+	return append(head, append(body, '\n')...), nil
+}

--- a/internal/stationxml/root.go
+++ b/internal/stationxml/root.go
@@ -1,0 +1,206 @@
+package stationxml
+
+import (
+	"time"
+)
+
+// Equipment describes a StationXML Equipment element
+type Equipment struct {
+	Type             string
+	Description      string
+	Manufacturer     string
+	Model            string
+	SerialNumber     string
+	InstallationDate time.Time
+	RemovalDate      time.Time
+	Response         string
+}
+
+// Stream forms the main part of an individual StationXML Channel element
+type Stream struct {
+	Code string
+
+	SamplingRate float64
+	Triggered    bool
+	Types        string
+
+	Vertical float64
+	Azimuth  float64
+	Dip      float64
+
+	Datalogger Equipment
+	Sensor     Equipment
+
+	StartDate time.Time
+	EndDate   time.Time
+
+	Response *ResponseType
+}
+
+// Channel forms the main part of a set of StationXML Channel elements
+type Channel struct {
+	LocationCode string
+
+	Latitude  float64
+	Longitude float64
+	Elevation float64
+	Survey    string
+	Datum     string
+
+	Streams []Stream
+}
+
+// Station forms the main part of a StationXML Station element.
+type Station struct {
+	Code        string
+	Name        string
+	Description string
+
+	Latitude  float64
+	Longitude float64
+	Elevation float64
+	Survey    string
+	Datum     string
+
+	StartDate time.Time
+	EndDate   time.Time
+
+	CreationDate    time.Time
+	TerminationDate time.Time
+
+	Channels []Channel
+}
+
+// Network forms the main part of a StationXML Network element.
+type Network struct {
+	Code        string
+	Description string
+	Restricted  bool
+
+	Stations []Station
+}
+
+// Start returns the earliest Station start time in a Network.
+func (n Network) Start() time.Time {
+	var start time.Time
+	for _, s := range n.Stations {
+		if start.IsZero() || s.StartDate.Before(start) {
+			start = s.StartDate
+		}
+	}
+	return start
+}
+
+// End returns the latest Station end time in a Network.
+func (n Network) End() time.Time {
+	var end time.Time
+	for _, s := range n.Stations {
+		if end.IsZero() || s.EndDate.After(end) {
+			end = s.EndDate
+		}
+	}
+	return end
+}
+
+// External maps between an External Network and individal Networks.
+type External struct {
+	Code        string
+	Description string
+	Restricted  bool
+
+	Networks []Network
+}
+
+// Start returns the earliest Station start time in an External Network.
+func (e External) Start() time.Time {
+	var start time.Time
+	for _, n := range e.Networks {
+		if t := n.Start(); start.IsZero() || t.Before(start) {
+			start = t
+		}
+	}
+	return start
+}
+
+// End returns the latest Station end time in an External Network.
+func (e External) End() time.Time {
+	var end time.Time
+	for _, n := range e.Networks {
+		if t := n.End(); end.IsZero() || t.After(end) {
+			end = t
+		}
+	}
+	return end
+}
+
+// Root describes the standard StationXML layout which can be used as the barebones for building version specific encoders.
+type Root struct {
+	Source string
+	Sender string
+	Module string
+	Create bool
+
+	Externals []External
+}
+
+// ExternalCode returns the network code of the first External entry in the Root structure, this is aimed at building single entry file names.
+func (r Root) ExternalCode() string {
+	for _, e := range r.Externals {
+		return e.Code
+	}
+	return ""
+}
+
+// NetworkCode returns the network code of the first Network entry in the Root structure, this is aimed at building single entry file names.
+func (r Root) NetworkCode() string {
+	for _, e := range r.Externals {
+		for _, n := range e.Networks {
+			return n.Code
+		}
+	}
+	return ""
+}
+
+// StationCode returns the station code of the first Station entry in the Root structure, this is aimed at building single entry file names.
+func (r Root) StationCode() string {
+	for _, e := range r.Externals {
+		for _, n := range e.Networks {
+			for _, s := range n.Stations {
+				return s.Code
+			}
+		}
+	}
+	return ""
+}
+
+// Single builds a Root structure for the given station code.
+func (r Root) Single(code string) (Root, bool) {
+	for _, e := range r.Externals {
+		for _, n := range e.Networks {
+			for _, s := range n.Stations {
+				if s.Code != code {
+					continue
+				}
+
+				root := Root{
+					Source: r.Source,
+					Sender: r.Sender,
+					Module: r.Module,
+					Create: r.Create,
+
+					Externals: []External{{
+						Code: e.Code,
+						Networks: []Network{{
+							Code:     n.Code,
+							Stations: []Station{s},
+						}},
+					}},
+				}
+
+				return root, true
+			}
+		}
+	}
+
+	return Root{}, false
+}

--- a/internal/stationxml/site.go
+++ b/internal/stationxml/site.go
@@ -1,0 +1,19 @@
+package stationxml
+
+// ToSiteSurey returns the survey notes fro a given survey method.
+func ToSiteSurvey(survey string) string {
+	switch survey {
+	case "Unknown":
+		return "Location estimation method is unknown"
+	case "External GPS Device":
+		return "Location estimated from external GPS measurement"
+	case "Internal GPS Clock":
+		return "Location estimated from internal GPS clock"
+	case "Topographic Map":
+		return "Location estimated from topographic map"
+	case "Site Survey":
+		return "Location estimated from plans and survey to mark"
+	default:
+		return "Location estimation method is unknown"
+	}
+}

--- a/resp/files/combined_Canterbury-Seismic-Instruments_Cusp_200sps.xml
+++ b/resp/files/combined_Canterbury-Seismic-Instruments_Cusp_200sps.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <InstrumentSensitivity>
     <Value>1e+06</Value>
@@ -11,7 +11,7 @@
     </OutputUnits>
   </InstrumentSensitivity>
   <Stage number="1">
-    <Coefficients resourceId="Coefficients#CUSP-200" name="">
+    <Coefficients resourceId="Coefficients#CUSP-200">
       <InputUnits>
         <Name>V</Name>
       </InputUnits>

--- a/resp/files/combined_Canterbury-Seismic-Instruments_EQR120_200sps.xml
+++ b/resp/files/combined_Canterbury-Seismic-Instruments_EQR120_200sps.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <InstrumentSensitivity>
     <Value>1e+06</Value>
@@ -11,7 +11,7 @@
     </OutputUnits>
   </InstrumentSensitivity>
   <Stage number="1">
-    <Coefficients resourceId="Coefficients#CUSP-200" name="">
+    <Coefficients resourceId="Coefficients#CUSP-200">
       <InputUnits>
         <Name>V</Name>
       </InputUnits>

--- a/resp/files/combined_GEM_Systems_GSM-19-1s.xml
+++ b/resp/files/combined_GEM_Systems_GSM-19-1s.xml
@@ -1,7 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <InstrumentSensitivity>
-    <Value>100.0</Value>
-    <Frequency>0.0</Frequency>
+    <Value>100</Value>
+    <Frequency>0</Frequency>
     <InputUnits>
       <Name>nT</Name>
     </InputUnits>
@@ -18,7 +19,7 @@
         <Name>count</Name>
       </OutputUnits>
       <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
-      <Numerator number="0">1.0</Numerator>
+      <Numerator number="0">1</Numerator>
     </Coefficients>
     <Decimation>
       <InputSampleRate>1</InputSampleRate>
@@ -28,8 +29,8 @@
       <Correction>0</Correction>
     </Decimation>
     <StageGain>
-      <Value>100.0</Value>
-      <Frequency>0.0</Frequency>
+      <Value>100</Value>
+      <Frequency>0</Frequency>
     </StageGain>
   </Stage>
 </Response>

--- a/resp/files/combined_SAIC_BPR-Subsystem_BPR-Subsystem_Z_15s.xml
+++ b/resp/files/combined_SAIC_BPR-Subsystem_BPR-Subsystem_Z_15s.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <InstrumentSensitivity>
     <Value>149253.73134328358</Value>
@@ -10,7 +11,7 @@
     </OutputUnits>
   </InstrumentSensitivity>
   <Stage number="1">
-    <Coefficients resourceId="Coefficients#DART-15s" name="">
+    <Coefficients resourceId="Coefficients#DART-15s">
       <InputUnits>
         <Name>m</Name>
       </InputUnits>

--- a/resp/files/derived_Water-Depth-10s.xml
+++ b/resp/files/derived_Water-Depth-10s.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <InstrumentSensitivity>
     <Value>10000</Value>
@@ -11,7 +11,7 @@
     </OutputUnits>
   </InstrumentSensitivity>
   <Stage number="1">
-    <Coefficients resourceId="Coefficients#WaterDepth0.1" name="">
+    <Coefficients resourceId="Coefficients#WaterDepth0.1">
       <InputUnits>
         <Name>m</Name>
       </InputUnits>

--- a/resp/files/derived_Water-Depth-10sps.xml
+++ b/resp/files/derived_Water-Depth-10sps.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <InstrumentSensitivity>
     <Value>10000</Value>
@@ -11,7 +11,7 @@
     </OutputUnits>
   </InstrumentSensitivity>
   <Stage number="1">
-    <Coefficients resourceId="Coefficients#WaterDepth10" name="">
+    <Coefficients resourceId="Coefficients#WaterDepth10">
       <InputUnits>
         <Name>m</Name>
       </InputUnits>

--- a/resp/files/derived_Water-Depth-1s.xml
+++ b/resp/files/derived_Water-Depth-1s.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <InstrumentSensitivity>
     <Value>10000</Value>
@@ -11,7 +11,7 @@
     </OutputUnits>
   </InstrumentSensitivity>
   <Stage number="1">
-    <Coefficients resourceId="Coefficients#WaterDepth1" name="">
+    <Coefficients resourceId="Coefficients#WaterDepth1">
       <InputUnits>
         <Name>m</Name>
       </InputUnits>

--- a/resp/files/derived_Water-Depth.xml
+++ b/resp/files/derived_Water-Depth.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <InstrumentSensitivity>
     <Value>10000</Value>
@@ -11,7 +11,7 @@
     </OutputUnits>
   </InstrumentSensitivity>
   <Stage number="1">
-    <Coefficients resourceId="Coefficients#WaterDepth0.1" name="">
+    <Coefficients resourceId="Coefficients#WaterDepth0.1">
       <InputUnits>
         <Name>m</Name>
       </InputUnits>

--- a/resp/files/sensor_Danish_Meteorological_Institue_FGE.xml
+++ b/resp/files/sensor_Danish_Meteorological_Institue_FGE.xml
@@ -10,11 +10,11 @@
     <ApproximationType>MACLAURIN</ApproximationType>
     <FrequencyLowerBound>0</FrequencyLowerBound>
     <FrequencyUpperBound>0</FrequencyUpperBound>
-    <!-- <ApproximationLowerBound>0</ApproximationLowerBound> -->
-    <!-- <ApproximationUpperBound>20</ApproximationUpperBound> -->
+    <ApproximationLowerBound>0</ApproximationLowerBound>
+    <ApproximationUpperBound>20</ApproximationUpperBound>
     <MaximumError>0</MaximumError>
-    <Coefficient number="0">0.0</Coefficient>
-    <Coefficient number="1">38000.0</Coefficient>
+    <Coefficient number="0">0</Coefficient>
+    <Coefficient number="1">38000</Coefficient>
   </InstrumentPolynomial>
   <Stage number="1">
     <Polynomial>
@@ -27,11 +27,11 @@
       <ApproximationType>MACLAURIN</ApproximationType>
       <FrequencyLowerBound>0</FrequencyLowerBound>
       <FrequencyUpperBound>0</FrequencyUpperBound>
-      <!-- <ApproximationLowerBound>0</ApproximationLowerBound> -->
-      <!-- <ApproximationUpperBound>20</ApproximationUpperBound> -->
+      <ApproximationLowerBound>0</ApproximationLowerBound>
+      <ApproximationUpperBound>20</ApproximationUpperBound>
       <MaximumError>0</MaximumError>
-      <Coefficient number="0">0.0</Coefficient>
-      <Coefficient number="1">38000.0</Coefficient>
+      <Coefficient number="0">0</Coefficient>
+      <Coefficient number="1">38000</Coefficient>
     </Polynomial>
   </Stage>
 </Response>

--- a/resp/files/sensor_Danish_Meteorological_Institue_FGE_Temperature.xml
+++ b/resp/files/sensor_Danish_Meteorological_Institue_FGE_Temperature.xml
@@ -9,13 +9,13 @@
       <Name>V</Name>
     </OutputUnits>
     <ApproximationType>MACLAURIN</ApproximationType>
-    <FrequencyLowerBound>0.0</FrequencyLowerBound>
-    <FrequencyUpperBound>0.0</FrequencyUpperBound>
-    <!-- <ApproximationLowerBound>0</ApproximationLowerBound> -->
-    <!-- <ApproximationUpperBound>20</ApproximationUpperBound> -->
-    <MaximumError>0.0</MaximumError>
-    <Coefficient number="0">-273.0</Coefficient>
-    <Coefficient number="1">200.0</Coefficient>
+    <FrequencyLowerBound>0</FrequencyLowerBound>
+    <FrequencyUpperBound>0</FrequencyUpperBound>
+    <ApproximationLowerBound>0</ApproximationLowerBound>
+    <ApproximationUpperBound>20</ApproximationUpperBound>
+    <MaximumError>0</MaximumError>
+    <Coefficient number="0">-273</Coefficient>
+    <Coefficient number="1">200</Coefficient>
   </InstrumentPolynomial>
   <Stage number="1">
     <Polynomial>
@@ -27,13 +27,13 @@
         <Name>V</Name>
       </OutputUnits>
       <ApproximationType>MACLAURIN</ApproximationType>
-      <FrequencyLowerBound>0.0</FrequencyLowerBound>
-      <FrequencyUpperBound>0.0</FrequencyUpperBound>
-      <!-- <ApproximationLowerBound>0</ApproximationLowerBound> -->
-      <!-- <ApproximationUpperBound>20</ApproximationUpperBound> -->
-      <MaximumError>0.0</MaximumError>
-      <Coefficient number="0">-273.0</Coefficient>
-      <Coefficient number="1">200.0</Coefficient>
+      <FrequencyLowerBound>0</FrequencyLowerBound>
+      <FrequencyUpperBound>0</FrequencyUpperBound>
+      <ApproximationLowerBound>0</ApproximationLowerBound>
+      <ApproximationUpperBound>20</ApproximationUpperBound>
+      <MaximumError>0</MaximumError>
+      <Coefficient number="0">-273</Coefficient>
+      <Coefficient number="1">200</Coefficient>
     </Polynomial>
   </Stage>
 </Response>

--- a/resp/resp_test.go
+++ b/resp/resp_test.go
@@ -1,0 +1,75 @@
+package resp
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GeoNet/delta/internal/stationxml"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAuto(t *testing.T) {
+	names, err := fs.Glob(os.DirFS("auto"), "*.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range names {
+		t.Run("check resp file: "+name, func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := fs.ReadFile(files, filepath.Join("auto", name))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			snippet, err := stationxml.NewResponseType(raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			data, err := snippet.Marshal()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !cmp.Equal(raw, data) {
+				t.Error(cmp.Diff(raw, data))
+			}
+		})
+	}
+}
+
+func TestFiles(t *testing.T) {
+	names, err := fs.Glob(os.DirFS("files"), "*.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range names {
+		t.Run("check resp file: "+name, func(t *testing.T) {
+
+			raw, err := fs.ReadFile(files, filepath.Join("files", name))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			snippet, err := stationxml.NewResponseType(raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			data, err := snippet.Marshal()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !cmp.Equal(raw, data) {
+				t.Error(cmp.Diff(raw, data))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the code to manipulate parts of a StationXML response type ,  it can join and normalise responses from different sensors and dataloggers.

It can adjust for different calibration values, gains, or preamps. 

It can also handle scaling of polynomial responses in a similar mannner.

This code only impacts the current system by adding a test in the `resp` directory to check that the generated or edited xml response files can read and decoded.

The next PRs will relate to encoding of this type into actual StationXML versions, as with the full StationXML root elements. 