### PR TITLE
fix: required to split out common ntrip files

### DIFF
--- a/cmd/bnc-config/build.go
+++ b/cmd/bnc-config/build.go
@@ -8,8 +8,8 @@ import (
 	"github.com/GeoNet/delta/meta"
 )
 
-// Build is a function that extracts information from delta meta data and local csv files.
-func Build(set *meta.Set, caster *ntrip.Caster, extra bool) (*Config, error) {
+// NewConfig is a function that extracts information from delta meta data and local csv files.
+func NewConfig(set *meta.Set, caster *ntrip.Caster, extra bool) (*Config, error) {
 
 	var config Config
 

--- a/cmd/bnc-config/config.go
+++ b/cmd/bnc-config/config.go
@@ -9,8 +9,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// Store bnc configuration as requred for a heira yaml file
-
 // MountConfig represents a set if ntripcaster mount point configuration details.
 type MountConfig struct {
 	Mount     string `yaml:"mount"`

--- a/cmd/bnc-config/config_test.go
+++ b/cmd/bnc-config/config_test.go
@@ -26,13 +26,13 @@ func TestFiles_Config(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	caster, err := ntrip.NewCaster("./testdata")
+	caster, err := ntrip.NewCaster("./testdata", "./testdata")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// build config from test files
-	config, err := Build(set, caster, true)
+	config, err := NewConfig(set, caster, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/ntripcaster-config/build.go
+++ b/cmd/ntripcaster-config/build.go
@@ -10,8 +10,8 @@ import (
 	"github.com/GeoNet/delta/meta"
 )
 
-// Config is a function that extracts information from delta meta data and local csv files.
-func Build(set *meta.Set, caster *ntrip.Caster) (*Config, error) {
+// NewConfig extracts information from delta meta data and local csv files.
+func NewConfig(set *meta.Set, caster *ntrip.Caster) (*Config, error) {
 
 	var config Config
 

--- a/cmd/ntripcaster-config/config.go
+++ b/cmd/ntripcaster-config/config.go
@@ -9,8 +9,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// Store ntripcaster configuration as requred for a heira yaml file
-
 // ClientMountConfig represents a set if ntripcaster user configuration details.
 type UserConfig struct {
 	Username string `yaml:"username"`

--- a/cmd/ntripcaster-config/config_test.go
+++ b/cmd/ntripcaster-config/config_test.go
@@ -26,13 +26,14 @@ func TestFiles_Config(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	caster, err := ntrip.NewCaster("./testdata")
+	// recover ntrip input files
+	caster, err := ntrip.NewCaster("./testdata", "./testdata")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// build config from test files
-	config, err := Build(set, caster)
+	config, err := NewConfig(set, caster)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/ntrip/ntrip.go
+++ b/internal/ntrip/ntrip.go
@@ -22,28 +22,29 @@ type Caster struct {
 }
 
 // NewCaster returns a Caster pointer after reading all expected config files.
-func NewCaster(base string) (*Caster, error) {
-	aliases, err := ReadAliases(filepath.Join(base, AliasesFile))
+func NewCaster(common, input string) (*Caster, error) {
+
+	formats, err := ReadFormats(filepath.Join(common, FormatsFile))
 	if err != nil {
 		return nil, err
 	}
 
-	formats, err := ReadFormats(filepath.Join(base, FormatsFile))
+	models, err := ReadModels(filepath.Join(common, ModelsFile))
 	if err != nil {
 		return nil, err
 	}
 
-	models, err := ReadModels(filepath.Join(base, ModelsFile))
+	aliases, err := ReadAliases(filepath.Join(input, AliasesFile))
 	if err != nil {
 		return nil, err
 	}
 
-	mounts, err := ReadMounts(filepath.Join(base, MountsFile))
+	mounts, err := ReadMounts(filepath.Join(input, MountsFile))
 	if err != nil {
 		return nil, err
 	}
 
-	users, err := ReadUsers(filepath.Join(base, UsersFile))
+	users, err := ReadUsers(filepath.Join(input, UsersFile))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The config files may be split into two directories, common and otherwise. This adds the xtra requirements to find these files. It also updates the code into the settings structure.