### PR TITLE
fix: update the way the stationxml networks get their start/end times

### DIFF
--- a/internal/stationxml/encoder10.go
+++ b/internal/stationxml/encoder10.go
@@ -521,8 +521,8 @@ func (e Encoder10) Network(root Root, external External) stationxml.NetworkType 
 					return stationxml.OpenRestrictedStatus
 				}
 			}(),
-			StartDate: e.toDateTime(external.Start()),
-			EndDate:   e.toDateTime(external.End()),
+			StartDate: e.toDateTime(external.StartDate),
+			EndDate:   e.toDateTime(external.EndDate),
 		},
 		Station: stations,
 	}

--- a/internal/stationxml/encoder11.go
+++ b/internal/stationxml/encoder11.go
@@ -510,8 +510,8 @@ func (e Encoder11) Network(root Root, external External) stationxml.NetworkType 
 					return stationxml.OpenRestrictedStatus
 				}
 			}(),
-			StartDate: e.toDateTime(external.Start()),
-			EndDate:   e.toDateTime(external.End()),
+			StartDate: e.toDateTime(external.StartDate),
+			EndDate:   e.toDateTime(external.EndDate),
 		},
 		Station: stations,
 	}

--- a/internal/stationxml/encoder12.go
+++ b/internal/stationxml/encoder12.go
@@ -510,8 +510,8 @@ func (e Encoder12) Network(root Root, external External) stationxml.NetworkType 
 					return stationxml.OpenRestrictedStatus
 				}
 			}(),
-			StartDate: e.toDateTime(external.Start()),
-			EndDate:   e.toDateTime(external.End()),
+			StartDate: e.toDateTime(external.StartDate),
+			EndDate:   e.toDateTime(external.EndDate),
 		},
 		Station: stations,
 	}

--- a/internal/stationxml/root.go
+++ b/internal/stationxml/root.go
@@ -80,57 +80,16 @@ type Network struct {
 	Stations []Station
 }
 
-// Start returns the earliest Station start time in a Network.
-func (n Network) Start() time.Time {
-	var start time.Time
-	for _, s := range n.Stations {
-		if start.IsZero() || s.StartDate.Before(start) {
-			start = s.StartDate
-		}
-	}
-	return start
-}
-
-// End returns the latest Station end time in a Network.
-func (n Network) End() time.Time {
-	var end time.Time
-	for _, s := range n.Stations {
-		if end.IsZero() || s.EndDate.After(end) {
-			end = s.EndDate
-		}
-	}
-	return end
-}
-
 // External maps between an External Network and individal Networks.
 type External struct {
 	Code        string
 	Description string
 	Restricted  bool
 
+	StartDate time.Time
+	EndDate   time.Time
+
 	Networks []Network
-}
-
-// Start returns the earliest Station start time in an External Network.
-func (e External) Start() time.Time {
-	var start time.Time
-	for _, n := range e.Networks {
-		if t := n.Start(); start.IsZero() || t.Before(start) {
-			start = t
-		}
-	}
-	return start
-}
-
-// End returns the latest Station end time in an External Network.
-func (e External) End() time.Time {
-	var end time.Time
-	for _, n := range e.Networks {
-		if t := n.End(); end.IsZero() || t.After(end) {
-			end = t
-		}
-	}
-	return end
 }
 
 // Root describes the standard StationXML layout which can be used as the barebones for building version specific encoders.


### PR DESCRIPTION
This is an attempt to be more consistent with how the start/end dates for the networks are managed, previously each network was based on the times of the stations included. This worked except for when single station xml was being generated and each xml had a different network code based on the single station.  This method finds the times prior to building the xml, it also only uses stations which have had a sensor installed at some time in their past