### PR TITLE
fix: add polynomial stage gain for version 1.0

### DIFF
--- a/internal/stationxml/encoder10.go
+++ b/internal/stationxml/encoder10.go
@@ -224,7 +224,15 @@ func (e Encoder10) Response(response *ResponseType) *stationxml.ResponseType {
 
 		// in v1.0 we don't used a base PolynomialType
 		if s.Polynomial != nil {
+
+			// assume gain is related to the second coefficient
+			value := 1.0
+			if len(s.Polynomial.Coefficients) > 1 {
+				value = 1.0 / s.Polynomial.Coefficients[1].Value
+			}
+
 			gain = stationxml.GainType{
+				Value:     value,
 				Frequency: response.frequency,
 			}
 		}


### PR DESCRIPTION
A quirk of StationXML version 1.0 makes setting a stage gain tricky for polynomial responses, this update implements the previous mechanism. A better approach is used for stationxml 1.1 & 1.2.