### PR TITLE
add miscellanoues notes inherited from old GNSS marks delta DB

### DIFF
--- a/environment/README.md
+++ b/environment/README.md
@@ -12,6 +12,8 @@ _Lists the geological and physical environment details of collection points._
 
 * `gauges.csv` - Gauges Descriptions.
 
+* `notes.csv` - miscellaneous notes about site geological characteristics
+
 * `placenames.csv` - Placename Descriptions.
 
 * `visibility.csv` - Sky View Descriptions.

--- a/environment/notes.csv
+++ b/environment/notes.csv
@@ -1,0 +1,85 @@
+﻿Station,CG,Network
+2406,CG,5/8 threaded bolt on top of concrete pillar
+ARTA,CG,Concrete pillar with 3 stainless rods drilled to 0.5m into concrete butress.Note that between 2006-10-12 and 2006-11-08 the existing pillar adjacent to this one was occupied using the code ATIA as a test.
+ATIA,XX,Test deployment for site ARTA
+AUCK,LI,Site upgraded to Trimble NETRS/Trimble Zephyr combination on 3rd November 2005
+BHST,CG,Hard rock (greywacke) at surface
+BLUF,LI,5/8 thread in centre of 120 mm diameter stainless steel plate set in concrete pillar
+CKID,CG,Replace trig B16N. No rock outcropping only clay/mudstone
+CLRR,CG,2016-13-11 M7.8 Kaikoura event response (scientific target: postseismic signal). Temporary site (LRR1) 20m from the deep braced monument recorded the first period after the Kaikoura earthquake.
+CLS3,XX,monument removed to allow for retaining work
+CLS5,XX,Equipment has been dismantled on 2016-04-26 because reasons. The monument has been left on place.
+CLS6,XX,Site used for landslide monitoring. Mark has been dismantled on 2016-08-28
+CLSG,XX,site has been dismantled after the June 13 2011 Christchurch earthquake due to its proximity to a cliff edge and its unsafety
+CMBL,CG,5/8 thread in centre of 160 mm diameter stainless steel plate set in 320 mm diameter concrete pillar. Pillar plate is 1601 mm above the top of previous mark (A Cape Campbell B28C).
+FALE,GN,IGS Pacific site. Post is cemented into a hole excavated approximately 1m deep in weathered igneous bedrock. Geodetic reference point is top-center of steel coupler atop steel mast.
+GDS1,XX,temporary mark deployed for M7.8 Kaikoura earthquake sequence monitoring. Tribrach found out of level on 2017-02-22 and readjusted at the same time of the NetR9 receiver swap.
+GLDB,LI,5/8 thread in centre of 100 mm diameter stainless steel plate set in concrete pillar.
+GLOK,CG,2016-13-11 M7.8 Kaikoura event response (scientific target: postseismic signal). A temporary site (LOK1) 350m SW of the deep braced monument recorded the initial period after the earthquake.
+GRAC,GN,GNS site moved from Gracefield to Avalon Lower Hutt
+GRNG,CG,This land is broad and flat with incised gullies (100m+ between gullies). Stratigraphy in the road cut shows flat lying layered seds and there is iron cemented river gravel in the gullies.
+GUNR,CG,ON LARGE LANDSLIDE. Analysis of the data shows GUNR is moving atypically for regional tectonics and compared to nearby stations (eg MTPR). Affected by large landslide (also scarp visible to North). More info in resolved RT ticket 57397.
+HAST,LI,5/8 thread in centre of 100 mm diameter stainless steel plate set in 400 mm diameter concrete pillar. Pillar plate is 735 mm above the top of previous mark (Roys Hill - A4F2).
+KAHU,CG,9m tall data comms mast installed at 3m south of the antenna on 2017-05-02
+KORO,CG,Aeolian Dunes.
+LDRZ,GN,Located at NIWA atmospheric research station. Monument was built in 1976
+LOK1,XX,temporary mark deployed for 13Nov2016 M7.8 Kaikoura earthquake sequence monitoring. Monument has been dismantled in November 2017 and site is replaced by permanent station GLOK
+LOOK,CG,On a spur 600m to the West of the peak of Lookout Mountain. 2016-13-11 M7.8 Kaikoura event response (scientific target: postseismic signal). Two temporary sites in the area (GDS1 and MUL1 located within 15 km) recorded the first period after the Kaikoura earthquake.
+LRR1,XX,temporary mark set to monitor 2016-11-13 M7.8 Kaikoura earthquake sequence. Replaced by a drilled braced monument (CLRR). The site has been dismantled
+MAHO,LI,antenna mount was not tightened properly from 2011-01-11 to 2011-05-17
+MAST,LI,decomissioned on 2016-04-06 because a house has been built close to the site. WRPA site is ~ 150m apart and is considered as MAST replacement within the PositioNZ network. Pillar has been destroyed and a survey mark installed  on 8 June 2016.
+MCNL,CG,there are major landslides off all faces of McNeill Hill but the top area selected for GPS and seismic is considered stable (from lanslide report by Nick Perrin).  The landslides are thought to be ancient and are probably not active
+METH,LI,all legs are short - 5.5m central leg and 6m N/S/E/W legs - as very coarse gravel/boulders encountered.
+MUL1,XX,temporary mark deployed for M7.8 Kaikoura earthquake sequence monitoring.
+NETT,SA,site dismantled in 2018 due to poor data quality and vicinity with HORN. Monument left in place
+NIUC,GN,Site was destroyed by cyclone Heta at the end of 2003 and replaced by NIUM
+NIUM,GN,Starting from 2014-03-13T01:30 the station is operated and maintained by Geoscience Australia.
+NMAI,CG,The site is on limestone which dips about 18 degrees to the SE from a measurement close to the site.
+OHIN,CG,There are numerous shallow surface slumps in the area but Nick is of the opinion that these will not affect a site on the broad flat top of the hill.
+PALI,CG,The drillers had problems with hole collapse at this site so it is effectively now a short-braced monument with legs grouted in place.  BORELOG: All holes are in soft brown fractured Greywacke: North leg - GL to 3m hole collapsing back to 3m; South leg - GL to 1.5m hole collapsing back at 1.5m; East and centre legs - GL to 1.8m holes collapsing back to 1.8m; West leg - GL to 3.2m hole collapsing back to  3.2m. Mark name changed from ""Cape Palliser CGPS to Cape Palliser on Sept 2014
+PARI,CG,Broad exposed slab of sandstone
+PORA,CG,5/8 thread in centre of 50 mm diameter stainless steel centre block of deep braced monument. Top of SS centre block is 1273 mm above the top of previous mark geodetic mark 30 (Poranagahau SD) - A47A. 
+RAHI,CG,hard limestone
+RGCR,CG,Abandoned due to the planting of pine trees in the proximity of the monument.
+RGHL,CG,Faulty antenna from 2017-03-20 to  2017-06-07
+RGKA,CG,Deep braced monument into pumice/ash and mamaku ignimbrite at depth.  5/8 thread on top of monument.
+RGLI,CG,Concrete pillar constructed using concrete pipe above rods rammed into approx 1m cubed hole; hole filled with concrete. Subsrate is layered friable ash and pumice tephra which is easy to dig.
+RGTA,CG,some legs are not deep-braced only shallow due to poor drilling conditions
+RGUT,CG,Concrete pillar constructed using concrete pipe above rods rammed into approx 1m cubed hole; hole filled with concrete.
+RGWC,CG,The monument legs were rammed into the ground to approximately 3m depth below the surface.
+RGWI,CG,Short braced monument with legs rammed to ~5m depth
+RGWV,CG,Broad grassy hill. Ignimbrite bedrock nearby and likely contactable at depth with Deep braced monument.
+TAKL,GN,"TAKL was decommissioned because the building to which it was attached is being moved by Ports of Auckland. The receiver was switched off at 03:44 UT 5 July 2007. The site has been re-established at a new location with a new 4-letter code (AUKT)."
+TEN2,XX,temporary mark deployed for M7.8 Kaikoura earthquake sequence monitoring. will be replaced by TENN
+TGHO,CG,Braced stainless steel pole mounted on the Horomatangi Reefs platform on the same pole as the lake levelling mark.
+TGHR,CG,Deep braced monument into welded Whakamaru ignimbrite.  5/8 thread on top of monument.
+TGOH,CG,Deep braced monument into pumice/tephra overlying rhyolite dome.
+TGRA,CG,Deep braced monument into rhyolite lava outcrop. 5/8 thread on top of monument.  BORELOG: North South and East Legs - 0-3m soft brown ash; 3-6m banded lenticular rhyolite; 6-9/9.5m soft fractured lenticular rhyolite. West Leg - 0-3m soft brown ash; 3-6m banded lenticular rhyolite; 6-6.8m soft fractured lenticular rhyolite. West leg losing grout - 800 litres used on this leg. Centre leg - 0-2.6m soft brown ash; 2.6-6m banded lenticular rhyolite."
+TGRI,CG,"Concrete Pillar monument 2m deep foundation hole with reinforcing extending into the concrete pipe
+TGTK,CG,5/8 thread in the top of the monument.  This monument replaces the mark known as Te Kawerauta 1836 at the same location.
+THAP,CG,andesite
+TINT,CG,Mudstone outcropping at surface
+UTKU,CG,utk landslide monitoring reference site
+VAVS,GN,"The VAVS antenna mast was exchanged on 9 June 2009.  The top of the new mast is 3 mm S 17 mm W 252 mm UP relative to the top of the old mast (accuracy is about 2 mm).  There will be an offset of this magnitude in the time series plus any offset due to the change of antenna.  February 2017 the roof of the building was renewed and the antenna mount has been damaged."
+VEXA,SA,On 17/03/2015 the grub screw antenna insert has been found loose and oriented 20deg NE. Antenna has been been realigned to 0deg N and tightened.
+VGDR,XX,"Concrete pillar made using formatube. Pillar damaged during september 25 2007 eruption has gained an eastward tilt.  may no longer be stable. Email from Steve Currie with results from april08 survey. From our crater rim deformation the changes (due to the damage) at your pillar relative to ITD3 (which is the mark on the adjacent knob ie the dome) are a movement (in NZMG) of 23mm south 86mm east a vector of 89mm) and has gone up? 3mm (this is close to survey uncertainty)."
+VGFW,CG,5/8 thread in centre of 160 mm diameter stainless steel plate set in a 300 mm external diameter concrete tube cast using a cardboard Formatube.
+VGKR,CG,5/8 thread in centre of 160 mm diameter stainless steel plate set in a 300 mm external diameter concrete tube cast using a cardboard Formatube.
+VGMO,CG,5/8 thread in centre of 160 mm diameter stainless steel plate set in a 300 mm external diameter PVC farm tuff tube filled with concrete.
+VGMT,LI,"5/8 thread in centre of 160 mm diameter stainless steel plate set in a 300 mm external diameter concrete pipe."
+VGNG,CG,cGPS monument: short braced three leg + vertical 25 mm stainless steel rebar rammed not glued. Longest leg about 3.7 m.
+VGNT,CG,Permanent occupation of the North Tongariro site. A temporary monument (VGT8) has been operational at the same location from 2013 to 2016
+VGOB,CG,Antenna mount was misplaced from 2016-05-12T03:58 to 2016-08-22T20:28 (about 10mm higher than its correct position)
+VGOT,CG,"Used as a temporary pillar from 2004-05-16 to 2004-05-20. Reoccupied 2006-06-08. Concrete pillar bolted onto solid lava flow."
+VGPK,CG,5/8 thread in centre of 160 mm diameter stainless steel plate set in a 300 mm external diameter concrete pipe.
+VGT2,CG,This is a mark created for the 2012 Tongariro Response and consists of an iron rod rammed into the ground.  A tripod was used to setup the antenna over the mark.  Site was buried in the 2012 eruption. Last data in the archive is from 2012-08-06
+VGT8,CG,monument dismantled on 2016-05-09 and replaced by VGNT.
+VGTR,CG,5/8 thread in centre of 160 mm diameter stainless steel plate set in a 300 mm external diameter concrete tube cast using a cardboard Formatube.
+VGTS,CG,5/8 thread in centre of 160 mm diameter stainless steel plate set in a 300 mm external diameter concrete tube cast using a cardboard Formatube.
+VGWH,CG,5/8 thread in centre of 160 mm diameter stainless steel plate set in a 300 mm external diameter concrete tube cast using a cardboard Formatube.
+VGWN,CG,5/8 thread in centre of 160 mm diameter stainless steel plate set in a 300 mm external diameter concrete tube cast using a cardboard Formatube.
+WARK,LI,"LINZ CGPS at VLBI site with streaming capabilities. Timing now being received from AUT's hydrogen maser 10MHz - switch over completed at 2012-03-23 00:22 UTC."
+WGTT,GN,There is a 20dB in-line amplifier in the antenna cable to boost the signal from the LEIAT504 antenna to the NetRS.  The amplifier is GPS Networking p/n LA20RPDC-. 
+WRA1,XX,"temporary mark set to monitor 2016-11-13 M7.8 Kaikoura earthquake sequence. Replaced by a drilled braced monument (WRAU). The site has been dismantled
+WRAU,CG,Hikurangi margin array (scientific target: SS events) and 2016-13-11 M7.8 Kaikoura event response (scientific target: postseismic signal). A temporary site (WRA1) 55m from the deep braced monument recorded the first period after the Kaikoura earthquake.
+YALD,CG,The mark is a SECO 2072-33 levelling mount installed on 16/09/2014 (21:00) UTC time mounted on top of the deep braced monument."


### PR DESCRIPTION
this one will require a bunch of improvements, but is hopefully a good start to replace https://github.com/GeoNet/delta/pull/460

We might add start/end date if we want, but in this case and for GNSS marks we only have notes that are not time dependent, but more focused on geology background, scope of the site and additional details for the monument

Much more and useful details in the original pull request