### PR TITLE
feat: add grouped XML formatted sensor list

### DIFF
--- a/cmd/sensor-config/envirosensor.go
+++ b/cmd/sensor-config/envirosensor.go
@@ -104,3 +104,107 @@ func (n *Network) EnviroSensor(set *meta.Set, enviro string, label string) error
 
 	return nil
 }
+
+func (s Settings) EnviroSensor(set *meta.Set, name, enviro string) (Group, bool) {
+
+	if _, ok := set.Network(enviro); !ok {
+		return Group{}, false
+	}
+
+	valid := make(map[string]interface{})
+	for _, f := range set.Features() {
+		valid[f.Station] = true
+	}
+
+	var stations []Station
+	for _, stn := range set.Stations() {
+		if _, ok := valid[stn.Code]; !ok {
+			continue
+		}
+
+		if stn.Network != enviro {
+			continue
+		}
+
+		var sites []Site
+		for _, site := range set.Sites() {
+			if site.Station != stn.Code {
+				continue
+			}
+
+			var sensors []Sensor
+			for _, v := range set.InstalledSensors() {
+				if v.Station != site.Station {
+					continue
+				}
+				if v.Location != site.Location {
+					continue
+				}
+
+				sensors = append(sensors, Sensor{
+					Make:  v.Make,
+					Model: v.Model,
+
+					Azimuth:  v.Azimuth,
+					Method:   v.Method,
+					Dip:      v.Dip,
+					Vertical: v.Vertical,
+					North:    v.North,
+					East:     v.East,
+
+					StartDate: v.Start,
+					EndDate:   v.End,
+				})
+			}
+
+			if !(len(sensors) > 0) {
+				continue
+			}
+
+			sort.Slice(sensors, func(i, j int) bool {
+				return sensors[i].Less(sensors[j])
+			})
+
+			sites = append(sites, Site{
+				Code: site.Location,
+
+				Latitude:  site.Latitude,
+				Longitude: site.Longitude,
+				Elevation: site.Elevation,
+				Datum:     site.Datum,
+				Survey:    site.Survey,
+
+				StartDate: site.Start,
+				EndDate:   site.End,
+
+				Sensors: sensors,
+			})
+		}
+
+		if !(len(sites) > 0) {
+			continue
+		}
+
+		sort.Slice(sites, func(i, j int) bool {
+			return sites[i].Less(sites[j])
+		})
+
+		stations = append(stations, Station{
+			Code: stn.Code,
+			Name: stn.Name,
+
+			Latitude:  stn.Latitude,
+			Longitude: stn.Longitude,
+			Elevation: stn.Elevation,
+			Depth:     stn.Depth,
+			Datum:     stn.Datum,
+
+			StartDate: stn.Start,
+			EndDate:   stn.End,
+
+			Sites: sites,
+		})
+	}
+
+	return Group{Name: name, Stations: stations}, true
+}

--- a/cmd/sensor-config/gnss.go
+++ b/cmd/sensor-config/gnss.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/GeoNet/delta/meta"
 )
@@ -94,4 +95,109 @@ func (n *Network) Gnss(set *meta.Set, antenna, receiver string) error {
 	}
 
 	return nil
