### PR TITLE
chore: update local test to remove obsolete stuff

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -12,7 +12,6 @@ trap error_handler ERR
 go test ./meta
 go test ./tides
 go test ./tests
-go test ./tools/stationxml
 go test ./tools/altus
 go test ./tools/cusp
 go test ./tools/amplitude


### PR DESCRIPTION
Hi Mark,

not sure if there's more to do for that, but this is to remove the now obsolete local test run for the deprecated `tools/stationxml`  folder

please let me know if there's more to do, or if wrong/unwanted we can just close this pr!