### PR TITLE
fix: apply goimports to code base, manually fixed

### DIFF
--- a/internal/stationxml/decoder10.go
+++ b/internal/stationxml/decoder10.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"sort"
 
-	"github.com/GeoNet/delta/internal/stationxml/v1.0"
+	stationxml "github.com/GeoNet/delta/internal/stationxml/v1.0"
 )
 
 type Decoder10 struct{}

--- a/internal/stationxml/decoder11.go
+++ b/internal/stationxml/decoder11.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"sort"
 
-	"github.com/GeoNet/delta/internal/stationxml/v1.1"
+	stationxml "github.com/GeoNet/delta/internal/stationxml/v1.1"
 )
 
 type Decoder11 struct{}

--- a/internal/stationxml/decoder12.go
+++ b/internal/stationxml/decoder12.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"sort"
 
-	"github.com/GeoNet/delta/internal/stationxml/v1.2"
+	stationxml "github.com/GeoNet/delta/internal/stationxml/v1.2"
 )
 
 type Decoder12 struct{}

--- a/internal/stationxml/encoder10.go
+++ b/internal/stationxml/encoder10.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/GeoNet/delta/internal/stationxml/v1.0"
+	stationxml "github.com/GeoNet/delta/internal/stationxml/v1.0"
 )
 
 type Encoder10 struct{}

--- a/internal/stationxml/encoder11.go
+++ b/internal/stationxml/encoder11.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/GeoNet/delta/internal/stationxml/v1.1"
+	stationxml "github.com/GeoNet/delta/internal/stationxml/v1.1"
 )
 
 type Encoder11 struct{}

--- a/internal/stationxml/encoder12.go
+++ b/internal/stationxml/encoder12.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/GeoNet/delta/internal/stationxml/v1.2"
+	stationxml "github.com/GeoNet/delta/internal/stationxml/v1.2"
 )
 
 type Encoder12 struct{}

--- a/resp/generate/a2d.go
+++ b/resp/generate/a2d.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/GeoNet/delta/internal/stationxml/v1.1"
+	stationxml "github.com/GeoNet/delta/internal/stationxml/v1.1"
 )
 
 func A2D(filter string, stage ResponseStage, count int, freq, rate float64) stationxml.ResponseStageType {

--- a/resp/generate/fir.go
+++ b/resp/generate/fir.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/GeoNet/delta/internal/stationxml/v1.1"
+	stationxml "github.com/GeoNet/delta/internal/stationxml/v1.1"
 )
 
 type FIR struct {

--- a/resp/generate/paz.go
+++ b/resp/generate/paz.go
@@ -5,7 +5,7 @@ import (
 	"math/cmplx"
 	"sort"
 
-	"github.com/GeoNet/delta/internal/stationxml/v1.1"
+	stationxml "github.com/GeoNet/delta/internal/stationxml/v1.1"
 )
 
 type PAZ struct {

--- a/resp/generate/polynomial.go
+++ b/resp/generate/polynomial.go
@@ -3,7 +3,7 @@ package main
 import (
 	"sort"
 
-	"github.com/GeoNet/delta/internal/stationxml/v1.1"
+	stationxml "github.com/GeoNet/delta/internal/stationxml/v1.1"
 )
 
 type Polynomial struct {

--- a/resp/generate/stationxml.go
+++ b/resp/generate/stationxml.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/GeoNet/delta/internal/stationxml/v1.1"
+	stationxml "github.com/GeoNet/delta/internal/stationxml/v1.1"
 )
 
 // ResponseType mimics stationxml.ResponseType but adds an XMLName tag to correctly marshal the type name.

--- a/tools/gloria/main.go
+++ b/tools/gloria/main.go
@@ -3,13 +3,14 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/GeoNet/delta/meta"
-	"github.com/GeoNet/kit/gloria_pb"
-	"github.com/golang/protobuf/proto"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/GeoNet/delta/meta"
+	"github.com/GeoNet/kit/gloria_pb"
+	"github.com/golang/protobuf/proto"
 )
 
 var (

--- a/tools/sit/main.go
+++ b/tools/sit/main.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/GeoNet/delta/meta"
-	"github.com/GeoNet/kit/sit_delta_pb"
-	"github.com/golang/protobuf/proto"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/GeoNet/delta/meta"
+	"github.com/GeoNet/kit/sit_delta_pb"
+	"github.com/golang/protobuf/proto"
 )
 
 func markPtr(mark meta.Mark) *meta.Mark {


### PR DESCRIPTION
For some reason the goimports command got confused with stationxml v1.? imports, needed to be hand fixed to match what was replaced