### PR TITLE
update delta testing to use set

### DIFF
--- a/tests/assets_test.go
+++ b/tests/assets_test.go
@@ -1,18 +1,18 @@
 package delta_test
 
 import (
-	"sort"
 	"testing"
 
+	"github.com/GeoNet/delta"
 	"github.com/GeoNet/delta/meta"
 )
 
-var testAssets = map[string]func([]meta.Asset) func(t *testing.T){
+var assetChecks = map[string]func(*meta.Set) func(t *testing.T){
 
-	"check for duplicate asset numbers": func(assets []meta.Asset) func(t *testing.T) {
+	"check for duplicate asset numbers": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 			reference := make(map[string]string)
-			for _, a := range assets {
+			for _, a := range set.Assets() {
 				if a.Number == "" {
 					continue
 				}
@@ -24,8 +24,9 @@ var testAssets = map[string]func([]meta.Asset) func(t *testing.T){
 		}
 	},
 
-	"check for duplicate equipment": func(assets []meta.Asset) func(t *testing.T) {
+	"check for duplicate equipment": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
+			assets := set.Assets()
 			for i := 0; i < len(assets); i++ {
 				for j := i + 1; j < len(assets); j++ {
 					switch {
@@ -42,30 +43,12 @@ var testAssets = map[string]func([]meta.Asset) func(t *testing.T){
 
 func TestAssets(t *testing.T) {
 
-	var assets meta.AssetList
-
-	files := map[string]string{
-		"antennas":    "../assets/antennas.csv",
-		"cameras":     "../assets/cameras.csv",
-		"dataloggers": "../assets/dataloggers.csv",
-		"metsensors":  "../assets/metsensors.csv",
-		"radomes":     "../assets/radomes.csv",
-		"receivers":   "../assets/receivers.csv",
-		"recorders":   "../assets/recorders.csv",
-		"sensors":     "../assets/sensors.csv",
+	set, err := delta.New()
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	for k, v := range files {
-		t.Run("load asset files: "+k, func(t *testing.T) {
-			var a meta.AssetList
-			loadListFile(t, v, &a)
-			assets = append(assets, a...)
-		})
-	}
-
-	sort.Sort(assets)
-
-	for k, fn := range testAssets {
-		t.Run(k, fn(assets))
+	for k, v := range assetChecks {
+		t.Run(k, v(set))
 	}
 }

--- a/tests/calibrations_test.go
+++ b/tests/calibrations_test.go
@@ -3,16 +3,17 @@ package delta_test
 import (
 	"testing"
 
+	"github.com/GeoNet/delta"
 	"github.com/GeoNet/delta/meta"
 )
 
-var testCalibrations = map[string]func([]meta.Calibration) func(t *testing.T){
+var calibrationChecks = map[string]func(*meta.Set) func(t *testing.T){
 
-	"check for calibration overlaps": func(installed []meta.Calibration) func(t *testing.T) {
+	"check for calibration overlaps": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 
 			installs := make(map[string]meta.CalibrationList)
-			for _, s := range installed {
+			for _, s := range set.Calibrations() {
 				installs[s.Id()] = append(installs[s.Id()], s)
 			}
 
@@ -41,14 +42,12 @@ var testCalibrations = map[string]func([]meta.Calibration) func(t *testing.T){
 			}
 		}
 	},
-}
 
-var testCalibrationsAssets = map[string]func([]meta.Calibration, []meta.Asset) func(t *testing.T){
-	"check for missing assets": func(installed []meta.Calibration, assets []meta.Asset) func(t *testing.T) {
+	"check for missing assets": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
-			for _, s := range installed {
+			for _, s := range set.Calibrations() {
 				var found bool
-				for _, a := range assets {
+				for _, a := range set.Assets() {
 					if a.Model != s.Model {
 						continue
 					}
@@ -62,29 +61,18 @@ var testCalibrationsAssets = map[string]func([]meta.Calibration, []meta.Asset) f
 				}
 				t.Errorf("unable to find calibration asset: %s [%s]", s.Model, s.Serial)
 			}
-
 		}
 	},
 }
 
 func TestCalibrations(t *testing.T) {
-	var installed meta.CalibrationList
-	loadListFile(t, "../install/calibrations.csv", &installed)
 
-	for k, fn := range testCalibrations {
-		t.Run(k, fn(installed))
+	set, err := delta.New()
+	if err != nil {
+		t.Fatal(err)
 	}
 
-}
-
-func TestCalibrations_Assets(t *testing.T) {
-	var installed meta.CalibrationList
-	loadListFile(t, "../install/calibrations.csv", &installed)
-
-	var sensors meta.AssetList
-	loadListFile(t, "../assets/sensors.csv", &sensors)
-
-	for k, fn := range testCalibrationsAssets {
-		t.Run(k, fn(installed, sensors))
+	for k, v := range calibrationChecks {
+		t.Run(k, v(set))
 	}
 }

--- a/tests/combined_test.go
+++ b/tests/combined_test.go
@@ -3,16 +3,15 @@ package delta_test
 import (
 	"testing"
 
+	"github.com/GeoNet/delta"
 	"github.com/GeoNet/delta/meta"
 )
 
-var testCombined = map[string]func([]meta.InstalledSensor, []meta.InstalledRecorder) func(t *testing.T){
-	"check for sensor/recorder installation location overlaps": func(sensors []meta.InstalledSensor, recorders []meta.InstalledRecorder) func(t *testing.T) {
+var combinedChecks = map[string]func(*meta.Set) func(t *testing.T){
+	"check for sensor/recorder installation location overlaps": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
-
-			var combined meta.InstalledSensorList
-			combined = append(combined, sensors...)
-			for _, r := range recorders {
+			combined := set.InstalledSensors()
+			for _, r := range set.InstalledRecorders() {
 				combined = append(combined, meta.InstalledSensor{
 					Install:  r.Install,
 					Station:  r.Station,
@@ -27,6 +26,7 @@ var testCombined = map[string]func([]meta.InstalledSensor, []meta.InstalledRecor
 				}
 				installs[s.Station] = append(installs[s.Station], s)
 			}
+
 			for _, v := range installs {
 				for i := 0; i < len(v); i++ {
 					for j := i + 1; j < len(v); j++ {
@@ -60,14 +60,12 @@ var testCombined = map[string]func([]meta.InstalledSensor, []meta.InstalledRecor
 
 func TestCombined(t *testing.T) {
 
-	var sensors meta.InstalledSensorList
-	loadListFile(t, "../install/sensors.csv", &sensors)
-
-	var recorders meta.InstalledRecorderList
-	loadListFile(t, "../install/recorders.csv", &recorders)
-
-	for k, fn := range testCombined {
-		t.Run(k, fn(sensors, recorders))
+	set, err := delta.New()
+	if err != nil {
+		t.Fatal(err)
 	}
 
+	for k, v := range combinedChecks {
+		t.Run(k, v(set))
+	}
 }

--- a/tests/connections_test.go
+++ b/tests/connections_test.go
@@ -6,13 +6,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GeoNet/delta"
 	"github.com/GeoNet/delta/meta"
 )
 
-var testConnections = map[string]func([]meta.Connection) func(t *testing.T){
+var connectionChecks = map[string]func(*meta.Set) func(t *testing.T){
 
-	"check for connection overlaps": func(connections []meta.Connection) func(t *testing.T) {
+	"check for connection overlaps": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
+			connections := set.Connections()
 			for i := 0; i < len(connections); i++ {
 				for j := i + 1; j < len(connections); j++ {
 					if connections[i].Station != connections[j].Station {
@@ -41,9 +43,10 @@ var testConnections = map[string]func([]meta.Connection) func(t *testing.T){
 			}
 		}
 	},
-	"check for connection span mismatch": func(connections []meta.Connection) func(t *testing.T) {
+
+	"check for connection span mismatch": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
-			for _, c := range connections {
+			for _, c := range set.Connections() {
 				if c.Start.After(c.End) {
 					t.Error("connection span mismatch: " + strings.Join([]string{
 						c.Station,
@@ -57,57 +60,54 @@ var testConnections = map[string]func([]meta.Connection) func(t *testing.T){
 			}
 		}
 	},
-}
 
-var testConnectionsStations = map[string]func([]meta.Connection, []meta.Station) func(t *testing.T){
-	"check for missing connection stations": func(connections []meta.Connection, list []meta.Station) func(t *testing.T) {
+	"check for missing connection stations": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 			stas := make(map[string]meta.Station)
-			for _, s := range list {
+			for _, s := range set.Stations() {
 				stas[s.Code] = s
 			}
-			for _, c := range connections {
+			for _, c := range set.Connections() {
 				if _, ok := stas[c.Station]; !ok {
 					t.Error("unknown connection station: " + c.Station)
 				}
 			}
 		}
 	},
-}
 
-var testConnectionsSites = map[string]func([]meta.Connection, []meta.Site) func(t *testing.T){
-	"check for missing connection stations": func(connections []meta.Connection, list []meta.Site) func(t *testing.T) {
+	"check for missing connection sites": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 
 			stations := make(map[string]meta.Site)
-			for _, s := range list {
+			for _, s := range set.Sites() {
 				stations[s.Station] = s
 			}
 
-			for _, c := range connections {
+			for _, c := range set.Connections() {
 				if _, ok := stations[c.Station]; !ok {
 					t.Error("unknown connection station: " + c.Station)
 				}
 			}
 		}
 	},
-	"check for missing connection site locations": func(connections []meta.Connection, list []meta.Site) func(t *testing.T) {
+
+	"check for missing connection site locations": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 
 			sites := make(map[string]map[string]meta.Site)
-			for _, s := range list {
+			for _, s := range set.Sites() {
 				if _, ok := sites[s.Station]; !ok {
 					sites[s.Station] = make(map[string]meta.Site)
 				}
 				sites[s.Station][s.Location] = s
 			}
 
-			for _, c := range connections {
+			for _, c := range set.Connections() {
 				if _, ok := sites[c.Station]; !ok {
 					t.Error("unknown connection station: " + c.Station)
 				}
 			}
-			for _, c := range connections {
+			for _, c := range set.Connections() {
 				if _, ok := sites[c.Station]; !ok {
 					continue
 				}
@@ -118,14 +118,11 @@ var testConnectionsSites = map[string]func([]meta.Connection, []meta.Site) func(
 			}
 		}
 	},
-}
 
-var testConnectionsDeployedDataloggers = map[string]func([]meta.Connection, []meta.DeployedDatalogger) func(t *testing.T){
-	"check for missing datalogger places": func(connections []meta.Connection, list []meta.DeployedDatalogger) func(t *testing.T) {
+	"check for missing datalogger places": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
-
 			places := make(map[string]string)
-			for _, d := range list {
+			for _, d := range set.DeployedDataloggers() {
 				switch d.Role {
 				case "":
 					places[d.Place] = d.Place
@@ -133,7 +130,7 @@ var testConnectionsDeployedDataloggers = map[string]func([]meta.Connection, []me
 					places[d.Place+"/"+d.Role] = d.Place
 				}
 			}
-			for _, c := range connections {
+			for _, c := range set.Connections() {
 				switch c.Role {
 				case "":
 					if _, ok := places[c.Place]; !ok {
@@ -147,24 +144,21 @@ var testConnectionsDeployedDataloggers = map[string]func([]meta.Connection, []me
 			}
 		}
 	},
-}
 
-var testConnectionsInstalledSensorAssets = map[string]func([]meta.Connection, []meta.InstalledSensor, []meta.Asset) func(t *testing.T){
-	"check for missing sensor connections": func(connections []meta.Connection, sensors []meta.InstalledSensor, list []meta.Asset) func(t *testing.T) {
+	"check for missing sensor connections": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
-
 			assets := make(map[struct {
 				m string
 				s string
 			}]meta.Asset)
-			for _, a := range list {
+			for _, a := range set.Assets() {
 				assets[struct {
 					m string
 					s string
 				}{m: a.Model, s: a.Serial}] = a
 			}
 
-			for _, s := range sensors {
+			for _, s := range set.InstalledSensors() {
 				if a, ok := assets[struct {
 					m string
 					s string
@@ -175,7 +169,7 @@ var testConnectionsInstalledSensorAssets = map[string]func([]meta.Connection, []
 					continue
 				}
 				var handled bool
-				for _, c := range connections {
+				for _, c := range set.Connections() {
 					if c.Station != s.Station || c.Location != s.Location {
 						continue
 					}
@@ -193,24 +187,22 @@ var testConnectionsInstalledSensorAssets = map[string]func([]meta.Connection, []
 			}
 		}
 	},
-}
 
-var testConnectionsDeployedDataloggersAssets = map[string]func([]meta.Connection, []meta.DeployedDatalogger, []meta.Asset) func(t *testing.T){
-	"check for missing datalogger connections": func(connections []meta.Connection, dataloggers []meta.DeployedDatalogger, list []meta.Asset) func(t *testing.T) {
+	"check for missing datalogger connections": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 
 			assets := make(map[struct {
 				m string
 				s string
 			}]meta.Asset)
-			for _, a := range list {
+			for _, a := range set.Assets() {
 				assets[struct {
 					m string
 					s string
 				}{m: a.Model, s: a.Serial}] = a
 			}
 
-			for _, d := range dataloggers {
+			for _, d := range set.DeployedDataloggers() {
 
 				if a, ok := assets[struct {
 					m string
@@ -223,7 +215,7 @@ var testConnectionsDeployedDataloggersAssets = map[string]func([]meta.Connection
 					continue
 				}
 				var handled bool
-				for _, c := range connections {
+				for _, c := range set.Connections() {
 					if c.Place != d.Place || c.Role != d.Role {
 						continue
 					}
@@ -245,78 +237,12 @@ var testConnectionsDeployedDataloggersAssets = map[string]func([]meta.Connection
 
 func TestConnections(t *testing.T) {
 
-	var connections meta.ConnectionList
-	loadListFile(t, "../install/connections.csv", &connections)
-
-	for k, fn := range testConnections {
-		t.Run(k, fn(connections))
+	set, err := delta.New()
+	if err != nil {
+		t.Fatal(err)
 	}
-}
 
-func TestConnections_Stations(t *testing.T) {
-
-	var connections meta.ConnectionList
-	loadListFile(t, "../install/connections.csv", &connections)
-
-	var stations meta.StationList
-	loadListFile(t, "../network/stations.csv", &stations)
-
-	for k, fn := range testConnectionsStations {
-		t.Run(k, fn(connections, stations))
-	}
-}
-
-func TestConnections_Sites(t *testing.T) {
-
-	var connections meta.ConnectionList
-	loadListFile(t, "../install/connections.csv", &connections)
-
-	var sites meta.SiteList
-	loadListFile(t, "../network/sites.csv", &sites)
-
-	for k, fn := range testConnectionsSites {
-		t.Run(k, fn(connections, sites))
-	}
-}
-
-func TestConnections_DeployedDataloggers(t *testing.T) {
-	var connections meta.ConnectionList
-	loadListFile(t, "../install/connections.csv", &connections)
-
-	var dataloggers meta.DeployedDataloggerList
-	loadListFile(t, "../install/dataloggers.csv", &dataloggers)
-
-	for k, fn := range testConnectionsDeployedDataloggers {
-		t.Run(k, fn(connections, dataloggers))
-	}
-}
-
-func TestConnections_DeployedDataloggersAssets(t *testing.T) {
-	var connections meta.ConnectionList
-	loadListFile(t, "../install/connections.csv", &connections)
-
-	var dataloggers meta.DeployedDataloggerList
-	loadListFile(t, "../install/dataloggers.csv", &dataloggers)
-
-	var assets meta.AssetList
-	loadListFile(t, "../assets/dataloggers.csv", &assets)
-
-	for k, fn := range testConnectionsDeployedDataloggersAssets {
-		t.Run(k, fn(connections, dataloggers, assets))
-	}
-}
-
-func TestConnections_InstalledSensorAssets(t *testing.T) {
-	var connections meta.ConnectionList
-	loadListFile(t, "../install/connections.csv", &connections)
-
-	var sensors meta.InstalledSensorList
-	loadListFile(t, "../install/sensors.csv", &sensors)
-
-	var assets meta.AssetList
-	loadListFile(t, "../assets/sensors.csv", &assets)
-
-	for k, fn := range testConnectionsInstalledSensorAssets {
-		t.Run(k, fn(connections, sensors, assets))
+	for k, v := range connectionChecks {
+		t.Run(k, v(set))
 	}
 }

--- a/tests/consistency_test.go
+++ b/tests/consistency_test.go
@@ -75,7 +75,11 @@ func TestConsistency(t *testing.T) {
 
 	for f, v := range files {
 
-		loadListFile(t, v.f, v.l)
+		if err := meta.LoadList(v.f, v.l); err != nil {
+			t.Fatalf("unable to load list file %s: %v", v.f, err)
+		}
+
+		sort.Sort(v.l)
 
 		for k, fn := range testConsistency {
 			t.Run(k+": "+f, fn(v.f, v.l))

--- a/tests/constituents_test.go
+++ b/tests/constituents_test.go
@@ -4,12 +4,14 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/GeoNet/delta"
 	"github.com/GeoNet/delta/meta"
 )
 
-var testConstituents = map[string]func([]meta.Constituent) func(t *testing.T){
-	"check for gauge duplication": func(constituents []meta.Constituent) func(t *testing.T) {
+var constituentChecks = map[string]func(*meta.Set) func(t *testing.T){
+	"check for gauge duplication": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
+			constituents := set.Constituents()
 			for i := 0; i < len(constituents); i++ {
 				for j := i + 1; j < len(constituents); j++ {
 					if constituents[i].Gauge != constituents[j].Gauge {
@@ -27,16 +29,13 @@ var testConstituents = map[string]func([]meta.Constituent) func(t *testing.T){
 			}
 		}
 	},
-}
-
-var testConstituentsGauges = map[string]func([]meta.Constituent, []meta.Gauge) func(t *testing.T){
-	"check for missing constituent gauges": func(constituents []meta.Constituent, list []meta.Gauge) func(t *testing.T) {
+	"check for missing constituent gauges": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 			gauges := make(map[string]meta.Gauge)
-			for _, g := range list {
+			for _, g := range set.Gauges() {
 				gauges[g.Code] = g
 			}
-			for _, c := range constituents {
+			for _, c := range set.Constituents() {
 				if _, ok := gauges[c.Gauge]; !ok {
 					t.Error("unknown gauge: " + c.Gauge)
 				}
@@ -46,23 +45,13 @@ var testConstituentsGauges = map[string]func([]meta.Constituent, []meta.Gauge) f
 }
 
 func TestConstituents(t *testing.T) {
-	var constituents meta.ConstituentList
-	loadListFile(t, "../environment/constituents.csv", &constituents)
 
-	for k, fn := range testConstituents {
-		t.Run(k, fn(constituents))
-	}
-}
-
-func TestConstituents_Gauges(t *testing.T) {
-	var constituents meta.ConstituentList
-	loadListFile(t, "../environment/constituents.csv", &constituents)
-
-	var gauges meta.GaugeList
-	loadListFile(t, "../environment/gauges.csv", &gauges)
-
-	for k, fn := range testConstituentsGauges {
-		t.Run(k, fn(constituents, gauges))
+	set, err := delta.New()
+	if err != nil {
+		t.Fatal(err)
 	}
 
+	for k, v := range constituentChecks {
+		t.Run(k, v(set))
+	}
 }

--- a/tests/doases_test.go
+++ b/tests/doases_test.go
@@ -3,16 +3,17 @@ package delta_test
 import (
 	"testing"
 
+	"github.com/GeoNet/delta"
 	"github.com/GeoNet/delta/meta"
 )
 
-var testInstalledDoases = map[string]func([]meta.InstalledDoas) func(t *testing.T){
+var doasChecks = map[string]func(*meta.Set) func(t *testing.T){
 
-	"check for doases installation equipment overlaps": func(doases []meta.InstalledDoas) func(t *testing.T) {
+	"check for doases installation equipment overlaps": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 
 			installs := make(map[string]meta.InstalledDoasList)
-			for _, c := range doases {
+			for _, c := range set.Doases() {
 				installs[c.Model] = append(installs[c.Model], c)
 			}
 
@@ -44,52 +45,44 @@ var testInstalledDoases = map[string]func([]meta.InstalledDoas) func(t *testing.
 			}
 		}
 	},
-}
 
-var testInstalledDoasesMounts = map[string]func([]meta.InstalledDoas, []meta.Mount) func(t *testing.T){
-
-	"check for doases installation equipment overlaps": func(doases []meta.InstalledDoas, mounts []meta.Mount) func(t *testing.T) {
+	"check for doases installation mount overlaps": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 			keys := make(map[string]interface{})
-			for _, m := range mounts {
+			for _, m := range set.Mounts() {
 				keys[m.Code] = true
 			}
 
-			for _, c := range doases {
+			for _, c := range set.Doases() {
 				if _, ok := keys[c.Mount]; !ok {
 					t.Errorf("unable to find doas mount %-5s", c.Mount)
 				}
 			}
 		}
 	},
-}
 
-var testInstalledDoasesViews = map[string]func([]meta.InstalledDoas, []meta.View) func(t *testing.T){
-
-	"check for doases installation views": func(doases []meta.InstalledDoas, views []meta.View) func(t *testing.T) {
+	"check for doases installation views": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 			type view struct{ m, c string }
 			keys := make(map[view]interface{})
-			for _, m := range views {
+			for _, m := range set.Views() {
 				keys[view{m.Mount, m.Code}] = true
 			}
 
-			for _, c := range doases {
+			for _, c := range set.Doases() {
 				if _, ok := keys[view{c.Mount, c.View}]; !ok {
 					t.Errorf("unable to find doas mount %-5s (%-2s)", c.Mount, c.View)
 				}
 			}
 		}
 	},
-}
 
-var testInstalledDoasesAssets = map[string]func([]meta.InstalledDoas, []meta.Asset) func(t *testing.T){
-	"check doases assets": func(doases []meta.InstalledDoas, assets []meta.Asset) func(t *testing.T) {
+	"check doases assets": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 
-			for _, r := range doases {
+			for _, r := range set.Doases() {
 				var found bool
-				for _, a := range assets {
+				for _, a := range set.Assets() {
 					if a.Model != r.Model {
 						continue
 					}
@@ -109,49 +102,12 @@ var testInstalledDoasesAssets = map[string]func([]meta.InstalledDoas, []meta.Ass
 
 func TestDoases(t *testing.T) {
 
-	var doases meta.InstalledDoasList
-	loadListFile(t, "../install/doases.csv", &doases)
-
-	for k, fn := range testInstalledDoases {
-		t.Run(k, fn(doases))
+	set, err := delta.New()
+	if err != nil {
+		t.Fatal(err)
 	}
-}
 
-func TestDoases_Mounts(t *testing.T) {
-
-	var doases meta.InstalledDoasList
-	loadListFile(t, "../install/doases.csv", &doases)
-
-	var mounts meta.MountList
-	loadListFile(t, "../network/mounts.csv", &mounts)
-
-	for k, fn := range testInstalledDoasesMounts {
-		t.Run(k, fn(doases, mounts))
-	}
-}
-
-func TestDoases_Views(t *testing.T) {
-
-	var doases meta.InstalledDoasList
-	loadListFile(t, "../install/doases.csv", &doases)
-
-	var views meta.ViewList
-	loadListFile(t, "../network/views.csv", &views)
-
-	for k, fn := range testInstalledDoasesViews {
-		t.Run(k, fn(doases, views))
-	}
-}
-
-func TestDoases_Assets(t *testing.T) {
-
-	var doases meta.InstalledDoasList
-	loadListFile(t, "../install/doases.csv", &doases)
-
-	var assets meta.AssetList
-	loadListFile(t, "../assets/doases.csv", &assets)
-
-	for k, fn := range testInstalledDoasesAssets {
-		t.Run(k, fn(doases, assets))
+	for k, v := range doasChecks {
+		t.Run(k, v(set))
 	}
 }


### PR DESCRIPTION
This is part of the delta test cleanup work with replacing individual calls to read files with using the built in `Set` features.

The may idea is to replace the standard test with a consistent function fingerprint, namely:

```golang
map[string]func(*meta.Set)func(t *testing.T)
```

Which allows building the set of tests via a map and a consistent calling mechanism, e.g.

``` golang
for k, v := range checks {
	t.Run(k, v(set))
}
```

where checks is a map as defined above, and t a `testing.T` value.  Eventually the tests can be gathered and calling functions can be updated or adjusted as needed, e.g. to insert parallel running etc.

There are no changes to  the actual tests in this code, simply the framing.
