### PR TITLE
feat: add check for radome graph for sitelogs

### DIFF
--- a/tools/sitelogs/main.go
+++ b/tools/sitelogs/main.go
@@ -591,10 +591,19 @@ func main() {
 					var graphs []string
 					models := make(map[string]interface{})
 					for _, a := range antennas {
-						if _, ok := models[a.AntennaType]; ok {
+						antennaType := a.AntennaType
+						// check for any graph which may include radome
+						if a.AntennaRadomeType != "NONE" {
+							withRadome := a.AntennaType + " " + a.AntennaRadomeType
+							if _, ok := antennaGraphs[withRadome]; ok {
+								antennaType = withRadome
+							}
+						}
+
+						if _, ok := models[antennaType]; ok {
 							continue
 						}
-						switch g, ok := antennaGraphs[a.AntennaType]; {
+						switch g, ok := antennaGraphs[antennaType]; {
 						case ok:
 							b, err := hex.DecodeString(g)
 							if err != nil {
@@ -603,9 +612,9 @@ func main() {
 							}
 							graphs = append(graphs, strings.Join([]string{a.AntennaType, string(b)}, "\n"))
 						default:
-							log.Printf("warning: missing antenna graph for: \"%s\"", a.AntennaType)
+							log.Printf("warning: missing antenna graph for: \"%s\"", antennaType)
 						}
-						models[a.AntennaType] = true
+						models[antennaType] = true
 					}
 					return "\n" + strings.Join(graphs, "\n")
 				}(),

--- a/tools/sitelogs/main.go
+++ b/tools/sitelogs/main.go
@@ -594,7 +594,7 @@ func main() {
 						antennaType := a.AntennaType
 						// check for any graph which may include radome
 						if a.AntennaRadomeType != "NONE" {
-							withRadome := a.AntennaType + " " + a.AntennaRadomeType
+							withRadome := a.AntennaType + "   " + a.AntennaRadomeType
 							if _, ok := antennaGraphs[withRadome]; ok {
 								antennaType = withRadome
 							}
@@ -610,7 +610,7 @@ func main() {
 								log.Printf("error: unable to decode antenna graph for: \"%s\"", a.AntennaType)
 								continue
 							}
-							graphs = append(graphs, strings.Join([]string{a.AntennaType, string(b)}, "\n"))
+							graphs = append(graphs, strings.Join([]string{antennaType, string(b)}, "\n"))
 						default:
 							log.Printf("warning: missing antenna graph for: \"%s\"", antennaType)
 						}


### PR DESCRIPTION
This update allows the sitelog code to check if there is a graph which includes a radome, if present, in which case that graph will be used. Otherwise, the antenna only graph will be used. In the configuration the antenna and radome should have a space between them.