### PR TITLE
refactor(headers): add headers to network tables

### DIFF
--- a/meta/asset.go
+++ b/meta/asset.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 )
@@ -21,6 +20,14 @@ const (
 	assetLast
 )
 
+var assetHeaders Header = map[string]int{
+	"Make":   assetMake,
+	"Model":  assetModel,
+	"Serial": assetSerial,
+	"Number": assetNumber,
+	"Notes":  assetNotes,
+}
+
 type AssetList []Asset
 
 func (a AssetList) Len() int           { return len(a) }
@@ -28,39 +35,46 @@ func (a AssetList) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a AssetList) Less(i, j int) bool { return a[i].Equipment.Less(a[j].Equipment) }
 
 func (a AssetList) encode() [][]string {
-	data := [][]string{{"Make", "Model", "Serial", "Number", "Notes"}}
-	for _, v := range a {
+	var data [][]string
+
+	data = append(data, assetHeaders.Columns())
+
+	for _, row := range a {
 		data = append(data, []string{
-			v.Make,
-			v.Model,
-			v.Serial,
-			v.Number,
-			v.Notes,
+			row.Make,
+			row.Model,
+			row.Serial,
+			row.Number,
+			row.Notes,
 		})
 	}
 	return data
 }
 
 func (a *AssetList) decode(data [][]string) error {
-	var assets []Asset
-	if len(data) > 1 {
-		for _, d := range data[1:] {
-			if len(d) != assetLast {
-				return fmt.Errorf("incorrect number of asset fields")
-			}
-			assets = append(assets, Asset{
-				Equipment: Equipment{
-					Make:   strings.TrimSpace(d[assetMake]),
-					Model:  strings.TrimSpace(d[assetModel]),
-					Serial: strings.TrimSpace(d[assetSerial]),
-				},
-				Number: strings.TrimSpace(d[assetNumber]),
-				Notes:  strings.TrimSpace(d[assetNotes]),
-			})
-		}
-
-		*a = AssetList(assets)
+	if !(len(data) > 1) {
+		return nil
 	}
+
+	var assets []Asset
+
+	fields := assetHeaders.Fields(data[0])
+	for _, row := range data[1:] {
+		d := fields.Remap(row)
+
+		assets = append(assets, Asset{
+			Equipment: Equipment{
+				Make:   strings.TrimSpace(d[assetMake]),
+				Model:  strings.TrimSpace(d[assetModel]),
+				Serial: strings.TrimSpace(d[assetSerial]),
+			},
+			Number: strings.TrimSpace(d[assetNumber]),
+			Notes:  strings.TrimSpace(d[assetNotes]),
+		})
+	}
+
+	*a = AssetList(assets)
+
 	return nil
 }
 

--- a/meta/calibration.go
+++ b/meta/calibration.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -23,6 +22,19 @@ const (
 	calibrationEnd
 	calibrationLast
 )
+
+var calibrationHeaders Header = map[string]int{
+	"Make":           calibrationMake,
+	"Model":          calibrationModel,
+	"Serial":         calibrationSerial,
+	"Number":         calibrationNumber,
+	"Scale Factor":   calibrationScaleFactor,
+	"Scale Bias":     calibrationScaleBias,
+	"Scale Absolute": calibrationScaleAbsolute,
+	"Frequency":      calibrationFrequency,
+	"Start Date":     calibrationStart,
+	"End Date":       calibrationEnd,
+}
 
 // Calibration defines times where sensor scaling or offsets are needed, these will be overwrite the
 // existing values, i.e. A + BX => A' + B' X, where A' and B' are the given bias and scaling factors.
@@ -69,33 +81,26 @@ func (c CalibrationList) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
 func (c CalibrationList) Less(i, j int) bool { return c[i].Less(c[j]) }
 
 func (c CalibrationList) encode() [][]string {
-	data := [][]string{{
-		"Make",
-		"Model",
-		"Serial",
-		"Number",
-		"Scale Factor",
-		"Scale Bias",
-		"Scale Absolute",
-		"Frequency",
-		"Start Date",
-		"End Date",
-	}}
 
-	for _, v := range c {
+	var data [][]string
+
+	data = append(data, calibrationHeaders.Columns())
+
+	for _, row := range c {
 		data = append(data, []string{
-			strings.TrimSpace(v.Make),
-			strings.TrimSpace(v.Model),
-			strings.TrimSpace(v.Serial),
-			strconv.Itoa(v.Number),
-			strings.TrimSpace(v.factor),
-			strings.TrimSpace(v.bias),
-			strings.TrimSpace(v.absolute),
-			strings.TrimSpace(v.frequency),
-			v.Start.Format(DateTimeFormat),
-			v.End.Format(DateTimeFormat),
+			strings.TrimSpace(row.Make),
+			strings.TrimSpace(row.Model),
+			strings.TrimSpace(row.Serial),
+			strconv.Itoa(row.Number),
+			strings.TrimSpace(row.factor),
+			strings.TrimSpace(row.bias),
+			strings.TrimSpace(row.absolute),
+			strings.TrimSpace(row.frequency),
+			row.Start.Format(DateTimeFormat),
+			row.End.Format(DateTimeFormat),
 		})
 	}
+
 	return data
 }
 
@@ -118,74 +123,76 @@ func (c *CalibrationList) toInt(str string, def int) (int, error) {
 }
 
 func (c *CalibrationList) decode(data [][]string) error {
+	if !(len(data) > 1) {
+		return nil
+	}
+
 	var calibrations []Calibration
-	if len(data) > 1 {
-		for _, d := range data[1:] {
-			if len(d) != calibrationLast {
-				return fmt.Errorf("incorrect number of installed calibration fields")
-			}
 
-			factor, err := c.toFloat64(d[calibrationScaleFactor], 1.0)
-			if err != nil {
-				return err
-			}
+	fields := calibrationHeaders.Fields(data[0])
+	for _, row := range data[1:] {
+		d := fields.Remap(row)
 
-			bias, err := c.toFloat64(d[calibrationScaleBias], 1.0)
-			if err != nil {
-				return err
-			}
-
-			absolute, err := c.toFloat64(d[calibrationScaleAbsolute], 0.0)
-			if err != nil {
-				return err
-			}
-
-			freq, err := c.toFloat64(d[calibrationFrequency], 0.0)
-			if err != nil {
-				return err
-			}
-
-			number, err := c.toInt(d[calibrationNumber], 0)
-			if err != nil {
-				return err
-			}
-
-			start, err := time.Parse(DateTimeFormat, d[calibrationStart])
-			if err != nil {
-				return err
-			}
-
-			end, err := time.Parse(DateTimeFormat, d[calibrationEnd])
-			if err != nil {
-				return err
-			}
-
-			calibrations = append(calibrations, Calibration{
-				Install: Install{
-					Equipment: Equipment{
-						Make:   strings.TrimSpace(d[calibrationMake]),
-						Model:  strings.TrimSpace(d[calibrationModel]),
-						Serial: strings.TrimSpace(d[calibrationSerial]),
-					},
-					Span: Span{
-						Start: start,
-						End:   end,
-					},
-				},
-				Number: number,
-
-				ScaleFactor:   factor,
-				ScaleBias:     bias,
-				ScaleAbsolute: absolute,
-				Frequency:     freq,
-
-				number:    strings.TrimSpace(d[calibrationNumber]),
-				factor:    strings.TrimSpace(d[calibrationScaleFactor]),
-				bias:      strings.TrimSpace(d[calibrationScaleBias]),
-				absolute:  strings.TrimSpace(d[calibrationScaleAbsolute]),
-				frequency: strings.TrimSpace(d[calibrationFrequency]),
-			})
+		factor, err := c.toFloat64(d[calibrationScaleFactor], 1.0)
+		if err != nil {
+			return err
 		}
+
+		bias, err := c.toFloat64(d[calibrationScaleBias], 1.0)
+		if err != nil {
+			return err
+		}
+
+		absolute, err := c.toFloat64(d[calibrationScaleAbsolute], 0.0)
+		if err != nil {
+			return err
+		}
+
+		freq, err := c.toFloat64(d[calibrationFrequency], 0.0)
+		if err != nil {
+			return err
+		}
+
+		number, err := c.toInt(d[calibrationNumber], 0)
+		if err != nil {
+			return err
+		}
+
+		start, err := time.Parse(DateTimeFormat, d[calibrationStart])
+		if err != nil {
+			return err
+		}
+
+		end, err := time.Parse(DateTimeFormat, d[calibrationEnd])
+		if err != nil {
+			return err
+		}
+
+		calibrations = append(calibrations, Calibration{
+			Install: Install{
+				Equipment: Equipment{
+					Make:   strings.TrimSpace(d[calibrationMake]),
+					Model:  strings.TrimSpace(d[calibrationModel]),
+					Serial: strings.TrimSpace(d[calibrationSerial]),
+				},
+				Span: Span{
+					Start: start,
+					End:   end,
+				},
+			},
+			Number: number,
+
+			ScaleFactor:   factor,
+			ScaleBias:     bias,
+			ScaleAbsolute: absolute,
+			Frequency:     freq,
+
+			number:    strings.TrimSpace(d[calibrationNumber]),
+			factor:    strings.TrimSpace(d[calibrationScaleFactor]),
+			bias:      strings.TrimSpace(d[calibrationScaleBias]),
+			absolute:  strings.TrimSpace(d[calibrationScaleAbsolute]),
+			frequency: strings.TrimSpace(d[calibrationFrequency]),
+		})
 	}
 
 	*c = CalibrationList(calibrations)

--- a/meta/citation.go
+++ b/meta/citation.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -20,6 +19,19 @@ const (
 	citationRetrieved
 	citationLast
 )
+
+var citationHeaders Header = map[string]int{
+	"Key":       citationKey,
+	"Author":    citationAuthor,
+	"Year":      citationYear,
+	"Title":     citationTitle,
+	"Published": citationPublished,
+	"Volume":    citationVolume,
+	"Pages":     citationPages,
+	"DOI":       citationDoi,
+	"Link":      citationLink,
+	"Retrieved": citationRetrieved,
+}
 
 type Citation struct {
 	Key       string
@@ -45,34 +57,38 @@ func (c CitationList) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
 func (c CitationList) Less(i, j int) bool { return c[i].Key < c[j].Key }
 
 func (c CitationList) encode() [][]string {
-	data := [][]string{{"Key", "Author", "Year", "Title", "Published", "Volume", "Pages", "DOI", "Link", "Retrieved"}}
-	for _, v := range c {
+	var data [][]string
+
+	data = append(data, citationHeaders.Columns())
+
+	for _, row := range c {
 		data = append(data, []string{
-			v.Key,
-			v.Author,
-			v.year,
-			v.Title,
-			v.Published,
-			v.Volume,
-			v.Pages,
-			v.doi,
-			v.Link,
-			v.retrieved,
+			row.Key,
+			row.Author,
+			row.year,
+			row.Title,
+			row.Published,
+			row.Volume,
+			row.Pages,
+			row.doi,
+			row.Link,
+			row.retrieved,
 		})
 	}
+
 	return data
 }
 
 func (c *CitationList) decode(data [][]string) error {
-	var citations []Citation
-
 	if !(len(data) > 1) {
 		return nil
 	}
-	for _, d := range data[1:] {
-		if len(d) != citationLast {
-			return fmt.Errorf("incorrect number of citation fields")
-		}
+
+	var citations []Citation
+
+	fields := citationHeaders.Fields(data[0])
+	for _, row := range data[1:] {
+		d := fields.Remap(row)
 
 		year, err := ParseInt(d[citationYear])
 		if err != nil {

--- a/meta/doas.go
+++ b/meta/doas.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -24,6 +23,21 @@ const (
 	installedDoasLast
 )
 
+var installedDoasHeaders Header = map[string]int{
+	"Make":       installedDoasMake,
+	"Model":      installedDoasModel,
+	"Serial":     installedDoasSerial,
+	"Mount":      installedDoasMount,
+	"View":       installedDoasView,
+	"Dip":        installedDoasDip,
+	"Azimuth":    installedDoasAzimuth,
+	"Height":     installedDoasHeight,
+	"North":      installedDoasNorth,
+	"East":       installedDoasEast,
+	"Start Date": installedDoasStart,
+	"End Date":   installedDoasEnd,
+}
+
 type InstalledDoas struct {
 	Install
 	Orientation
@@ -35,126 +49,123 @@ type InstalledDoas struct {
 
 type InstalledDoasList []InstalledDoas
 
-func (a InstalledDoasList) Len() int           { return len(a) }
-func (a InstalledDoasList) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a InstalledDoasList) Less(i, j int) bool { return a[i].Install.Less(a[j].Install) }
+func (id InstalledDoasList) Len() int           { return len(id) }
+func (id InstalledDoasList) Swap(i, j int)      { id[i], id[j] = id[j], id[i] }
+func (id InstalledDoasList) Less(i, j int) bool { return id[i].Install.Less(id[j].Install) }
 
-func (a InstalledDoasList) encode() [][]string {
-	data := [][]string{{
-		"Make",
-		"Model",
-		"Serial",
-		"Mount",
-		"View",
-		"Dip",
-		"Azimuth",
-		"Height",
-		"North",
-		"East",
-		"Start Date",
-		"End Date",
-	}}
-	for _, v := range a {
+func (id InstalledDoasList) encode() [][]string {
+	var data [][]string
+
+	data = append(data, installedDoasHeaders.Columns())
+
+	for _, row := range id {
 		data = append(data, []string{
-			strings.TrimSpace(v.Make),
-			strings.TrimSpace(v.Model),
-			strings.TrimSpace(v.Serial),
-			strings.TrimSpace(v.Mount),
-			strings.TrimSpace(v.View),
-			strings.TrimSpace(v.dip),
-			strings.TrimSpace(v.azimuth),
-			strings.TrimSpace(v.vertical),
-			strings.TrimSpace(v.north),
-			strings.TrimSpace(v.east),
-			v.Start.Format(DateTimeFormat),
-			v.End.Format(DateTimeFormat),
+			strings.TrimSpace(row.Make),
+			strings.TrimSpace(row.Model),
+			strings.TrimSpace(row.Serial),
+			strings.TrimSpace(row.Mount),
+			strings.TrimSpace(row.View),
+			strings.TrimSpace(row.dip),
+			strings.TrimSpace(row.azimuth),
+			strings.TrimSpace(row.vertical),
+			strings.TrimSpace(row.north),
+			strings.TrimSpace(row.east),
+			row.Start.Format(DateTimeFormat),
+			row.End.Format(DateTimeFormat),
 		})
 	}
+
 	return data
 }
 
-func (a *InstalledDoasList) decode(data [][]string) error {
+func (id *InstalledDoasList) decode(data [][]string) error {
+	if !(len(data) > 1) {
+		return nil
+	}
+
 	var doases []InstalledDoas
-	if len(data) > 1 {
-		for _, d := range data[1:] {
-			if len(d) != installedDoasLast {
-				return fmt.Errorf("incorrect number of installed doas fields")
-			}
-			var err error
 
-			var dip, azimuth float64
-			if dip, err = strconv.ParseFloat(d[installedDoasDip], 64); err != nil {
-				return err
-			}
-			if azimuth, err = strconv.ParseFloat(d[installedDoasAzimuth], 64); err != nil {
-				return err
-			}
+	fields := installedDoasHeaders.Fields(data[0])
+	for _, row := range data[1:] {
+		d := fields.Remap(row)
 
-			var height, north, east float64
-			if height, err = strconv.ParseFloat(d[installedDoasHeight], 64); err != nil {
-				return err
-			}
-			if north, err = strconv.ParseFloat(d[installedDoasNorth], 64); err != nil {
-				return err
-			}
-			if east, err = strconv.ParseFloat(d[installedDoasEast], 64); err != nil {
-				return err
-			}
-
-			var start, end time.Time
-			if start, err = time.Parse(DateTimeFormat, d[installedDoasStart]); err != nil {
-				return err
-			}
-			if end, err = time.Parse(DateTimeFormat, d[installedDoasEnd]); err != nil {
-				return err
-			}
-
-			doases = append(doases, InstalledDoas{
-				Install: Install{
-					Equipment: Equipment{
-						Make:   strings.TrimSpace(d[installedDoasMake]),
-						Model:  strings.TrimSpace(d[installedDoasModel]),
-						Serial: strings.TrimSpace(d[installedDoasSerial]),
-					},
-					Span: Span{
-						Start: start,
-						End:   end,
-					},
-				},
-				Orientation: Orientation{
-					Dip:     dip,
-					Azimuth: azimuth,
-
-					dip:     strings.TrimSpace(d[installedDoasDip]),
-					azimuth: strings.TrimSpace(d[installedDoasAzimuth]),
-				},
-				Offset: Offset{
-					Vertical: height,
-					North:    north,
-					East:     east,
-
-					vertical: strings.TrimSpace(d[installedDoasHeight]),
-					north:    strings.TrimSpace(d[installedDoasNorth]),
-					east:     strings.TrimSpace(d[installedDoasEast]),
-				},
-				Mount: strings.TrimSpace(d[installedDoasMount]),
-				View:  strings.TrimSpace(d[installedDoasView]),
-			})
+		dip, err := strconv.ParseFloat(d[installedDoasDip], 64)
+		if err != nil {
+			return err
+		}
+		azimuth, err := strconv.ParseFloat(d[installedDoasAzimuth], 64)
+		if err != nil {
+			return err
 		}
 
-		*a = InstalledDoasList(doases)
+		height, err := strconv.ParseFloat(d[installedDoasHeight], 64)
+		if err != nil {
+			return err
+		}
+		north, err := strconv.ParseFloat(d[installedDoasNorth], 64)
+		if err != nil {
+			return err
+		}
+		east, err := strconv.ParseFloat(d[installedDoasEast], 64)
+		if err != nil {
+			return err
+		}
+
+		start, err := time.Parse(DateTimeFormat, d[installedDoasStart])
+		if err != nil {
+			return err
+		}
+		end, err := time.Parse(DateTimeFormat, d[installedDoasEnd])
+		if err != nil {
+			return err
+		}
+
+		doases = append(doases, InstalledDoas{
+			Install: Install{
+				Equipment: Equipment{
+					Make:   strings.TrimSpace(d[installedDoasMake]),
+					Model:  strings.TrimSpace(d[installedDoasModel]),
+					Serial: strings.TrimSpace(d[installedDoasSerial]),
+				},
+				Span: Span{
+					Start: start,
+					End:   end,
+				},
+			},
+			Orientation: Orientation{
+				Dip:     dip,
+				Azimuth: azimuth,
+
+				dip:     strings.TrimSpace(d[installedDoasDip]),
+				azimuth: strings.TrimSpace(d[installedDoasAzimuth]),
+			},
+			Offset: Offset{
+				Vertical: height,
+				North:    north,
+				East:     east,
+
+				vertical: strings.TrimSpace(d[installedDoasHeight]),
+				north:    strings.TrimSpace(d[installedDoasNorth]),
+				east:     strings.TrimSpace(d[installedDoasEast]),
+			},
+			Mount: strings.TrimSpace(d[installedDoasMount]),
+			View:  strings.TrimSpace(d[installedDoasView]),
+		})
 	}
+
+	*id = InstalledDoasList(doases)
+
 	return nil
 }
 
 func LoadInstalledDoass(path string) ([]InstalledDoas, error) {
-	var a []InstalledDoas
+	var id []InstalledDoas
 
-	if err := LoadList(path, (*InstalledDoasList)(&a)); err != nil {
+	if err := LoadList(path, (*InstalledDoasList)(&id)); err != nil {
 		return nil, err
 	}
 
-	sort.Sort(InstalledDoasList(a))
+	sort.Sort(InstalledDoasList(id))
 
-	return a, nil
+	return id, nil
 }

--- a/meta/feature.go
+++ b/meta/feature.go
@@ -99,16 +99,16 @@ func (f FeatureList) encode() [][]string {
 	var data [][]string
 
 	data = append(data, featureHeaders.Columns())
-	for _, v := range f {
+	for _, row := range f {
 		data = append(data, []string{
-			strings.TrimSpace(v.Station),
-			strings.TrimSpace(v.Location),
-			strings.TrimSpace(v.Sublocation),
-			strings.TrimSpace(v.Property),
-			strings.TrimSpace(v.Description),
-			strings.TrimSpace(v.Aspect),
-			v.Start.Format(DateTimeFormat),
-			v.End.Format(DateTimeFormat),
+			strings.TrimSpace(row.Station),
+			strings.TrimSpace(row.Location),
+			strings.TrimSpace(row.Sublocation),
+			strings.TrimSpace(row.Property),
+			strings.TrimSpace(row.Description),
+			strings.TrimSpace(row.Aspect),
+			row.Start.Format(DateTimeFormat),
+			row.End.Format(DateTimeFormat),
 		})
 	}
 
@@ -123,8 +123,8 @@ func (f *FeatureList) decode(data [][]string) error {
 	var features []Feature
 
 	fields := featureHeaders.Fields(data[0])
-	for _, v := range data[1:] {
-		d := fields.Remap(v)
+	for _, row := range data[1:] {
+		d := fields.Remap(row)
 
 		start, err := time.Parse(DateTimeFormat, d[featureStart])
 		if err != nil {

--- a/meta/gauge.go
+++ b/meta/gauge.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -20,6 +19,18 @@ const (
 	gaugeEnd
 	gaugeLast
 )
+
+var gaugeHeaders Header = map[string]int{
+	"Gauge":                 gaugeCode,
+	"Network":               gaugeNetwork,
+	"Identification Number": gaugeNumber,
+	"Analysis Time Zone":    gaugeAnalysisTimeZone,
+	"Analysis Latitude":     gaugeAnalysisLatitude,
+	"Analysis Longitude":    gaugeAnalysisLongitude,
+	"Crex Tag":              gaugeCrex,
+	"Start Date":            gaugeStart,
+	"End Date":              gaugeEnd,
+}
 
 type Gauge struct {
 	Span
@@ -51,86 +62,84 @@ func (g GaugeList) Less(i, j int) bool {
 }
 
 func (g GaugeList) encode() [][]string {
-	data := [][]string{{
-		"Gauge",
-		"Network",
-		"Identification Number",
-		"Analysis Time Zone",
-		"Analysis Latitude",
-		"Analysis Longitude",
-		"Crex Tag",
-		"Start Date",
-		"End Date",
-	}}
-	for _, v := range g {
+	var data [][]string
+
+	data = append(data, gaugeHeaders.Columns())
+
+	for _, row := range g {
 		data = append(data, []string{
-			strings.TrimSpace(v.Code),
-			strings.TrimSpace(v.Network),
-			strings.TrimSpace(v.Number),
-			strings.TrimSpace(v.timeZone),
-			strings.TrimSpace(v.latitude),
-			strings.TrimSpace(v.longitude),
-			strings.TrimSpace(v.Crex),
-			v.Start.Format(DateTimeFormat),
-			v.End.Format(DateTimeFormat),
+			strings.TrimSpace(row.Code),
+			strings.TrimSpace(row.Network),
+			strings.TrimSpace(row.Number),
+			strings.TrimSpace(row.timeZone),
+			strings.TrimSpace(row.latitude),
+			strings.TrimSpace(row.longitude),
+			strings.TrimSpace(row.Crex),
+			row.Start.Format(DateTimeFormat),
+			row.End.Format(DateTimeFormat),
 		})
 	}
+
 	return data
 }
 
 func (g *GaugeList) decode(data [][]string) error {
+	if !(len(data) > 1) {
+		return nil
+	}
+
 	var gauges []Gauge
-	if len(data) > 1 {
-		for _, d := range data[1:] {
-			if len(d) != gaugeLast {
-				return fmt.Errorf("incorrect number of installed gauge fields")
-			}
-			var err error
 
-			var lat, lon, zone float64
-			if zone, err = strconv.ParseFloat(d[gaugeAnalysisTimeZone], 64); err != nil {
-				return err
-			}
-			if lat, err = strconv.ParseFloat(d[gaugeAnalysisLatitude], 64); err != nil {
-				return err
-			}
-			if lon, err = strconv.ParseFloat(d[gaugeAnalysisLongitude], 64); err != nil {
-				return err
-			}
+	fields := gaugeHeaders.Fields(data[0])
+	for _, row := range data[1:] {
+		d := fields.Remap(row)
 
-			start, err := time.Parse(DateTimeFormat, d[gaugeStart])
-			if err != nil {
-				return err
-			}
-			end, err := time.Parse(DateTimeFormat, d[gaugeEnd])
-			if err != nil {
-				return err
-			}
-
-			gauges = append(gauges, Gauge{
-				Span: Span{
-					Start: start,
-					End:   end,
-				},
-				Reference: Reference{
-					Code:    strings.TrimSpace(d[gaugeCode]),
-					Network: strings.TrimSpace(d[gaugeNetwork]),
-				},
-				Number: strings.TrimSpace(d[gaugeNumber]),
-				Point: Point{
-					Latitude:  lat,
-					Longitude: lon,
-					latitude:  strings.TrimSpace(d[gaugeAnalysisLatitude]),
-					longitude: strings.TrimSpace(d[gaugeAnalysisLongitude]),
-				},
-				Crex:     strings.TrimSpace(d[gaugeCrex]),
-				TimeZone: zone,
-				timeZone: strings.TrimSpace(d[gaugeAnalysisTimeZone]),
-			})
+		zone, err := strconv.ParseFloat(d[gaugeAnalysisTimeZone], 64)
+		if err != nil {
+			return err
+		}
+		lat, err := strconv.ParseFloat(d[gaugeAnalysisLatitude], 64)
+		if err != nil {
+			return err
+		}
+		lon, err := strconv.ParseFloat(d[gaugeAnalysisLongitude], 64)
+		if err != nil {
+			return err
 		}
 
-		*g = GaugeList(gauges)
+		start, err := time.Parse(DateTimeFormat, d[gaugeStart])
+		if err != nil {
+			return err
+		}
+		end, err := time.Parse(DateTimeFormat, d[gaugeEnd])
+		if err != nil {
+			return err
+		}
+
+		gauges = append(gauges, Gauge{
+			Span: Span{
+				Start: start,
+				End:   end,
+			},
+			Reference: Reference{
+				Code:    strings.TrimSpace(d[gaugeCode]),
+				Network: strings.TrimSpace(d[gaugeNetwork]),
+			},
+			Number: strings.TrimSpace(d[gaugeNumber]),
+			Point: Point{
+				Latitude:  lat,
+				Longitude: lon,
+				latitude:  strings.TrimSpace(d[gaugeAnalysisLatitude]),
+				longitude: strings.TrimSpace(d[gaugeAnalysisLongitude]),
+			},
+			Crex:     strings.TrimSpace(d[gaugeCrex]),
+			TimeZone: zone,
+			timeZone: strings.TrimSpace(d[gaugeAnalysisTimeZone]),
+		})
 	}
+
+	*g = GaugeList(gauges)
+
 	return nil
 }
 

--- a/meta/mark.go
+++ b/meta/mark.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -22,6 +21,19 @@ const (
 	markLast
 )
 
+var markHeaders Header = map[string]int{
+	"Mark":       markCode,
+	"Network":    markNetwork,
+	"Igs":        markIgs,
+	"Name":       markName,
+	"Latitude":   markLatitude,
+	"Longitude":  markLongitude,
+	"Elevation":  markElevation,
+	"Datum":      markDatum,
+	"Start Date": markStartTime,
+	"End Date":   markEndTime,
+}
+
 type Mark struct {
 	Reference
 	Point
@@ -37,105 +49,103 @@ func (m MarkList) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
 func (m MarkList) Less(i, j int) bool { return m[i].Code < m[j].Code }
 
 func (m MarkList) encode() [][]string {
-	data := [][]string{{
-		"Mark",
-		"Network",
-		"Igs",
-		"Name",
-		"Latitude",
-		"Longitude",
-		"Elevation",
-		"Datum",
-		"Start Date",
-		"End Date",
-	}}
-	for _, v := range m {
+	var data [][]string
+
+	data = append(data, markHeaders.Columns())
+	for _, row := range m {
 		data = append(data, []string{
-			strings.TrimSpace(v.Code),
-			strings.TrimSpace(v.Network),
+			strings.TrimSpace(row.Code),
+			strings.TrimSpace(row.Network),
 			func() string {
-				if v.Igs {
+				if row.Igs {
 					return "yes"
 				}
 				return "no"
 			}(),
-			strings.TrimSpace(v.Name),
-			strings.TrimSpace(v.latitude),
-			strings.TrimSpace(v.longitude),
-			strings.TrimSpace(v.elevation),
-			strings.TrimSpace(v.Datum),
-			v.Start.Format(DateTimeFormat),
-			v.End.Format(DateTimeFormat),
+			strings.TrimSpace(row.Name),
+			strings.TrimSpace(row.latitude),
+			strings.TrimSpace(row.longitude),
+			strings.TrimSpace(row.elevation),
+			strings.TrimSpace(row.Datum),
+			row.Start.Format(DateTimeFormat),
+			row.End.Format(DateTimeFormat),
 		})
 	}
+
 	return data
 }
 
 func (m *MarkList) decode(data [][]string) error {
+	if !(len(data) > 1) {
+		return nil
+	}
+
 	var marks []Mark
-	if len(data) > 1 {
-		for _, d := range data[1:] {
-			if len(d) != markLast {
-				return fmt.Errorf("incorrect number of installed mark fields")
-			}
-			var err error
 
-			var igs bool
-			if igs, err = strconv.ParseBool(d[markIgs]); err != nil {
-				switch d[markIgs] {
-				case "y", "Y", "yes", "YES":
-					igs = true
-				case "n", "N", "no", "NO":
-					igs = false
-				default:
-					return err
-				}
-			}
+	fields := markHeaders.Fields(data[0])
+	for _, row := range data[1:] {
+		d := fields.Remap(row)
 
-			var lat, lon, elev float64
-			if lat, err = strconv.ParseFloat(d[markLatitude], 64); err != nil {
+		igs, err := strconv.ParseBool(d[markIgs])
+		if err != nil {
+			switch d[markIgs] {
+			case "y", "Y", "yes", "YES":
+				igs = true
+			case "n", "N", "no", "NO":
+				igs = false
+			default:
 				return err
 			}
-			if lon, err = strconv.ParseFloat(d[markLongitude], 64); err != nil {
-				return err
-			}
-			if elev, err = strconv.ParseFloat(d[markElevation], 64); err != nil {
-				return err
-			}
-
-			var start, end time.Time
-			if start, err = time.Parse(DateTimeFormat, d[markStartTime]); err != nil {
-				return err
-			}
-			if end, err = time.Parse(DateTimeFormat, d[markEndTime]); err != nil {
-				return err
-			}
-			marks = append(marks, Mark{
-				Reference: Reference{
-					Code:    strings.TrimSpace(d[markCode]),
-					Network: strings.TrimSpace(d[markNetwork]),
-					Name:    strings.TrimSpace(d[markName]),
-				},
-				Span: Span{
-					Start: start,
-					End:   end,
-				},
-				Point: Point{
-					Latitude:  lat,
-					Longitude: lon,
-					Elevation: elev,
-					Datum:     strings.TrimSpace(d[markDatum]),
-
-					latitude:  strings.TrimSpace(d[markLatitude]),
-					longitude: strings.TrimSpace(d[markLongitude]),
-					elevation: strings.TrimSpace(d[markElevation]),
-				},
-				Igs: igs,
-			})
 		}
 
-		*m = MarkList(marks)
+		lat, err := strconv.ParseFloat(d[markLatitude], 64)
+		if err != nil {
+			return err
+		}
+		lon, err := strconv.ParseFloat(d[markLongitude], 64)
+		if err != nil {
+			return err
+		}
+		elev, err := strconv.ParseFloat(d[markElevation], 64)
+		if err != nil {
+			return err
+		}
+
+		start, err := time.Parse(DateTimeFormat, d[markStartTime])
+		if err != nil {
+			return err
+		}
+		end, err := time.Parse(DateTimeFormat, d[markEndTime])
+		if err != nil {
+			return err
+		}
+
+		marks = append(marks, Mark{
+			Reference: Reference{
+				Code:    strings.TrimSpace(d[markCode]),
+				Network: strings.TrimSpace(d[markNetwork]),
+				Name:    strings.TrimSpace(d[markName]),
+			},
+			Span: Span{
+				Start: start,
+				End:   end,
+			},
+			Point: Point{
+				Latitude:  lat,
+				Longitude: lon,
+				Elevation: elev,
+				Datum:     strings.TrimSpace(d[markDatum]),
+
+				latitude:  strings.TrimSpace(d[markLatitude]),
+				longitude: strings.TrimSpace(d[markLongitude]),
+				elevation: strings.TrimSpace(d[markElevation]),
+			},
+			Igs: igs,
+		})
 	}
+
+	*m = MarkList(marks)
+
 	return nil
 }
 

--- a/meta/metsensor.go
+++ b/meta/metsensor.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -9,22 +8,39 @@ import (
 )
 
 const (
-	installedMetsensorMake = iota
-	installedMetsensorModel
-	installedMetsensorSerial
-	installedMetsensorMark
-	installedMetsensorIMSComment
-	installedMetsensorHumidityAccuracy
-	installedMetsensorPressureAccuracy
-	installedMetsensorTemperatureAccuracy
-	installedMetsensorLatitude
-	installedMetsensorLongitude
-	installedMetsensorElevation
-	installedMetsensorDatum
-	installedMetsensorStart
-	installedMetsensorStop
-	installedMetsensorLast
+	installedMetSensorMake = iota
+	installedMetSensorModel
+	installedMetSensorSerial
+	installedMetSensorMark
+	installedMetSensorIMSComment
+	installedMetSensorHumidityAccuracy
+	installedMetSensorPressureAccuracy
+	installedMetSensorTemperatureAccuracy
+	installedMetSensorLatitude
+	installedMetSensorLongitude
+	installedMetSensorElevation
+	installedMetSensorDatum
+	installedMetSensorStart
+	installedMetSensorStop
+	installedMetSensorLast
 )
+
+var installedMetSensorHeaders Header = map[string]int{
+	"Make":        installedMetSensorMake,
+	"Model":       installedMetSensorModel,
+	"Serial":      installedMetSensorSerial,
+	"Mark":        installedMetSensorMark,
+	"IMS Comment": installedMetSensorIMSComment,
+	"Humidity":    installedMetSensorHumidityAccuracy,
+	"Pressure":    installedMetSensorPressureAccuracy,
+	"Temperature": installedMetSensorTemperatureAccuracy,
+	"Latitude":    installedMetSensorLatitude,
+	"Longitude":   installedMetSensorLongitude,
+	"Elevation":   installedMetSensorElevation,
+	"Datum":       installedMetSensorDatum,
+	"Start Date":  installedMetSensorStart,
+	"End Date":    installedMetSensorStop,
+}
 
 type MetSensorAccuracy struct {
 	Humidity    float64
@@ -47,136 +63,132 @@ type InstalledMetSensor struct {
 
 type InstalledMetSensorList []InstalledMetSensor
 
-func (m InstalledMetSensorList) Len() int           { return len(m) }
-func (m InstalledMetSensorList) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
-func (m InstalledMetSensorList) Less(i, j int) bool { return m[i].Install.Less(m[j].Install) }
+func (ims InstalledMetSensorList) Len() int           { return len(ims) }
+func (ims InstalledMetSensorList) Swap(i, j int)      { ims[i], ims[j] = ims[j], ims[i] }
+func (ims InstalledMetSensorList) Less(i, j int) bool { return ims[i].Install.Less(ims[j].Install) }
 
-func (m InstalledMetSensorList) encode() [][]string {
-	data := [][]string{{
-		"Make",
-		"Model",
-		"Serial",
-		"Mark",
-		"IMS Comment",
-		"Humidity",
-		"Pressure",
-		"Temperature",
-		"Latitude",
-		"Longitude",
-		"Elevation",
-		"Datum",
-		"Start Date",
-		"End Date",
-	}}
-	for _, v := range m {
+func (ims InstalledMetSensorList) encode() [][]string {
+	var data [][]string
+
+	data = append(data, installedMetSensorHeaders.Columns())
+
+	for _, row := range ims {
 		data = append(data, []string{
-			strings.TrimSpace(v.Make),
-			strings.TrimSpace(v.Model),
-			strings.TrimSpace(v.Serial),
-			strings.TrimSpace(v.Mark),
-			strings.TrimSpace(v.IMSComment),
-			strings.TrimSpace(v.Accuracy.humidity),
-			strings.TrimSpace(v.Accuracy.pressure),
-			strings.TrimSpace(v.Accuracy.temperature),
-			strings.TrimSpace(v.latitude),
-			strings.TrimSpace(v.longitude),
-			strings.TrimSpace(v.elevation),
-			strings.TrimSpace(v.Datum),
-			v.Start.Format(DateTimeFormat),
-			v.End.Format(DateTimeFormat),
+			strings.TrimSpace(row.Make),
+			strings.TrimSpace(row.Model),
+			strings.TrimSpace(row.Serial),
+			strings.TrimSpace(row.Mark),
+			strings.TrimSpace(row.IMSComment),
+			strings.TrimSpace(row.Accuracy.humidity),
+			strings.TrimSpace(row.Accuracy.pressure),
+			strings.TrimSpace(row.Accuracy.temperature),
+			strings.TrimSpace(row.latitude),
+			strings.TrimSpace(row.longitude),
+			strings.TrimSpace(row.elevation),
+			strings.TrimSpace(row.Datum),
+			row.Start.Format(DateTimeFormat),
+			row.End.Format(DateTimeFormat),
 		})
 	}
+
 	return data
 }
 
-func (m *InstalledMetSensorList) decode(data [][]string) error {
-	var installedMetsensors []InstalledMetSensor
-	if len(data) > 1 {
-		for _, d := range data[1:] {
-			if len(d) != installedMetsensorLast {
-				return fmt.Errorf("incorrect number of installed metsensor fields")
-			}
-			var err error
+func (ims *InstalledMetSensorList) decode(data [][]string) error {
+	if !(len(data) > 1) {
+		return nil
+	}
 
-			var h, p, t float64
-			if h, err = strconv.ParseFloat(d[installedMetsensorHumidityAccuracy], 64); err != nil {
-				return err
-			}
-			if p, err = strconv.ParseFloat(d[installedMetsensorPressureAccuracy], 64); err != nil {
-				return err
-			}
-			if t, err = strconv.ParseFloat(d[installedMetsensorTemperatureAccuracy], 64); err != nil {
-				return err
-			}
+	var installedMetSensors []InstalledMetSensor
 
-			var lat, lon, elev float64
-			if lat, err = strconv.ParseFloat(d[installedMetsensorLatitude], 64); err != nil {
-				return err
-			}
-			if lon, err = strconv.ParseFloat(d[installedMetsensorLongitude], 64); err != nil {
-				return err
-			}
-			if elev, err = strconv.ParseFloat(d[installedMetsensorElevation], 64); err != nil {
-				return err
-			}
+	fields := installedMetSensorHeaders.Fields(data[0])
+	for _, row := range data[1:] {
+		d := fields.Remap(row)
 
-			var start, end time.Time
-			if start, err = time.Parse(DateTimeFormat, d[installedMetsensorStart]); err != nil {
-				return err
-			}
-			if end, err = time.Parse(DateTimeFormat, d[installedMetsensorStop]); err != nil {
-				return err
-			}
-
-			installedMetsensors = append(installedMetsensors, InstalledMetSensor{
-				Install: Install{
-					Equipment: Equipment{
-						Make:   strings.TrimSpace(d[installedMetsensorMake]),
-						Model:  strings.TrimSpace(d[installedMetsensorModel]),
-						Serial: strings.TrimSpace(d[installedMetsensorSerial]),
-					},
-					Span: Span{
-						Start: start,
-						End:   end,
-					},
-				},
-				Point: Point{
-					Latitude:  lat,
-					Longitude: lon,
-					Elevation: elev,
-					Datum:     strings.TrimSpace(d[installedMetsensorDatum]),
-
-					latitude:  strings.TrimSpace(d[installedMetsensorLatitude]),
-					longitude: strings.TrimSpace(d[installedMetsensorLongitude]),
-					elevation: strings.TrimSpace(d[installedMetsensorElevation]),
-				},
-				Mark:       strings.TrimSpace(d[installedMetsensorMark]),
-				IMSComment: strings.TrimSpace(d[installedMetsensorIMSComment]),
-				Accuracy: MetSensorAccuracy{
-					Humidity:    h,
-					Pressure:    p,
-					Temperature: t,
-
-					humidity:    strings.TrimSpace(d[installedMetsensorHumidityAccuracy]),
-					pressure:    strings.TrimSpace(d[installedMetsensorPressureAccuracy]),
-					temperature: strings.TrimSpace(d[installedMetsensorTemperatureAccuracy]),
-				},
-			})
+		h, err := strconv.ParseFloat(d[installedMetSensorHumidityAccuracy], 64)
+		if err != nil {
+			return err
+		}
+		p, err := strconv.ParseFloat(d[installedMetSensorPressureAccuracy], 64)
+		if err != nil {
+			return err
+		}
+		t, err := strconv.ParseFloat(d[installedMetSensorTemperatureAccuracy], 64)
+		if err != nil {
+			return err
 		}
 
-		*m = InstalledMetSensorList(installedMetsensors)
+		lat, err := strconv.ParseFloat(d[installedMetSensorLatitude], 64)
+		if err != nil {
+			return err
+		}
+		lon, err := strconv.ParseFloat(d[installedMetSensorLongitude], 64)
+		if err != nil {
+			return err
+		}
+		elev, err := strconv.ParseFloat(d[installedMetSensorElevation], 64)
+		if err != nil {
+			return err
+		}
+
+		start, err := time.Parse(DateTimeFormat, d[installedMetSensorStart])
+		if err != nil {
+			return err
+		}
+		end, err := time.Parse(DateTimeFormat, d[installedMetSensorStop])
+		if err != nil {
+			return err
+		}
+
+		installedMetSensors = append(installedMetSensors, InstalledMetSensor{
+			Install: Install{
+				Equipment: Equipment{
+					Make:   strings.TrimSpace(d[installedMetSensorMake]),
+					Model:  strings.TrimSpace(d[installedMetSensorModel]),
+					Serial: strings.TrimSpace(d[installedMetSensorSerial]),
+				},
+				Span: Span{
+					Start: start,
+					End:   end,
+				},
+			},
+			Point: Point{
+				Latitude:  lat,
+				Longitude: lon,
+				Elevation: elev,
+				Datum:     strings.TrimSpace(d[installedMetSensorDatum]),
+
+				latitude:  strings.TrimSpace(d[installedMetSensorLatitude]),
+				longitude: strings.TrimSpace(d[installedMetSensorLongitude]),
+				elevation: strings.TrimSpace(d[installedMetSensorElevation]),
+			},
+			Mark:       strings.TrimSpace(d[installedMetSensorMark]),
+			IMSComment: strings.TrimSpace(d[installedMetSensorIMSComment]),
+			Accuracy: MetSensorAccuracy{
+				Humidity:    h,
+				Pressure:    p,
+				Temperature: t,
+
+				humidity:    strings.TrimSpace(d[installedMetSensorHumidityAccuracy]),
+				pressure:    strings.TrimSpace(d[installedMetSensorPressureAccuracy]),
+				temperature: strings.TrimSpace(d[installedMetSensorTemperatureAccuracy]),
+			},
+		})
 	}
+
+	*ims = InstalledMetSensorList(installedMetSensors)
+
 	return nil
 }
 
 func LoadInstalledMetSensors(path string) ([]InstalledMetSensor, error) {
-	var m []InstalledMetSensor
+	var ims []InstalledMetSensor
 
-	if err := LoadList(path, (*InstalledMetSensorList)(&m)); err != nil {
+	if err := LoadList(path, (*InstalledMetSensorList)(&ims)); err != nil {
 		return nil, err
 	}
 
-	sort.Sort(InstalledMetSensorList(m))
+	sort.Sort(InstalledMetSensorList(ims))
 
-	return m, nil
+	return ims, nil
 }

--- a/meta/sample.go
+++ b/meta/sample.go
@@ -89,18 +89,18 @@ func (s SampleList) encode() [][]string {
 	var data [][]string
 
 	data = append(data, sampleHeaders.Columns())
-	for _, v := range s {
+	for _, row := range s {
 		data = append(data, []string{
-			strings.TrimSpace(v.Code),
-			strings.TrimSpace(v.Network),
-			strings.TrimSpace(v.Name),
-			strings.TrimSpace(v.latitude),
-			strings.TrimSpace(v.longitude),
-			strings.TrimSpace(v.elevation),
-			strings.TrimSpace(v.depth),
-			strings.TrimSpace(v.Datum),
-			v.Start.Format(DateTimeFormat),
-			v.End.Format(DateTimeFormat),
+			strings.TrimSpace(row.Code),
+			strings.TrimSpace(row.Network),
+			strings.TrimSpace(row.Name),
+			strings.TrimSpace(row.latitude),
+			strings.TrimSpace(row.longitude),
+			strings.TrimSpace(row.elevation),
+			strings.TrimSpace(row.depth),
+			strings.TrimSpace(row.Datum),
+			row.Start.Format(DateTimeFormat),
+			row.End.Format(DateTimeFormat),
 		})
 	}
 
@@ -115,8 +115,8 @@ func (s *SampleList) decode(data [][]string) error {
 	}
 
 	fields := sampleHeaders.Fields(data[0])
-	for _, v := range data[1:] {
-		d := fields.Remap(v)
+	for _, row := range data[1:] {
+		d := fields.Remap(row)
 
 		lat, err := strconv.ParseFloat(d[sampleLatitude], 64)
 		if err != nil {

--- a/meta/site.go
+++ b/meta/site.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -22,6 +21,19 @@ const (
 	siteLast
 )
 
+var siteHeaders Header = map[string]int{
+	"Station":    siteStation,
+	"Location":   siteLocation,
+	"Latitude":   siteLatitude,
+	"Longitude":  siteLongitude,
+	"Elevation":  siteElevation,
+	"Depth":      siteDepth,
+	"Datum":      siteDatum,
+	"Survey":     siteSurvey,
+	"Start Date": siteStart,
+	"End Date":   siteEnd,
+}
+
 type Site struct {
 	Point
 	Span
@@ -30,16 +42,6 @@ type Site struct {
 	Location string
 	Survey   string
 }
-
-/*
-func (s Site) Elevation() (float64, bool) {
-	return 0, false
-}
-
-func (s Site) Depth() (float64, bool) {
-	return 0, false
-}
-*/
 
 func (s Site) Less(site Site) bool {
 	switch {
@@ -63,31 +65,21 @@ func (s SiteList) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s SiteList) Less(i, j int) bool { return s[i].Less(s[j]) }
 
 func (s SiteList) encode() [][]string {
-	data := [][]string{{
-		"Station",
-		"Location",
-		"Latitude",
-		"Longitude",
-		"Elevation",
-		"Depth",
-		"Datum",
-		"Survey",
-		"Start Date",
-		"End Date",
-	}}
+	var data [][]string
 
-	for _, v := range s {
+	data = append(data, siteHeaders.Columns())
+	for _, row := range s {
 		data = append(data, []string{
-			strings.TrimSpace(v.Station),
-			strings.TrimSpace(v.Location),
-			strings.TrimSpace(v.latitude),
-			strings.TrimSpace(v.longitude),
-			strings.TrimSpace(v.elevation),
-			strings.TrimSpace(v.depth),
-			strings.TrimSpace(v.Datum),
-			strings.TrimSpace(v.Survey),
-			v.Start.Format(DateTimeFormat),
-			v.End.Format(DateTimeFormat),
+			strings.TrimSpace(row.Station),
+			strings.TrimSpace(row.Location),
+			strings.TrimSpace(row.latitude),
+			strings.TrimSpace(row.longitude),
+			strings.TrimSpace(row.elevation),
+			strings.TrimSpace(row.depth),
+			strings.TrimSpace(row.Datum),
+			strings.TrimSpace(row.Survey),
+			row.Start.Format(DateTimeFormat),
+			row.End.Format(DateTimeFormat),
 		})
 	}
 
@@ -96,66 +88,67 @@ func (s SiteList) encode() [][]string {
 
 func (s *SiteList) decode(data [][]string) error {
 	var sites []Site
-	if len(data) > 1 {
-		for _, d := range data[1:] {
-			if len(d) != siteLast {
-				return fmt.Errorf("incorrect number of installed site fields")
-			}
-			var err error
 
-			var lat, lon, elev, depth float64
-			if lat, err = strconv.ParseFloat(d[siteLatitude], 64); err != nil {
-				return err
-			}
-			if lon, err = strconv.ParseFloat(d[siteLongitude], 64); err != nil {
-				return err
-			}
-			if d[siteElevation] != "" {
-				if elev, err = strconv.ParseFloat(d[siteElevation], 64); err != nil {
-					return err
-				}
-			}
-			if d[siteDepth] != "" {
-				if depth, err = strconv.ParseFloat(d[siteDepth], 64); err != nil {
-					return err
-				}
-			}
+	if !(len(data) > 1) {
+		return nil
+	}
 
-			var start, end time.Time
-			if start, err = time.Parse(DateTimeFormat, d[siteStart]); err != nil {
-				return err
-			}
-			if end, err = time.Parse(DateTimeFormat, d[siteEnd]); err != nil {
-				return err
-			}
+	fields := siteHeaders.Fields(data[0])
+	for _, row := range data[1:] {
+		d := fields.Remap(row)
 
-			sites = append(sites, Site{
-				Point: Point{
-					// geographic details
-					Latitude:  lat,
-					Longitude: lon,
-					Elevation: elev,
-					Depth:     depth,
-					Datum:     strings.TrimSpace(d[siteDatum]),
-
-					// shadow variables
-					latitude:  d[siteLatitude],
-					longitude: d[siteLongitude],
-					elevation: d[siteElevation],
-					depth:     d[siteDepth],
-				},
-				Span: Span{
-					Start: start,
-					End:   end,
-				},
-				Station:  strings.TrimSpace(d[siteStation]),
-				Location: strings.TrimSpace(d[siteLocation]),
-				Survey:   strings.TrimSpace(d[siteSurvey]),
-			})
+		lat, err := strconv.ParseFloat(d[siteLatitude], 64)
+		if err != nil {
+			return err
+		}
+		lon, err := strconv.ParseFloat(d[siteLongitude], 64)
+		if err != nil {
+			return err
+		}
+		elev, err := ParseFloat64(d[siteElevation])
+		if err != nil {
+			return err
+		}
+		depth, err := ParseFloat64(d[siteDepth])
+		if err != nil {
+			return err
 		}
 
-		*s = SiteList(sites)
+		start, err := time.Parse(DateTimeFormat, d[siteStart])
+		if err != nil {
+			return err
+		}
+		end, err := time.Parse(DateTimeFormat, d[siteEnd])
+		if err != nil {
+			return err
+		}
+
+		sites = append(sites, Site{
+			Point: Point{
+				// geographic details
+				Latitude:  lat,
+				Longitude: lon,
+				Elevation: elev,
+				Depth:     depth,
+				Datum:     strings.TrimSpace(d[siteDatum]),
+
+				// shadow variables
+				latitude:  d[siteLatitude],
+				longitude: d[siteLongitude],
+				elevation: d[siteElevation],
+				depth:     d[siteDepth],
+			},
+			Span: Span{
+				Start: start,
+				End:   end,
+			},
+			Station:  strings.TrimSpace(d[siteStation]),
+			Location: strings.TrimSpace(d[siteLocation]),
+			Survey:   strings.TrimSpace(d[siteSurvey]),
+		})
 	}
+
+	*s = SiteList(sites)
 
 	return nil
 }

--- a/meta/station.go
+++ b/meta/station.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -21,6 +20,19 @@ const (
 	stationEnd
 	stationLast
 )
+
+var stationHeaders Header = map[string]int{
+	"Station":    stationCode,
+	"Network":    stationNetwork,
+	"Name":       stationName,
+	"Latitude":   stationLatitude,
+	"Longitude":  stationLongitude,
+	"Elevation":  stationElevation,
+	"Depth":      stationDepth,
+	"Datum":      stationDatum,
+	"Start Date": stationStart,
+	"End Date":   stationEnd,
+}
 
 type Station struct {
 	Reference
@@ -46,97 +58,94 @@ func (s StationList) Less(i, j int) bool {
 }
 
 func (s StationList) encode() [][]string {
-	data := [][]string{{
-		"Station",
-		"Network",
-		"Name",
-		"Latitude",
-		"Longitude",
-		"Elevation",
-		"Depth",
-		"Datum",
-		"Start Date",
-		"End Date",
-	}}
-	for _, v := range s {
+	var data [][]string
+
+	data = append(data, stationHeaders.Columns())
+	for _, row := range s {
 		data = append(data, []string{
-			strings.TrimSpace(v.Code),
-			strings.TrimSpace(v.Network),
-			strings.TrimSpace(v.Name),
-			strings.TrimSpace(v.latitude),
-			strings.TrimSpace(v.longitude),
-			strings.TrimSpace(v.elevation),
-			strings.TrimSpace(v.depth),
-			strings.TrimSpace(v.Datum),
-			v.Start.Format(DateTimeFormat),
-			v.End.Format(DateTimeFormat),
+			strings.TrimSpace(row.Code),
+			strings.TrimSpace(row.Network),
+			strings.TrimSpace(row.Name),
+			strings.TrimSpace(row.latitude),
+			strings.TrimSpace(row.longitude),
+			strings.TrimSpace(row.elevation),
+			strings.TrimSpace(row.depth),
+			strings.TrimSpace(row.Datum),
+			row.Start.Format(DateTimeFormat),
+			row.End.Format(DateTimeFormat),
 		})
 	}
+
 	return data
 }
 
 func (s *StationList) decode(data [][]string) error {
+	if !(len(data) > 1) {
+		return nil
+	}
+
 	var stations []Station
-	if len(data) > 1 {
-		for _, d := range data[1:] {
-			if len(d) != stationLast {
-				return fmt.Errorf("incorrect number of installed station fields")
-			}
-			var err error
 
-			var lat, lon, elev, depth float64
-			if lat, err = strconv.ParseFloat(d[stationLatitude], 64); err != nil {
-				return err
-			}
-			if lon, err = strconv.ParseFloat(d[stationLongitude], 64); err != nil {
-				return err
-			}
-			if d[stationElevation] != "" {
-				if elev, err = strconv.ParseFloat(d[stationElevation], 64); err != nil {
-					return err
-				}
-			}
-			if d[stationDepth] != "" {
-				if depth, err = strconv.ParseFloat(d[stationDepth], 64); err != nil {
-					return err
-				}
-			}
+	fields := stationHeaders.Fields(data[0])
+	for _, row := range data[1:] {
+		d := fields.Remap(row)
 
-			var start, end time.Time
-			if start, err = time.Parse(DateTimeFormat, d[stationStart]); err != nil {
-				return err
-			}
-			if end, err = time.Parse(DateTimeFormat, d[stationEnd]); err != nil {
-				return err
-			}
-
-			stations = append(stations, Station{
-				Reference: Reference{
-					Code:    strings.TrimSpace(d[stationCode]),
-					Network: strings.TrimSpace(d[stationNetwork]),
-					Name:    strings.TrimSpace(d[stationName]),
-				},
-				Span: Span{
-					Start: start,
-					End:   end,
-				},
-				Point: Point{
-					Latitude:  lat,
-					Longitude: lon,
-					Elevation: elev,
-					Datum:     strings.TrimSpace(d[stationDatum]),
-					Depth:     depth,
-
-					latitude:  strings.TrimSpace(d[stationLatitude]),
-					longitude: strings.TrimSpace(d[stationLongitude]),
-					elevation: strings.TrimSpace(d[stationElevation]),
-					depth:     strings.TrimSpace(d[stationDepth]),
-				},
-			})
+		lat, err := strconv.ParseFloat(d[stationLatitude], 64)
+		if err != nil {
+			return err
 		}
 
-		*s = StationList(stations)
+		lon, err := strconv.ParseFloat(d[stationLongitude], 64)
+		if err != nil {
+			return err
+		}
+
+		elev, err := ParseFloat64(d[stationElevation])
+		if err != nil {
+			return err
+		}
+
+		depth, err := ParseFloat64(d[stationDepth])
+		if err != nil {
+			return err
+		}
+
+		start, err := time.Parse(DateTimeFormat, d[stationStart])
+		if err != nil {
+			return err
+		}
+		end, err := time.Parse(DateTimeFormat, d[stationEnd])
+		if err != nil {
+			return err
+		}
+
+		stations = append(stations, Station{
+			Reference: Reference{
+				Code:    strings.TrimSpace(d[stationCode]),
+				Network: strings.TrimSpace(d[stationNetwork]),
+				Name:    strings.TrimSpace(d[stationName]),
+			},
+			Span: Span{
+				Start: start,
+				End:   end,
+			},
+			Point: Point{
+				Latitude:  lat,
+				Longitude: lon,
+				Elevation: elev,
+				Datum:     strings.TrimSpace(d[stationDatum]),
+				Depth:     depth,
+
+				latitude:  strings.TrimSpace(d[stationLatitude]),
+				longitude: strings.TrimSpace(d[stationLongitude]),
+				elevation: strings.TrimSpace(d[stationElevation]),
+				depth:     strings.TrimSpace(d[stationDepth]),
+			},
+		})
 	}
+
+	*s = StationList(stations)
+
 	return nil
 }
 

--- a/meta/streams.go
+++ b/meta/streams.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -21,6 +20,19 @@ const (
 	streamEnd
 	streamLast
 )
+
+var streamHeaders Header = map[string]int{
+	"Station":       streamStation,
+	"Location":      streamLocation,
+	"Band":          streamBand,
+	"Source":        streamSource,
+	"Sampling Rate": streamSamplingRate,
+	"Axial":         streamAxial,
+	"Reversed":      streamReversed,
+	"Triggered":     streamTriggered,
+	"Start Date":    streamStart,
+	"End Date":      streamEnd,
+}
 
 type Stream struct {
 	Span
@@ -71,87 +83,84 @@ func (s StreamList) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s StreamList) Less(i, j int) bool { return s[i].Less(s[j]) }
 
 func (s StreamList) encode() [][]string {
-	data := [][]string{{
-		"Station",
-		"Location",
-		"Band",
-		"Source",
-		"Sampling Rate",
-		"Axial",
-		"Reversed",
-		"Triggered",
-		"Start Date",
-		"End Date",
-	}}
-	for _, v := range s {
+	var data [][]string
+
+	data = append(data, streamHeaders.Columns())
+
+	for _, row := range s {
 		data = append(data, []string{
-			strings.TrimSpace(v.Station),
-			strings.TrimSpace(v.Location),
-			strings.TrimSpace(v.Band),
-			strings.TrimSpace(v.Source),
-			strings.TrimSpace(v.samplingRate),
-			strings.TrimSpace(v.Axial),
-			strings.TrimSpace(strconv.FormatBool(v.Reversed)),
-			strings.TrimSpace(strconv.FormatBool(v.Triggered)),
-			v.Start.Format(DateTimeFormat),
-			v.End.Format(DateTimeFormat),
+			strings.TrimSpace(row.Station),
+			strings.TrimSpace(row.Location),
+			strings.TrimSpace(row.Band),
+			strings.TrimSpace(row.Source),
+			strings.TrimSpace(row.samplingRate),
+			strings.TrimSpace(row.Axial),
+			strings.TrimSpace(strconv.FormatBool(row.Reversed)),
+			strings.TrimSpace(strconv.FormatBool(row.Triggered)),
+			row.Start.Format(DateTimeFormat),
+			row.End.Format(DateTimeFormat),
 		})
 	}
+
 	return data
 }
 
-func (c *StreamList) decode(data [][]string) error {
+func (s *StreamList) decode(data [][]string) error {
+	if !(len(data) > 1) {
+		return nil
+	}
+
 	var streams []Stream
-	if len(data) > 1 {
-		for _, v := range data[1:] {
-			if len(v) != streamLast {
-				return fmt.Errorf("incorrect number of installed stream fields")
-			}
-			var err error
 
-			var start, end time.Time
-			if start, err = time.Parse(DateTimeFormat, v[streamStart]); err != nil {
-				return err
-			}
-			if end, err = time.Parse(DateTimeFormat, v[streamEnd]); err != nil {
-				return err
-			}
+	fields := streamHeaders.Fields(data[0])
+	for _, row := range data[1:] {
+		d := fields.Remap(row)
 
-			var rate float64
-			if rate, err = strconv.ParseFloat(v[streamSamplingRate], 64); err != nil {
-				return err
-			}
-			if rate < 0 {
-				rate = -1.0 / rate
-			}
-
-			var reversed, triggered bool
-			if reversed, err = strconv.ParseBool(v[streamReversed]); err != nil {
-				return err
-			}
-			if triggered, err = strconv.ParseBool(v[streamTriggered]); err != nil {
-				return err
-			}
-
-			streams = append(streams, Stream{
-				Station:      strings.TrimSpace(v[streamStation]),
-				Location:     strings.TrimSpace(v[streamLocation]),
-				Band:         strings.TrimSpace(v[streamBand]),
-				Source:       strings.TrimSpace(v[streamSource]),
-				SamplingRate: rate,
-				samplingRate: strings.TrimSpace(v[streamSamplingRate]),
-				Axial:        strings.TrimSpace(v[streamAxial]),
-				Reversed:     reversed,
-				Triggered:    triggered,
-				Span: Span{
-					Start: start,
-					End:   end,
-				},
-			})
+		start, err := time.Parse(DateTimeFormat, d[streamStart])
+		if err != nil {
+			return err
+		}
+		end, err := time.Parse(DateTimeFormat, d[streamEnd])
+		if err != nil {
+			return err
 		}
 
-		*c = StreamList(streams)
+		rate, err := strconv.ParseFloat(d[streamSamplingRate], 64)
+		if err != nil {
+			return err
+		}
+		if rate < 0 {
+			rate = -1.0 / rate
+		}
+
+		reversed, err := strconv.ParseBool(d[streamReversed])
+		if err != nil {
+			return err
+		}
+		triggered, err := strconv.ParseBool(d[streamTriggered])
+		if err != nil {
+			return err
+		}
+
+		streams = append(streams, Stream{
+			Station:      strings.TrimSpace(d[streamStation]),
+			Location:     strings.TrimSpace(d[streamLocation]),
+			Band:         strings.TrimSpace(d[streamBand]),
+			Source:       strings.TrimSpace(d[streamSource]),
+			SamplingRate: rate,
+			samplingRate: strings.TrimSpace(d[streamSamplingRate]),
+			Axial:        strings.TrimSpace(d[streamAxial]),
+			Reversed:     reversed,
+			Triggered:    triggered,
+			Span: Span{
+				Start: start,
+				End:   end,
+			},
+		})
 	}
+
+	*s = StreamList(streams)
+
 	return nil
 }
 

--- a/meta/telemetry.go
+++ b/meta/telemetry.go
@@ -74,13 +74,13 @@ func (t TelemetryList) encode() [][]string {
 	var data [][]string
 
 	data = append(data, telemetryHeaders.Columns())
-	for _, v := range t {
+	for _, row := range t {
 		data = append(data, []string{
-			strings.TrimSpace(v.Station),
-			strings.TrimSpace(v.Location),
-			strings.TrimSpace(v.factor),
-			v.Start.Format(DateTimeFormat),
-			v.End.Format(DateTimeFormat),
+			strings.TrimSpace(row.Station),
+			strings.TrimSpace(row.Location),
+			strings.TrimSpace(row.factor),
+			row.Start.Format(DateTimeFormat),
+			row.End.Format(DateTimeFormat),
 		})
 	}
 
@@ -99,16 +99,16 @@ func (t *TelemetryList) toFloat64(str string, def float64) (float64, error) {
 }
 
 func (t *TelemetryList) decode(data [][]string) error {
-	var telemetries []Telemetry
-
 	// needs more than a comment line
 	if !(len(data) > 1) {
 		return nil
 	}
 
+	var telemetries []Telemetry
+
 	fields := telemetryHeaders.Fields(data[0])
-	for _, v := range data[1:] {
-		d := fields.Remap(v)
+	for _, row := range data[1:] {
+		d := fields.Remap(row)
 
 		factor, err := t.toFloat64(d[telemetryScaleFactor], 1.0)
 		if err != nil {
@@ -144,13 +144,13 @@ func (t *TelemetryList) decode(data [][]string) error {
 }
 
 func LoadTelemetries(path string) ([]Telemetry, error) {
-	var g []Telemetry
+	var t []Telemetry
 
-	if err := LoadList(path, (*TelemetryList)(&g)); err != nil {
+	if err := LoadList(path, (*TelemetryList)(&t)); err != nil {
 		return nil, err
 	}
 
-	sort.Sort(TelemetryList(g))
+	sort.Sort(TelemetryList(t))
 
-	return g, nil
+	return t, nil
 }

--- a/meta/view.go
+++ b/meta/view.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -21,6 +20,18 @@ const (
 	viewLast
 )
 
+var viewHeaders Header = map[string]int{
+	"Mount":       viewMount,
+	"View":        viewCode,
+	"Label":       viewLabel,
+	"Azimuth":     viewAzimuth,
+	"Method":      viewMethod,
+	"Dip":         viewDip,
+	"Description": viewDescription,
+	"Start Date":  viewStart,
+	"End Date":    viewEnd,
+}
+
 type View struct {
 	Orientation
 	Span
@@ -33,96 +44,94 @@ type View struct {
 
 type ViewList []View
 
-func (l ViewList) Len() int      { return len(l) }
-func (l ViewList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
-func (l ViewList) Less(i, j int) bool {
+func (v ViewList) Len() int      { return len(v) }
+func (v ViewList) Swap(i, j int) { v[i], v[j] = v[j], v[i] }
+func (v ViewList) Less(i, j int) bool {
 	switch {
-	case l[i].Mount < l[j].Mount:
+	case v[i].Mount < v[j].Mount:
 		return true
-	case l[i].Mount > l[j].Mount:
+	case v[i].Mount > v[j].Mount:
 		return false
-	case l[i].Code < l[j].Code:
+	case v[i].Code < v[j].Code:
 		return true
 	default:
 		return false
 	}
 }
 
-func (m ViewList) encode() [][]string {
-	data := [][]string{{
-		"Mount",
-		"View",
-		"Label",
-		"Azimuth",
-		"Method",
-		"Dip",
-		"Description",
-		"Start Date",
-		"End Date",
-	}}
-	for _, l := range m {
+func (v ViewList) encode() [][]string {
+	var data [][]string
+
+	data = append(data, viewHeaders.Columns())
+
+	for _, row := range v {
 		data = append(data, []string{
-			strings.TrimSpace(l.Mount),
-			strings.TrimSpace(l.Code),
-			strings.TrimSpace(l.Label),
-			strings.TrimSpace(l.azimuth),
-			strings.TrimSpace(l.Method),
-			strings.TrimSpace(l.dip),
-			strings.TrimSpace(l.Description),
-			l.Start.Format(DateTimeFormat),
-			l.End.Format(DateTimeFormat),
+			strings.TrimSpace(row.Mount),
+			strings.TrimSpace(row.Code),
+			strings.TrimSpace(row.Label),
+			strings.TrimSpace(row.azimuth),
+			strings.TrimSpace(row.Method),
+			strings.TrimSpace(row.dip),
+			strings.TrimSpace(row.Description),
+			row.Start.Format(DateTimeFormat),
+			row.End.Format(DateTimeFormat),
 		})
 	}
+
 	return data
 }
 
-func (l *ViewList) decode(data [][]string) error {
+func (v *ViewList) decode(data [][]string) error {
+	if !(len(data) > 1) {
+		return nil
+	}
+
 	var views []View
-	if len(data) > 1 {
-		for _, d := range data[1:] {
-			if len(d) != viewLast {
-				return fmt.Errorf("incorrect number of installed view fields")
-			}
-			var err error
 
-			var dip, azimuth float64
-			if dip, err = strconv.ParseFloat(d[viewDip], 64); err != nil {
-				return err
-			}
-			if azimuth, err = strconv.ParseFloat(d[viewAzimuth], 64); err != nil {
-				return err
-			}
+	fields := viewHeaders.Fields(data[0])
+	for _, row := range data[1:] {
+		d := fields.Remap(row)
 
-			var start, end time.Time
-			if start, err = time.Parse(DateTimeFormat, d[viewStart]); err != nil {
-				return err
-			}
-			if end, err = time.Parse(DateTimeFormat, d[viewEnd]); err != nil {
-				return err
-			}
-
-			views = append(views, View{
-				Mount:       strings.TrimSpace(d[viewMount]),
-				Code:        strings.TrimSpace(d[viewCode]),
-				Label:       strings.TrimSpace(d[viewLabel]),
-				Description: strings.TrimSpace(d[viewDescription]),
-				Orientation: Orientation{
-					Dip:     dip,
-					Azimuth: azimuth,
-					Method:  strings.TrimSpace(d[viewMethod]),
-
-					azimuth: strings.TrimSpace(d[viewAzimuth]),
-					dip:     strings.TrimSpace(d[viewDip]),
-				},
-				Span: Span{
-					Start: start,
-					End:   end,
-				},
-			})
+		dip, err := strconv.ParseFloat(d[viewDip], 64)
+		if err != nil {
+			return err
+		}
+		azimuth, err := strconv.ParseFloat(d[viewAzimuth], 64)
+		if err != nil {
+			return err
 		}
 
-		*l = ViewList(views)
+		start, err := time.Parse(DateTimeFormat, d[viewStart])
+		if err != nil {
+			return err
+		}
+		end, err := time.Parse(DateTimeFormat, d[viewEnd])
+		if err != nil {
+			return err
+		}
+
+		views = append(views, View{
+			Mount:       strings.TrimSpace(d[viewMount]),
+			Code:        strings.TrimSpace(d[viewCode]),
+			Label:       strings.TrimSpace(d[viewLabel]),
+			Description: strings.TrimSpace(d[viewDescription]),
+			Orientation: Orientation{
+				Dip:     dip,
+				Azimuth: azimuth,
+				Method:  strings.TrimSpace(d[viewMethod]),
+
+				azimuth: strings.TrimSpace(d[viewAzimuth]),
+				dip:     strings.TrimSpace(d[viewDip]),
+			},
+			Span: Span{
+				Start: start,
+				End:   end,
+			},
+		})
 	}
+
+	*v = ViewList(views)
+
 	return nil
 }
 


### PR DESCRIPTION
This is a refactor to get all the table code to line up, it basically adds a Header struct to each table and then uses it to encode/decode each row.  I've also standardised the variable naming a little more.  This is a no change update and the tests pass as before.