### PR TITLE
fix: update dart response to include fake stage

### DIFF
--- a/meta/collection.go
+++ b/meta/collection.go
@@ -156,6 +156,10 @@ func (s *Set) Collections(site Site) []Collection {
 					continue
 				}
 
+				if component.SamplingRate != stream.SamplingRate && component.SamplingRate != 0.0 {
+					continue
+				}
+
 				for _, channel := range s.Channels() {
 					if recorder.Make != channel.Make {
 						continue

--- a/resp/files/combined_SAIC_BPR-Subsystem_BPR-Subsystem_Z_15s.xml
+++ b/resp/files/combined_SAIC_BPR-Subsystem_BPR-Subsystem_Z_15s.xml
@@ -16,7 +16,7 @@
         <Name>m</Name>
       </InputUnits>
       <OutputUnits>
-        <Name>count</Name>
+        <Name>V</Name>
       </OutputUnits>
       <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
     </Coefficients>
@@ -29,6 +29,28 @@
     </Decimation>
     <StageGain>
       <Value>149253.73134328358</Value>
+      <Frequency>1</Frequency>
+    </StageGain>
+  </Stage>
+  <Stage number="2">
+    <Coefficients resourceId="Coefficients#GAIN-1">
+      <InputUnits>
+        <Name>V</Name>
+      </InputUnits>
+      <OutputUnits>
+        <Name>count</Name>
+      </OutputUnits>
+      <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+    </Coefficients>
+    <Decimation>
+      <InputSampleRate>1</InputSampleRate>
+      <Factor>1</Factor>
+      <Offset>0</Offset>
+      <Delay>0</Delay>
+      <Correction>0</Correction>
+    </Decimation>
+    <StageGain>
+      <Value>1</Value>
       <Frequency>1</Frequency>
     </StageGain>
   </Stage>

--- a/resp/files/combined_SAIC_BPR-Subsystem_BPR-Subsystem_Z_900s.xml
+++ b/resp/files/combined_SAIC_BPR-Subsystem_BPR-Subsystem_Z_900s.xml
@@ -16,7 +16,7 @@
         <Name>m</Name>
       </InputUnits>
       <OutputUnits>
-        <Name>count</Name>
+        <Name>V</Name>
       </OutputUnits>
       <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
     </Coefficients>
@@ -29,6 +29,28 @@
     </Decimation>
     <StageGain>
       <Value>149253.73134328358</Value>
+      <Frequency>1</Frequency>
+    </StageGain>
+  </Stage>
+  <Stage number="2">
+    <Coefficients resourceId="Coefficients#GAIN-1">
+      <InputUnits>
+        <Name>V</Name>
+      </InputUnits>
+      <OutputUnits>
+        <Name>count</Name>
+      </OutputUnits>
+      <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+    </Coefficients>
+    <Decimation>
+      <InputSampleRate>1</InputSampleRate>
+      <Factor>1</Factor>
+      <Offset>0</Offset>
+      <Delay>0</Delay>
+      <Correction>0</Correction>
+    </Decimation>
+    <StageGain>
+      <Value>1</Value>
       <Frequency>1</Frequency>
     </StageGain>
   </Stage>


### PR DESCRIPTION
The fake stage is needed for seiscomp to convert the fdsn xml.

Also fixes the multiple channels, due to the sampling rate being in the component aspect.