+}
+
+func (s Settings) Gnss(set *meta.Set, name, networks string) (Group, bool) {
+
+	nets := make(map[string]interface{})
+	for _, n := range strings.Split(networks, ",") {
+		if n = strings.TrimSpace(n); n != "" {
+			nets[n] = true
+		}
+	}
+
+	var marks []Mark
+	for _, mark := range set.Marks() {
+		net, ok := set.Network(mark.Network)
+		if !ok {
+			continue
+		}
+		if _, ok := nets[net.Code]; !ok {
+			continue
+		}
+
+		monument, ok := set.Monument(mark.Code)
+		if !ok {
+			continue
+		}
+
+		var receivers []Sensor
+		for _, r := range set.DeployedReceivers() {
+			if r.Mark != mark.Code {
+				continue
+			}
+
+			receivers = append(receivers, Sensor{
+				Make:  r.Make,
+				Model: r.Model,
+
+				StartDate: r.Start,
+				EndDate:   r.End,
+			})
+		}
+
+		if !(len(receivers) > 0) {
+			continue
+		}
+
+		sort.Slice(receivers, func(i, j int) bool {
+			return receivers[i].Less(receivers[j])
+		})
+
+		var antennas []Sensor
+		for _, a := range set.InstalledAntennas() {
+			if a.Mark != mark.Code {
+				continue
+			}
+
+			antennas = append(antennas, Sensor{
+				Make:  a.Make,
+				Model: a.Model,
+
+				Vertical: a.Vertical,
+				North:    a.North,
+				East:     a.East,
+				Azimuth:  a.Azimuth,
+
+				StartDate: a.Start,
+				EndDate:   a.End,
+			})
+		}
+
+		if !(len(antennas) > 0) {
+			continue
+		}
+
+		sort.Slice(antennas, func(i, j int) bool {
+			return antennas[i].Less(antennas[j])
+		})
+
+		marks = append(marks, Mark{
+			Code:        mark.Code,
+			Name:        mark.Name,
+			DomesNumber: monument.DomesNumber,
+
+			Latitude:  mark.Latitude,
+			Longitude: mark.Longitude,
+			Elevation: mark.Elevation,
+			Datum:     mark.Datum,
+
+			GroundRelationship: monument.GroundRelationship,
+
+			MarkType:        monument.MarkType,
+			MonumentType:    monument.Type,
+			FoundationType:  monument.FoundationType,
+			FoundationDepth: monument.FoundationDepth,
+			Bedrock:         monument.Bedrock,
+			Geology:         monument.Geology,
+
+			StartDate: mark.Start,
+			EndDate:   mark.End,
+
+			Antennas:  antennas,
+			Receivers: receivers,
+		})
+	}
+
+	return Group{Name: name, Marks: marks}, true
 }

--- a/cmd/sensor-config/installed.go
+++ b/cmd/sensor-config/installed.go
@@ -115,3 +115,134 @@ func (n *Network) InstalledSensors(set *meta.Set, match *regexp.Regexp, network,
 
 	return nil
 }
+
+func (s Settings) InstalledSensors(set *meta.Set, name string, match *regexp.Regexp, networks string, sensors ...string) (Group, bool) {
+
+	nets := make(map[string]interface{})
+	for _, n := range strings.Split(networks, ",") {
+		if n = strings.TrimSpace(n); n != "" {
+			nets[n] = true
+		}
+	}
+
+	types := make(map[string]interface{})
+	for _, t := range sensors {
+		types[strings.TrimSpace(t)] = true
+	}
+
+	var stations []Station
+	for _, stn := range set.Stations() {
+		net, ok := set.Network(stn.Network)
+		if !ok {
+			continue
+		}
+		if _, ok := nets[net.Code]; !ok {
+			continue
+		}
+
+		var sites []Site
+		for _, site := range set.Sites() {
+			if site.Station != stn.Code {
+				continue
+			}
+
+			if !match.MatchString(site.Location) {
+				continue
+			}
+
+			sensors := make(map[Sensor][]string)
+
+			for _, c := range set.Collections(site) {
+
+				if _, ok := types[c.Component.Type]; !ok && len(types) > 0 {
+					continue
+				}
+
+				sensor := Sensor{
+					Make:  c.InstalledSensor.Make,
+					Model: c.InstalledSensor.Model,
+
+					Azimuth: c.InstalledSensor.Azimuth,
+					Method:  c.InstalledSensor.Method,
+					Dip:     c.InstalledSensor.Dip,
+
+					Vertical: c.InstalledSensor.Vertical,
+					North:    c.InstalledSensor.North,
+					East:     c.InstalledSensor.East,
+
+					StartDate: c.InstalledSensor.Start,
+					EndDate:   c.InstalledSensor.End,
+				}
+
+				sensors[sensor] = append(sensors[sensor], c.Code())
+			}
+
+			var list []Sensor
+			for sensor, chans := range sensors {
+				dedupe := make(map[string]interface{})
+				for _, c := range chans {
+					dedupe[c] = true
+				}
+				var channels []string
+				for k := range dedupe {
+					channels = append(channels, k)
+				}
+				sort.Strings(channels)
+				sensor.Channels = strings.Join(channels, ",")
+				list = append(list, sensor)
+			}
+
+			// need at least one sensor
+			if !(len(list) > 0) {
+				continue
+			}
+
+			sort.Slice(list, func(i, j int) bool {
+				return list[i].Less(list[j])
+			})
+
+			sites = append(sites, Site{
+				Code: site.Location,
+
+				Latitude:  site.Latitude,
+				Longitude: site.Longitude,
+				Elevation: site.Elevation,
+				Depth:     site.Depth,
+				Datum:     site.Datum,
+				Survey:    site.Survey,
+
+				StartDate: site.Start,
+				EndDate:   site.End,
+
+				Sensors: list,
+			})
+		}
+
+		// need at least one site
+		if !(len(sites) > 0) {
+			continue
+		}
+
+		sort.Slice(sites, func(i, j int) bool {
+			return sites[i].Less(sites[j])
+		})
+
+		stations = append(stations, Station{
+			Code: stn.Code,
+			Name: stn.Name,
+
+			Latitude:  stn.Latitude,
+			Longitude: stn.Longitude,
+			Elevation: stn.Elevation,
+			Depth:     stn.Depth,
+			Datum:     stn.Datum,
+
+			StartDate: stn.Start,
+			EndDate:   stn.End,
+
+			Sites: sites,
+		})
+	}
+
+	return Group{Name: name, Stations: stations}, true
+}

