### PR TITLE
fix: removed the tool/sit debug code which was breaking the linter

### DIFF
--- a/tools/sit/main.go
+++ b/tools/sit/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -451,13 +450,6 @@ func main() {
 		if err := os.WriteFile(pbfile, b, 0600); err != nil {
 			fmt.Fprintf(os.Stderr, "error: unable to write file: %v\n", err)
 			os.Exit(-1)
-		}
-		if verbose {
-			out_json, _ := json.MarshalIndent(site_pb, "", "  ")
-			err = os.WriteFile(filepath.Join(output, strings.ToUpper(s)+".json"), []byte(out_json), 0600)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "error: unable to write debug json: %v\n", err)
-			}
 		}
 
 	}


### PR DESCRIPTION
Doing a json encoding on protobufs isn't recommended. It fails to parse the linter checks due to an embedded mutex.

```
tools/sit/main.go:455:38: copylocks: call of json.MarshalIndent copies lock value: github.com/GeoNet/kit/sit_delta_pb.Site contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex (govet)
			out_json, _ := json.MarshalIndent(site_pb, "", "  ")
```

simple solution is to remove offending code as it was only used for debugging.