### PR TITLE
add 50Hz Cusp-Me resp

### DIFF
--- a/resp/auto.go
+++ b/resp/auto.go
@@ -969,7 +969,7 @@ var Responses []Response = []Response{
 				},
 				Reversed: false,
 			}, {
-				DataloggerList: []string{"CUSP3D", "CUSP3C", "CUSP3C3", "CUSPM"},
+				DataloggerList: []string{"CUSP3D", "CUSP3C", "CUSP3C3", "CUSPM", "CUSP-Me"},
 				Type:           "CG",
 				Label:          "BN",
 				SampleRate:     50,

--- a/resp/responses/configurations/strongmotion.yaml
+++ b/resp/responses/configurations/strongmotion.yaml
@@ -325,6 +325,7 @@ response:
       - CUSP3C
       - CUSP3C3
       - CUSPM
+      - CUSP-Me
       type: CG
       label: BN
       samplerate: 50


### PR DESCRIPTION
Missed one, this adds the BN? response details for the Cusp-Me devices.