--- a/cmd/sensor-config/manualcollect.go
+++ b/cmd/sensor-config/manualcollect.go
@@ -91,3 +91,95 @@ func (n *Network) ManualCollection(set *meta.Set, network, label string) error {
 
 	return nil
 }
+
+func (s Settings) ManualCollection(set *meta.Set, name, network string) (Group, bool) {
+
+	var samples []Station
+	for _, sample := range set.Samples() {
+
+		net, ok := set.Network(sample.Network)
+		if !ok {
+			continue
+		}
+		if net.Code != network {
+			continue
+		}
+
+		var sites []Site
+		for _, point := range set.Points() {
+			if point.Sample != sample.Code {
+				continue
+			}
+
+			var sensors []Sensor
+			for _, feature := range set.Features() {
+				if feature.Station != sample.Code {
+					continue
+				}
+				if feature.Location != point.Location {
+					continue
+				}
+
+				sensors = append(sensors, Sensor{
+					Code:        feature.Sublocation,
+					Property:    feature.Property,
+					Aspect:      feature.Aspect,
+					Description: feature.Description,
+
+					StartDate: feature.Start,
+					EndDate:   feature.End,
+				})
+			}
+
+			if !(len(sensors) > 0) {
+				continue
+			}
+
+			sort.Slice(sensors, func(i, j int) bool {
+				return sensors[i].Less(sensors[j])
+			})
+
+			sites = append(sites, Site{
+				Code: point.Location,
+
+				Latitude:  point.Latitude,
+				Longitude: point.Longitude,
+				Elevation: point.Elevation,
+				Depth:     point.Depth,
+				Datum:     point.Datum,
+				Survey:    point.Survey,
+
+				StartDate: point.Start,
+				EndDate:   point.End,
+
+				Sensors: sensors,
+			})
+		}
+
+		if !(len(sites) > 0) {
+			continue
+		}
+
+		sort.Slice(sites, func(i, j int) bool {
+			return sites[i].Less(sites[j])
+		})
+
+		samples = append(samples, Station{
+			Code: sample.Code,
+			Name: sample.Name,
+
+			Latitude:  sample.Latitude,
+			Longitude: sample.Longitude,
+			Elevation: sample.Elevation,
+			Depth:     sample.Depth,
+			Datum:     sample.Datum,
+
+			StartDate: sample.Start,
+			EndDate:   sample.End,
+
+			Sites: sites,
+		})
+	}
+
+	return Group{Name: name, Samples: samples}, true
+}

