### PR TITLE
fix: bug with testing responses and do a double encode check

### DIFF
--- a/resp/resp_test.go
+++ b/resp/resp_test.go
@@ -18,6 +18,7 @@ func TestAuto(t *testing.T) {
 	}
 
 	for _, name := range names {
+		name := name
 		t.Run("check resp file: "+name, func(t *testing.T) {
 			t.Parallel()
 
@@ -26,18 +27,28 @@ func TestAuto(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			snippet, err := stationxml.NewResponseType(raw)
+			first, err := stationxml.NewResponseType(raw)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			data, err := snippet.Marshal()
+			data, err := first.Marshal()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if !cmp.Equal(raw, data) {
-				t.Error(cmp.Diff(raw, data))
+			second, err := stationxml.NewResponseType(data)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			check, err := second.Marshal()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !cmp.Equal(data, check) {
+				t.Error(cmp.Diff(data, check))
 			}
 		})
 	}


### PR DESCRIPTION
Caused by the Parallel call, this then only checked the last response file.

The auto responses are generated using a different technique so will not match, unless the same mechanism is used. This will likely be fixed