### PR TITLE
Historical_Overseas_Stations.md

### DIFF
--- a/docs/stations/Historical_Overseas_Stations.md
+++ b/docs/stations/Historical_Overseas_Stations.md
@@ -1,0 +1,30 @@
+## About overseas stations in Delta repository - Reference ##
+Historical long standing seismological international stations were refered to 
+in Delta/network/stations.csv and Delta/network/networks.csv as the "OE" network
+these have been removed since. 
+
+#### Station Recordings and Instrumentation ####
+Most likely used in the paper seismograms and pre-miniseed recordings. 
+	
+#### Countries Australia, U.S.A., Japan  ####
+Delta reference as it was for "historical stations": 
+> BRS,OE,Brisbane,-27.389720485,152.774988403,525,,WGS84,1937-09-01T00:00:00Z,9999-01-01
+> CAN,OE,Canberra,-35.3208,148.9987,700,,NZGD49,1958-01-01T00:00:00Z,9999-01-01
+> COO,OE,Cooney Tunnel,-30.5778,151.8917,653,,NZGD49,1974-08-17T00:00:00Z,1991-09-19
+> CTA,OE,Charters Towers,-20.086291797,146.254463618,357,,WGS84,1957-09-15T00:00:00Z,9999-01-01
+> HON,OE,Honolulu,-21.319815863,-158.007798757,2,,WGS84,1902-01-01T00:00:00Z,9999-01-0
+> HUA,OE,Huancayo,-12.036389747,-75.321986265,3313,,WGS84,1932-04-01T00:00:00Z,9999-01-01
+> KOB,OE,Kobe,-34.686303733,135.179788878,58,,WGS84,1939-11-01T00:00:00Z,9999-01-01
+> NAG,OE,Nagoya,-35.163019642,136.968099401,52,,WGS84,1891-02-01T00:00:00Z,9999-01-0
+> NIA,OE,Norfolk Island,-29.039783059,167.960134076,130,,WGS84,1969-12-01T00:00:00Z,1977-05-28
+> PAS,OE,Pasadena,-34.146386171,-118.170846348,295,,WGS84,1927-03-17T00:00:00Z,2006-10-31
+> PER,OE,Perth,-31.9528,115.8395,55,,NZGD49,1901-01-01T00:00:00Z,1963-08-01
+> RIV,OE,Riverview,-33.8295,151.1583,25,,NZGD49,1909-01-01T00:00:00Z,9999-01-01
+> SYD,OE,Sydney,-33.8667,151.2,43,,NZGD49,1906-01-01T00:00:00Z,1948-12-31
+> TOK,OE,Tokyo,-35.684741727,139.758118639,21,,WGS84,1875-06-01T00:00:00Z,9999-01-01
+> TOO,OE,Toolangi,-37.5713,145.4905,604,,NZGD49,1962-01-01T00:00:00Z,9999-01-01
+
+####  Additional information #### 
+    No information on these
+    No additional metadata
+    No information about data being used in events


### PR DESCRIPTION
For information only. 
Document Delta past content of Overseas stations references. 
Overseas Station localization content only.
Removed from repository since. 
