### PR TITLE
feat: update actions tests order

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,7 @@ permissions:
   checks: write
 
 jobs:
-  delta-apps:
-    uses: GeoNet/Actions/.github/workflows/reusable-go-apps.yml@main
-
   delta-test:
-    needs: delta-apps
     runs-on: ubuntu-latest
     steps:
       - name: Checkout delta repo
@@ -39,9 +35,13 @@ jobs:
       - name: Run local tests
         run: go test ./tests
 
+  delta-apps:
+    needs: delta-test
+    uses: GeoNet/Actions/.github/workflows/reusable-go-apps.yml@main
+
   delta-deploy:
     if: github.ref == 'refs/heads/main'
-    needs: delta-test
+    needs: delta-apps
     runs-on: ubuntu-latest
     steps:
       - name: Trigger build in ac-tools


### PR DESCRIPTION
This swaps the testing actions to avoid overloaded testing debug, first check delta, then check the apps. This is to avoid confusing users with application code rather than delta file problems