### PR TITLE
fix: with connections ignore streams for recorder installed sensors

### DIFF
--- a/meta/collection.go
+++ b/meta/collection.go
@@ -301,6 +301,9 @@ func (s *Set) Collections(site Site) []Collection {
 					if stream.Location != site.Location {
 						continue
 					}
+					if stream.Location == recorder.Location {
+						continue
+					}
 
 					span, ok := span.Extent(stream.Span)
 					if !ok {


### PR DESCRIPTION
This is to allow for connections to recorders to ignore the built in sensor, previously these were being picked up and building extra channel elements.