--- a/cmd/sensor-config/mount.go
+++ b/cmd/sensor-config/mount.go
@@ -185,3 +185,187 @@ func (n *Network) Doas(set *meta.Set, network, label string) error {
 
 	return nil
 }
+
+func (s Settings) Cameras(set *meta.Set, name, network string) (Group, bool) {
+
+	net, ok := set.Network(network)
+	if !ok {
+		return Group{}, false
+	}
+
+	var mounts []Mount
+	for _, mount := range set.Mounts() {
+		if mount.Network != net.Code {
+			continue
+		}
+
+		var views []View
+		for _, view := range set.Views() {
+			if mount.Code != view.Mount {
+				continue
+			}
+
+			var cameras []Sensor
+
+			for _, camera := range set.InstalledCameras() {
+				if mount.Code != camera.Mount {
+					continue
+				}
+				if view.Code != camera.View {
+					continue
+				}
+				cameras = append(cameras, Sensor{
+					Make:  camera.Make,
+					Model: camera.Model,
+
+					Dip:     camera.Dip,
+					Azimuth: camera.Azimuth,
+
+					Vertical: camera.Vertical,
+					North:    camera.North,
+					East:     camera.East,
+
+					StartDate: camera.Start,
+					EndDate:   camera.End,
+				})
+			}
+
+			sort.Slice(cameras, func(i, j int) bool {
+				return cameras[i].Less(cameras[j])
+			})
+
+			views = append(views, View{
+				Code:        view.Code,
+				Label:       view.Label,
+				Description: view.Description,
+
+				Azimuth: view.Azimuth,
+				Method:  view.Method,
+				Dip:     view.Dip,
+
+				StartDate: view.Start,
+				EndDate:   view.End,
+
+				Sensors: cameras,
+			})
+		}
+
+		if !(len(views) > 0) {
+			continue
+		}
+
+		sort.Slice(views, func(i, j int) bool {
+			return views[i].Less(views[j])
+		})
+
+		mounts = append(mounts, Mount{
+			Code:  mount.Code,
+			Name:  mount.Name,
+			Mount: mount.Description,
+
+			Latitude:  mount.Latitude,
+			Longitude: mount.Longitude,
+			Elevation: mount.Elevation,
+			Datum:     mount.Datum,
+
+			StartDate: mount.Start,
+			EndDate:   mount.End,
+
+			Views: views,
+		})
+	}
+
+	return Group{Name: name, Mounts: mounts}, true
+}
+
+func (s Settings) Doases(set *meta.Set, name, network string) (Group, bool) {
+
+	net, ok := set.Network(network)
+	if !ok {
+		return Group{}, false
+	}
+
+	var mounts []Mount
+	for _, mount := range set.Mounts() {
+		if mount.Network != net.Code {
+			continue
+		}
+
+		var views []View
+		for _, view := range set.Views() {
+			if mount.Code != view.Mount {
+				continue
+			}
+
+			var doases []Sensor
+
+			for _, doas := range set.Doases() {
+				if mount.Code != doas.Mount {
+					continue
+				}
+				if view.Code != doas.View {
+					continue
+				}
+				doases = append(doases, Sensor{
+					Make:  doas.Make,
+					Model: doas.Model,
+
+					Dip:     doas.Dip,
+					Azimuth: doas.Azimuth,
+
+					Vertical: doas.Vertical,
+					North:    doas.North,
+					East:     doas.East,
+
+					StartDate: doas.Start,
+					EndDate:   doas.End,
+				})
+			}
+
+			sort.Slice(doases, func(i, j int) bool {
+				return doases[i].Less(doases[j])
+			})
+
+			views = append(views, View{
+				Code:        view.Code,
+				Label:       view.Label,
+				Description: view.Description,
+
+				Azimuth: view.Azimuth,
+				Method:  view.Method,
+				Dip:     view.Dip,
+
+				StartDate: view.Start,
+				EndDate:   view.End,
+
+				Sensors: doases,
+			})
+		}
+
+		if !(len(views) > 0) {
+			continue
+		}
+
+		sort.Slice(views, func(i, j int) bool {
+			return views[i].Less(views[j])
+		})
+
+		mounts = append(mounts, Mount{
+			Code:  mount.Code,
+			Name:  mount.Name,
+			Mount: mount.Description,
+
+			Latitude:  mount.Latitude,
+			Longitude: mount.Longitude,
+			Elevation: mount.Elevation,
+			Datum:     mount.Datum,
+
+			StartDate: mount.Start,
+			EndDate:   mount.End,
+
+			Views: views,
+		})
+	}
+
+	return Group{Name: name, Mounts: mounts}, true
+}

