### PR TITLE
chore: upgrade go version to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GeoNet/delta
 
-go 1.20
+go 1.21
 
 require (
 	aqwari.net/xml v0.0.0-20210331023308-d9421b293817


### PR DESCRIPTION
Reference: https://github.com/GeoNet/tickets/issues/13645