### PR TITLE
Add a telemetry table

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -24,6 +24,7 @@ Meta information for the GeoNet equipment network.
 * `components.csv` - Individual sensor elements including measurement position and responses.
 * `channels.csv` - Individual datalogger recording elements including digitiser position, sampling rate, and responses.
 * [`preamps.csv`](#preamps) - site specific settings applied to individual datalogger pre-amplification that may impact overall sensitivities.
+* [`telemetries.csv`](#telemetries) - site specific settings applied to datalogger and sensor connections that may use analogue telemetry.
 
 * `cameras.csv` - Installed field cameras.
 * `doases.csv` - Installed field DOAS (Differential Optical Absorption Spectrometer) equipment.
@@ -360,6 +361,19 @@ and the expected response. Some digitisers have different nominal responses for 
 | _Location_ | Recording sensor site _Location_ |
 | _Subsource_ | The sensor channel _Subsource_ which has the preamp configured (e.g _"Z"_). An empty value indicates all channels have this setting for the provided _Location_.
 | _Scale Factor_ | The datalogger pre-amp scale factor used for this time span. These tend to be integer steps and may be referenced as **gain** settings.
+| _Start_ | Gain start time|
+| _Stop_ | Gain stop time|
+
+#### _TELEMETRIES_ ####
+
+Sometimes the datalogger and the sensor are not at the same location. Usually this means there is some form of analogue link between the two, either a dedicated
+telephone line, or an FM radio link. This table allows this to be documented, and provides a mechanism to adjust the signal gains if known.
+
+| Field | Description | Units |
+| --- | --- | --- |
+| _Station_ | Datalogger recording _Station_|
+| _Location_ | Recording sensor site _Location_ |
+| _Gain_ | The telemetry gain factor for the analogue link, this represents the amplification of the signal if appropriate, an empty value is assumed to be 1.0
 | _Start_ | Gain start time|
 | _Stop_ | Gain stop time|
 

--- a/install/README.md
+++ b/install/README.md
@@ -361,8 +361,8 @@ and the expected response. Some digitisers have different nominal responses for 
 | _Location_ | Recording sensor site _Location_ |
 | _Subsource_ | The sensor channel _Subsource_ which has the preamp configured (e.g _"Z"_). An empty value indicates all channels have this setting for the provided _Location_.
 | _Scale Factor_ | The datalogger pre-amp scale factor used for this time span. These tend to be integer steps and may be referenced as **gain** settings.
-| _Start_ | Gain start time|
-| _Stop_ | Gain stop time|
+| _Start_ | Preamp start time|
+| _Stop_ | Preamp stop time|
 
 #### _TELEMETRIES_ ####
 
@@ -373,9 +373,9 @@ telephone line, or an FM radio link. This table allows this to be documented, an
 | --- | --- | --- |
 | _Station_ | Datalogger recording _Station_|
 | _Location_ | Recording sensor site _Location_ |
-| _Gain_ | The telemetry gain factor for the analogue link, this represents the amplification of the signal if appropriate, an empty value is assumed to be 1.0
-| _Start_ | Gain start time|
-| _Stop_ | Gain stop time|
+| _Scale Factor_ | The telemetry gain factor for the analogue link, this represents the amplification of the signal if appropriate, an empty value is assumed to be 1.0
+| _Start_ | Telemetry start time|
+| _Stop_ | Telemetry stop time|
 
 ### CAMERA ###
 

--- a/install/telemetries.csv
+++ b/install/telemetries.csv
@@ -1,0 +1,2 @@
+Station,Location,Gain,Start Date,End Date
+KAVZ,10,,2004-12-03T22:00:00Z,2004-12-14T19:00:00Z

--- a/install/telemetries.csv
+++ b/install/telemetries.csv
@@ -1,2 +1,2 @@
-Station,Location,Gain,Start Date,End Date
+Station,Location,Scale Factor,Start Date,End Date
 KAVZ,10,,2004-12-03T22:00:00Z,2004-12-14T19:00:00Z

--- a/meta/generate/generate.go
+++ b/meta/generate/generate.go
@@ -63,7 +63,7 @@ func (g Generate) Write(w io.Writer) error {
 
 	t, err := template.New("generate").Funcs(
 		template.FuncMap{
-			"title": func(s string) string { return cases.Title(language.English).String(s) },
+			"title": func(s string) string { return cases.Title(language.English, cases.NoLower).String(s) },
 			"join":  func(k string, s []string) string { return strings.Join(s, k) },
 		},
 	).Parse(generateTemplate)

--- a/meta/generate/main.go
+++ b/meta/generate/main.go
@@ -41,6 +41,7 @@ func main() {
 			"sites":               {"Site"},
 			"stations":            {"Station"},
 			"streams":             {"Stream"},
+			"telemetries":         {"Telemetry"},
 			"views":               {"View"},
 			"visibilities":        {"Visibility"},
 			"channels":            {"Channel"},

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -10,6 +10,11 @@ import (
 // and that times are in UTC.
 const DateTimeFormat = "2006-01-02T15:04:05Z"
 
+// Format outputs a Time using the DateTimeFormat format.
+func Format(t time.Time) string {
+	return t.Format(DateTimeFormat)
+}
+
 // Reference describes a location where measurements can be taken.
 type Reference struct {
 	// Code is used to identify the measurement location.

--- a/meta/set.go
+++ b/meta/set.go
@@ -39,6 +39,7 @@ const (
 	SensorsFile      = "install/sensors.csv"
 	SessionsFile     = "install/sessions.csv"
 	StreamsFile      = "install/streams.csv"
+	TelemetriesFile  = "install/telemetries.csv"
 
 	ConstituentsFile = "environment/constituents.csv"
 	FeaturesFile     = "environment/features.csv"
@@ -87,6 +88,7 @@ type Set struct {
 	installedSensors    InstalledSensorList
 	sessions            SessionList
 	streams             StreamList
+	telemetries         TelemetryList
 
 	constituents ConstituentList
 	features     FeatureList
@@ -129,6 +131,7 @@ func (s *Set) files() map[string]List {
 		SensorsFile:      &s.installedSensors,
 		SessionsFile:     &s.sessions,
 		StreamsFile:      &s.streams,
+		TelemetriesFile:  &s.telemetries,
 
 		ConstituentsFile: &s.constituents,
 		FeaturesFile:     &s.features,

--- a/meta/set_auto.go
+++ b/meta/set_auto.go
@@ -234,6 +234,13 @@ func (s Set) Streams() []Stream {
 	return streams
 }
 
+// Telemetries is a helper function to return a slice copy of Telemetry values.
+func (s Set) Telemetries() []Telemetry {
+	telemetries := make([]Telemetry, len(s.telemetries))
+	copy(telemetries, s.telemetries)
+	return telemetries
+}
+
 // Views is a helper function to return a slice copy of View values.
 func (s Set) Views() []View {
 	views := make([]View, len(s.views))

--- a/meta/telemetry.go
+++ b/meta/telemetry.go
@@ -1,0 +1,156 @@
+package meta
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/GeoNet/delta/internal/expr"
+)
+
+const (
+	telemetryStation = iota
+	telemetryLocation
+	telemetryGain
+	telemetryStart
+	telemetryEnd
+	telemetryLast
+)
+
+var telemetryHeaders Header = map[string]int{
+	"Station":    telemetryStation,
+	"Location":   telemetryLocation,
+	"Gain":       telemetryGain,
+	"Start Date": telemetryStart,
+	"End Date":   telemetryEnd,
+}
+
+// Telemetry describes when a datalogger is connected to a sensor via analogue telemetry (e.g. FM radio).
+type Telemetry struct {
+	Span
+
+	Station  string
+	Location string
+	Gain     float64
+
+	gain string
+}
+
+// String implements the Stringer interface.
+func (t Telemetry) String() string {
+	return strings.Join([]string{t.Station, t.Location, Format(t.Start)}, " ")
+}
+
+// Id returns a unique string which can be used for sorting or checking.
+func (t Telemetry) Id() string {
+	return strings.Join([]string{t.Station, t.Location}, ":")
+}
+
+// Less returns whether one Telemetry sorts before another.
+func (t Telemetry) Less(telemetry Telemetry) bool {
+	switch {
+	case t.Station < telemetry.Station:
+		return true
+	case t.Station > telemetry.Station:
+		return false
+	case t.Location < telemetry.Location:
+		return true
+	case t.Location > telemetry.Location:
+		return false
+	case t.Span.Start.Before(telemetry.Span.Start):
+		return true
+	default:
+		return false
+	}
+}
+
+type TelemetryList []Telemetry
+
+func (t TelemetryList) Len() int           { return len(t) }
+func (t TelemetryList) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
+func (t TelemetryList) Less(i, j int) bool { return t[i].Less(t[j]) }
+
+func (t TelemetryList) encode() [][]string {
+	var data [][]string
+
+	data = append(data, telemetryHeaders.Columns())
+	for _, v := range t {
+		data = append(data, []string{
+			strings.TrimSpace(v.Station),
+			strings.TrimSpace(v.Location),
+			strings.TrimSpace(v.gain),
+			v.Start.Format(DateTimeFormat),
+			v.End.Format(DateTimeFormat),
+		})
+	}
+
+	return data
+}
+
+// toFloat64 is used in decoding to allow mathematical expressions as well as actual floating point values,
+// if the string parameter is empty the default value will be returned.
+func (t *TelemetryList) toFloat64(str string, def float64) (float64, error) {
+	switch s := strings.TrimSpace(str); {
+	case s != "":
+		return expr.ToFloat64(s)
+	default:
+		return def, nil
+	}
+}
+
+func (t *TelemetryList) decode(data [][]string) error {
+	var telemetries []Telemetry
+
+	// needs more than a comment line
+	if !(len(data) > 1) {
+		return nil
+	}
+
+	fields := telemetryHeaders.Fields(data[0])
+	for _, v := range data[1:] {
+		d := fields.Remap(v)
+
+		gain, err := t.toFloat64(d[telemetryGain], 1.0)
+		if err != nil {
+			return err
+		}
+
+		start, err := time.Parse(DateTimeFormat, d[telemetryStart])
+		if err != nil {
+			return err
+		}
+
+		end, err := time.Parse(DateTimeFormat, d[telemetryEnd])
+		if err != nil {
+			return err
+		}
+
+		telemetries = append(telemetries, Telemetry{
+			Span: Span{
+				Start: start,
+				End:   end,
+			},
+			Gain:     gain,
+			Station:  strings.TrimSpace(d[telemetryStation]),
+			Location: strings.TrimSpace(d[telemetryLocation]),
+
+			gain: strings.TrimSpace(d[telemetryGain]),
+		})
+	}
+
+	*t = TelemetryList(telemetries)
+
+	return nil
+}
+
+func LoadTelemetries(path string) ([]Telemetry, error) {
+	var g []Telemetry
+
+	if err := LoadList(path, (*TelemetryList)(&g)); err != nil {
+		return nil, err
+	}
+
+	sort.Sort(TelemetryList(g))
+
+	return g, nil
+}

--- a/meta/telemetry.go
+++ b/meta/telemetry.go
@@ -11,29 +11,29 @@ import (
 const (
 	telemetryStation = iota
 	telemetryLocation
-	telemetryGain
+	telemetryScaleFactor
 	telemetryStart
 	telemetryEnd
 	telemetryLast
 )
 
 var telemetryHeaders Header = map[string]int{
-	"Station":    telemetryStation,
-	"Location":   telemetryLocation,
-	"Gain":       telemetryGain,
-	"Start Date": telemetryStart,
-	"End Date":   telemetryEnd,
+	"Station":      telemetryStation,
+	"Location":     telemetryLocation,
+	"Scale Factor": telemetryScaleFactor,
+	"Start Date":   telemetryStart,
+	"End Date":     telemetryEnd,
 }
 
 // Telemetry describes when a datalogger is connected to a sensor via analogue telemetry (e.g. FM radio).
 type Telemetry struct {
 	Span
 
-	Station  string
-	Location string
-	Gain     float64
+	Station     string
+	Location    string
+	ScaleFactor float64
 
-	gain string
+	factor string
 }
 
 // String implements the Stringer interface.
@@ -78,7 +78,7 @@ func (t TelemetryList) encode() [][]string {
 		data = append(data, []string{
 			strings.TrimSpace(v.Station),
 			strings.TrimSpace(v.Location),
-			strings.TrimSpace(v.gain),
+			strings.TrimSpace(v.factor),
 			v.Start.Format(DateTimeFormat),
 			v.End.Format(DateTimeFormat),
 		})
@@ -110,7 +110,7 @@ func (t *TelemetryList) decode(data [][]string) error {
 	for _, v := range data[1:] {
 		d := fields.Remap(v)
 
-		gain, err := t.toFloat64(d[telemetryGain], 1.0)
+		factor, err := t.toFloat64(d[telemetryScaleFactor], 1.0)
 		if err != nil {
 			return err
 		}
@@ -130,11 +130,11 @@ func (t *TelemetryList) decode(data [][]string) error {
 				Start: start,
 				End:   end,
 			},
-			Gain:     gain,
-			Station:  strings.TrimSpace(d[telemetryStation]),
-			Location: strings.TrimSpace(d[telemetryLocation]),
+			ScaleFactor: factor,
+			Station:     strings.TrimSpace(d[telemetryStation]),
+			Location:    strings.TrimSpace(d[telemetryLocation]),
 
-			gain: strings.TrimSpace(d[telemetryGain]),
+			factor: strings.TrimSpace(d[telemetryScaleFactor]),
 		})
 	}
 

--- a/meta/telemetry_test.go
+++ b/meta/telemetry_test.go
@@ -1,0 +1,22 @@
+package meta
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTelemetry(t *testing.T) {
+
+	t.Run("check telemetry", testListFunc("testdata/telemetries.csv", &TelemetryList{
+		Telemetry{
+			Station:  "KAVZ",
+			Location: "10",
+			Span: Span{
+				Start: time.Date(2004, 12, 3, 22, 0, 0, 0, time.UTC),
+				End:   time.Date(2004, 12, 14, 19, 0, 0, 0, time.UTC),
+			},
+			Gain: 1.0,
+			gain: "",
+		},
+	}))
+}

--- a/meta/telemetry_test.go
+++ b/meta/telemetry_test.go
@@ -15,8 +15,8 @@ func TestTelemetry(t *testing.T) {
 				Start: time.Date(2004, 12, 3, 22, 0, 0, 0, time.UTC),
 				End:   time.Date(2004, 12, 14, 19, 0, 0, 0, time.UTC),
 			},
-			Gain: 1.0,
-			gain: "",
+			ScaleFactor: 1.0,
+			factor:      "",
 		},
 	}))
 }

--- a/meta/testdata/telemetries.csv
+++ b/meta/testdata/telemetries.csv
@@ -1,0 +1,2 @@
+Station,Location,Gain,Start Date,End Date
+KAVZ,10,,2004-12-03T22:00:00Z,2004-12-14T19:00:00Z

--- a/meta/testdata/telemetries.csv
+++ b/meta/testdata/telemetries.csv
@@ -1,2 +1,2 @@
-Station,Location,Gain,Start Date,End Date
+Station,Location,Scale Factor,Start Date,End Date
 KAVZ,10,,2004-12-03T22:00:00Z,2004-12-14T19:00:00Z

--- a/tests/telemetry_test.go
+++ b/tests/telemetry_test.go
@@ -33,7 +33,7 @@ var telemetryChecks = map[string]func(*meta.Set) func(t *testing.T){
 	"check for zero gain telemetries": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 			for _, v := range set.Telemetries() {
-				if v.Gain != 0.0 {
+				if v.ScaleFactor != 0.0 {
 					continue
 				}
 				t.Errorf("error: telemetry with zero gain for %q", v.String())

--- a/tests/telemetry_test.go
+++ b/tests/telemetry_test.go
@@ -1,0 +1,55 @@
+package delta_test
+
+import (
+	"testing"
+
+	"github.com/GeoNet/delta"
+	"github.com/GeoNet/delta/meta"
+)
+
+var telemetryChecks = map[string]func(*meta.Set) func(t *testing.T){
+
+	"check for overlapping telemeties": func(set *meta.Set) func(t *testing.T) {
+		return func(t *testing.T) {
+			telemetries := set.Telemetries()
+			for i := 0; i < len(telemetries); i++ {
+				for j := i + 1; j < len(telemetries); j++ {
+					if telemetries[i].Station != telemetries[j].Station {
+						continue
+					}
+					if telemetries[i].Location != telemetries[j].Location {
+						continue
+					}
+					if !telemetries[i].Span.Overlaps(telemetries[j].Span) {
+						continue
+					}
+
+					t.Errorf("error: telemetry overlap for %q", telemetries[i].String())
+				}
+			}
+		}
+	},
+
+	"check for zero gain telemetries": func(set *meta.Set) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, v := range set.Telemetries() {
+				if v.Gain != 0.0 {
+					continue
+				}
+				t.Errorf("error: telemetry with zero gain for %q", v.String())
+			}
+		}
+	},
+}
+
+func TestTelemities(t *testing.T) {
+
+	set, err := delta.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for k, v := range telemetryChecks {
+		t.Run(k, v(set))
+	}
+}


### PR DESCRIPTION
This PR tries to handle an edge case whereby the datalogger and the sensor are not at the same location and they are connected via analogue telemetry.  Either using FM radio or via leased-line modems.

This should add an extra stage in the response with notionally a gain of 1.0 (it's usually quite hard to work out the actual gain, but if this is done then the adjustment can be made here).

The main part is to add the `telemetries.csv` file and an extra related "Correction" option (very similar to the Preamp stage).