--- a/cmd/sensor-config/network.go
+++ b/cmd/sensor-config/network.go
@@ -186,8 +186,19 @@ func (m Mount) Less(mount Mount) bool {
 	return m.Code < mount.Code
 }
 
+type Group struct {
+	Name string `xml:"name,omitempty,attr" json:"name,omitempty"`
+
+	Marks    []Mark    `xml:"Mark,omitempty" json:"marks,omitempty"`
+	Mounts   []Mount   `xml:"Mount,omitempty" json:"mounts,omitempty"`
+	Samples  []Station `xml:"Sample,omitempty" json:"samples,omitempty"`
+	Stations []Station `xml:"Station,omitempty" json:"stations,omitempty"`
+}
+
 type Network struct {
 	XMLName xml.Name `xml:"SensorXML"`
+
+	Groups []Group `xml:"Group,omitempty" json:"group,omitempty"`
 
 	Stations []Station `xml:"Station,omitempty" json:"station,omitempty"`
 	Marks    []Mark    `xml:"Mark,omitempty" json:"mark,omitempty"`
@@ -212,5 +223,22 @@ func (n *Network) EncodeXML(wr io.Writer, prefix, indent string) error {
 }
 
 func (n *Network) EncodeJSON(wr io.Writer) error {
-	return json.NewEncoder(wr).Encode(n)
+	// remap network to avoid xml specific details
+	remap := struct {
+		Groups   []Group   `json:"group,omitempty"`
+		Stations []Station `json:"station,omitempty"`
+		Marks    []Mark    `json:"mark,omitempty"`
+		Buoys    []Station `json:"buoy,omitempty"`
+		Mounts   []Mount   `json:"mount,omitempty"`
+		Samples  []Station `json:"sample,omitempty"`
+	}{
+		Groups:   n.Groups,
+		Stations: n.Stations,
+		Marks:    n.Marks,
+		Buoys:    n.Buoys,
+		Mounts:   n.Mounts,
+		Samples:  n.Samples,
+	}
+
+	return json.NewEncoder(wr).Encode(remap)
 }

--- a/cmd/sensor-config/settings.go
+++ b/cmd/sensor-config/settings.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GeoNet/delta/meta"
+)
+
+func (s Settings) Network(set *meta.Set) (Network, error) {
+
+	var network Network
+
+	// this is the legacy mechanism - which has trouble with sensors at sites which have unrelated networks
+	for _, n := range strings.Split(s.networks, ",") {
+		if err := network.InstalledSensors(set, &s.combined, strings.TrimSpace(n), ""); err != nil {
+			return Network{}, fmt.Errorf("unable to build seismic details (%s): %v", n, err)
+		}
+	}
+
+	if err := network.InstalledSensors(set, &s.water, s.coastal, "Coastal"); err != nil {
+		return Network{}, fmt.Errorf("unable to build water details: %v", err)
+	}
+
+	if err := network.InstalledSensors(set, &s.water, s.lentic, "Lake"); err != nil {
+		return Network{}, fmt.Errorf("unable to build water details: %v", err)
+	}
+
+	if err := network.EnviroSensor(set, s.enviro, "Environmental Sensor"); err != nil {
+		return Network{}, fmt.Errorf("unable to build envirosensor configuration: %v", err)
+	}
+
+	if err := network.Dart(set, s.dart, "DART Bottom Pressure Recorder"); err != nil {
+		return Network{}, fmt.Errorf("unable to build dart configuration: %v", err)
+	}
+
+	if err := network.Gnss(set, "GNSS Antenna", "GNSS Receiver"); err != nil {
+		return Network{}, fmt.Errorf("unable to build gnss configuration: %v", err)
+	}
+
+	if err := network.Camera(set, s.volcano, "Camera"); err != nil {
+		return Network{}, fmt.Errorf("unable to build camera configuration: %v", err)
+	}
+
+	if err := network.Camera(set, s.building, "Camera"); err != nil {
+		return Network{}, fmt.Errorf("unable to build camera configuration: %v", err)
+	}
+
+	if err := network.Doas(set, s.doas, "DOAS"); err != nil {
+		return Network{}, fmt.Errorf("unable to build camera configuration: %v", err)
+	}
+
+	if err := network.ManualCollection(set, s.manual, "Manual Collection"); err != nil {
+		return Network{}, fmt.Errorf("unable to build camera configuration: %v", err)
+	}
+
+	return network, nil
+}
+
+func (s Settings) Groups(set *meta.Set) Network {
+
+	var network Network
+
+	if group, ok := s.InstalledSensors(set, "Air pressure sensor", &s.acoustic, s.networks); ok {
+		network.Groups = append(network.Groups, group)
+	}
+
+	if group, ok := s.InstalledSensors(set, "Broadband seismometer", &s.seismic, s.networks, "Broadband Seismometer"); ok {
+		network.Groups = append(network.Groups, group)
+	}
+
+	if group, ok := s.InstalledSensors(set, "Coastal sea level gauge", &s.water, s.coastal); ok {
+		network.Groups = append(network.Groups, group)
+	}
+
+	if group, ok := s.InstalledSensors(set, "DART bottom pressure recorder", &s.water, s.dart); ok {
+		network.Groups = append(network.Groups, group)
+	}
+
+	if group, ok := s.EnviroSensor(set, "Environmental sensor", s.enviro); ok {
+		network.Groups = append(network.Groups, group)
+	}
+
+	if group, ok := s.Doases(set, "DOAS spectrometer", s.doas); ok {
+		network.Groups = append(network.Groups, group)
+	}
+
+	if group, ok := s.InstalledSensors(set, "Geomagnetic sensor", &s.geomag, s.magnetic); ok {
+		network.Groups = append(network.Groups, group)
+	}
+
+	if group, ok := s.Gnss(set, "GNSS/GPS", s.gnss); ok {
+		network.Groups = append(network.Groups, group)
+	}
+
+	if group, ok := s.InstalledSensors(set, "Lake level gauge", &s.water, s.lentic); ok {
+		network.Groups = append(network.Groups, group)
+	}
+
+	if group, ok := s.ManualCollection(set, "Manual collection", s.manual); ok {
+		network.Groups = append(network.Groups, group)
+	}
+
+	if group, ok := s.InstalledSensors(set, "Short period seismometer", &s.seismic, s.networks, "Short Period Seismometer"); ok {
+		network.Groups = append(network.Groups, group)
+	}
+
+	if group, ok := s.InstalledSensors(set, "Strong motion sensor", &s.strong, s.networks); ok {
+		network.Groups = append(network.Groups, group)
+	}
+
+	if group, ok := s.Cameras(set, "Volcano camera", s.volcano); ok {
+		network.Groups = append(network.Groups, group)
+	}
+
+	return network
+}


### PR DESCRIPTION
This XML format is a little easier to handle sensors that are installed at stations with unrelated network details, such as an acoustic sensor at a coastal gauge site, or a geomagnetic sensor at a strong motion site.

It removes the concept of the network (other than the total as a whole) and adds groups of sensors with a given characteristic. The type of installation is maintained, such as a Station/Sensor, or a Mark/Monument, or a Mount/View.