### PR TITLE
feat(geomag): allow an recorder to use extra channels

### DIFF
--- a/meta/collection.go
+++ b/meta/collection.go
@@ -274,7 +274,7 @@ func (s *Set) Collections(site Site) []Collection {
 			continue
 		}
 		for _, connection := range s.Connections() {
-			if connection.Station != recorder.Station {
+			if connection.Station != site.Station {
 				continue
 			}
 			if connection.Role != recorder.Location {
@@ -308,10 +308,10 @@ func (s *Set) Collections(site Site) []Collection {
 					}
 
 					for _, component := range s.Components() {
-						if sensor.Make != component.Make {
+						if component.Make != sensor.Make {
 							continue
 						}
-						if sensor.Model != component.Model {
+						if component.Model != sensor.Model {
 							continue
 						}
 
@@ -320,17 +320,17 @@ func (s *Set) Collections(site Site) []Collection {
 						}
 
 						for _, channel := range s.Channels() {
-							if recorder.Make != channel.Make {
+							if channel.Make != recorder.Make {
 								continue
 							}
-							if recorder.DataloggerModel != channel.Model {
+							if channel.Model != recorder.DataloggerModel {
 								continue
 							}
-							if component.Number+connection.Number < channel.Number {
+							if channel.SamplingRate != stream.SamplingRate {
 								continue
 							}
 
-							if stream.SamplingRate != channel.SamplingRate {
+							if component.Number+connection.Number < channel.Number {
 								continue
 							}
 

--- a/tests/connections_test.go
+++ b/tests/connections_test.go
@@ -130,6 +130,9 @@ var connectionChecks = map[string]func(*meta.Set) func(t *testing.T){
 					places[d.Place+"/"+d.Role] = d.Place
 				}
 			}
+			for _, r := range set.InstalledRecorders() {
+				places[r.Station+"/"+r.Location] = r.Station
+			}
 			for _, c := range set.Connections() {
 				switch c.Role {
 				case "":


### PR DESCRIPTION
This PR adds the ability to use the extra channels of an installed recorder to attach a sensor.

Requires the sensor channels, and components as per normal, but allows the option of using a connection with the Place being the recorder site, and the role the recorder location.