### PR TITLE
feat: update the response code to build short response snippets

### DIFF
--- a/resp/info.go
+++ b/resp/info.go
@@ -1,0 +1,50 @@
+package resp
+
+// ResponseInfo is used to store simplified conversion details.
+type ResponseInfo struct {
+	Sensitivity float64
+	Gain        float64
+	Bias        float64
+	Input       string
+	Output      string
+}
+
+// Info builds a ResponseInfo for the given response base and sensor, database and stream collection details.
+func (r *Resp) Info(responses ...string) (*ResponseInfo, error) {
+
+	// simple response
+	info := ResponseInfo{
+		Sensitivity: 1.0,
+		Gain:        1.0,
+	}
+
+	// run through the desired responses.
+	for _, lookup := range responses {
+
+		res, err := r.Type(lookup)
+		if err != nil {
+			return nil, err
+		}
+
+		// extract the response details into the response info.
+		switch {
+		case res.InstrumentSensitivity != nil:
+			if info.Input == "" {
+				info.Input = res.InstrumentSensitivity.InputUnits.Name
+			}
+			info.Output = res.InstrumentSensitivity.OutputUnits.Name
+			info.Sensitivity *= res.InstrumentSensitivity.Value
+		case res.InstrumentPolynomial != nil:
+			if info.Input == "" {
+				info.Input = res.InstrumentPolynomial.InputUnits.Name
+			}
+			info.Output = res.InstrumentPolynomial.OutputUnits.Name
+			if coefs := res.PolynomialCoefficients(); len(coefs) == 2 {
+				info.Bias = coefs[0].Value
+				info.Gain = coefs[1].Value
+			}
+		}
+	}
+
+	return &info, nil
+}

--- a/resp/instrument.go
+++ b/resp/instrument.go
@@ -1,0 +1,502 @@
+package resp
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var ErrInvalidResponse = errors.New("attempt to correct the wrong type of response, biases require a polynomial response")
+
+type InstrumentResponseOpt func(*InstrumentResponse)
+
+// InstrumentResponse is used for building an instrument response based on sensor and datalogger pairs. It makes no assumption about
+// the StationXML version, ideally it should encompass all required elements. The conversion from a bas Response to a
+// particular version is done via encoding interfaces.
+type InstrumentResponse struct {
+	Prefix        string
+	Serial        string
+	Frequency     float64
+	ScaleFactor   float64
+	ScaleBias     float64
+	ScaleAbsolute float64
+	GainFactor    float64
+	GainBias      float64
+	GainAbsolute  float64
+	Telemetry     float64
+	Preamp        float64
+
+	sensor     *ResponseType
+	datalogger *ResponseType
+
+	stages []ResponseStageType
+}
+
+// Prefix sets the label used to prefix Response element names.
+func Prefix(prefix string) InstrumentResponseOpt {
+	return func(r *InstrumentResponse) {
+		r.Prefix = prefix
+	}
+}
+
+// Serial sets the label used to prefix Response equipment labels.
+func Serial(serial string) InstrumentResponseOpt {
+	return func(r *InstrumentResponse) {
+		r.Serial = serial
+	}
+}
+
+// Frequency is used to set the overall reference frequency for the Response.
+func Frequency(frequency float64) InstrumentResponseOpt {
+	return func(r *InstrumentResponse) {
+		r.Frequency = frequency
+	}
+}
+
+// Calibration is used to set a initial sensor reference gain, this overrides the default values.
+func Calibration(factor, bias, absolute float64) InstrumentResponseOpt {
+	return func(r *InstrumentResponse) {
+		r.ScaleFactor = factor
+		r.ScaleBias = bias
+		r.ScaleAbsolute = absolute
+	}
+}
+
+// Gain is used to adjusts the installed sensor gains, this is in addition to the default values.
+func Gain(factor, bias, absolute float64) InstrumentResponseOpt {
+	return func(r *InstrumentResponse) {
+		r.GainFactor = factor
+		r.GainBias = bias
+		r.GainAbsolute = absolute
+	}
+}
+
+// Telemetry is used to adjusts the sensor and datalogger connection gain, this is in addition to the default values.
+func Telemetry(gain float64) InstrumentResponseOpt {
+	return func(r *InstrumentResponse) {
+		r.Telemetry = gain
+	}
+}
+
+// Preamp is used to adjusts the datalogger gains, this is in addition to the default values.
+func Preamp(preamp float64) InstrumentResponseOpt {
+	return func(r *InstrumentResponse) {
+		r.Preamp = preamp
+	}
+}
+
+// NewResponse builds a Response with the given options.
+func NewInstrumentResponse(opts ...InstrumentResponseOpt) *InstrumentResponse {
+	r := InstrumentResponse{
+		ScaleFactor: 1.0,
+		GainFactor:  1.0,
+	}
+	r.Config(opts...)
+	return &r
+}
+
+// Config can be used to set extra Response options.
+func (r *InstrumentResponse) Config(opts ...InstrumentResponseOpt) {
+	for _, opt := range opts {
+		opt(r)
+	}
+}
+
+// SetPrefix sets the label used to prefix Response element names.
+func (r *InstrumentResponse) SetPrefix(prefix string) {
+	Prefix(prefix)(r)
+}
+
+// SetSerial sets the label used to prefix Response equipment labels.
+func (r *InstrumentResponse) SetSerial(serial string) {
+	Serial(serial)(r)
+}
+
+// SetFrequency is used to set the overall reference frequency for the Response.
+func (r *InstrumentResponse) SetFrequency(frequency float64) {
+	Frequency(frequency)(r)
+}
+
+// SetCalibration is used to set a initial sensor reference gain, this overrides the default values.
+func (r *InstrumentResponse) SetCalibration(scale, bias, absolute float64) {
+	Calibration(scale, bias, absolute)(r)
+}
+
+// SetGain is used to adjusts the installed sensor gains, this is in addition to the default values.
+func (r *InstrumentResponse) SetGain(scale, bias, absolute float64) {
+	Gain(scale, bias, absolute)(r)
+}
+
+// SetPreamp is used to adjusts the datalogger gains, this is in addition to the default values.
+func (r *InstrumentResponse) SetPreamp(preamp float64) {
+	Preamp(preamp)(r)
+}
+
+// SetTelemetry is used to adjusts the datalogger gains, this is in addition to the default values.
+func (r *InstrumentResponse) SetTelemetry(gain float64) {
+	Telemetry(gain)(r)
+}
+
+// Polynomial finds the PolynomialType in the Response if one is present.
+func (r *InstrumentResponse) Polynomial() *PolynomialType {
+	for _, s := range r.stages {
+		if s.Polynomial == nil {
+			continue
+		}
+		return s.Polynomial
+	}
+	return nil
+}
+
+// SetSensor takes an XML encoded ResponseType that represents a Sensor and adds it to the Response.
+func (r *InstrumentResponse) SetSensor(data []byte) error {
+
+	var sensor ResponseType
+	if err := xml.Unmarshal(data, &sensor); err != nil {
+		return err
+	}
+
+	switch {
+	case sensor.InstrumentSensitivity != nil:
+		// check biases, as these imply a polynomial response
+		if r.ScaleBias != 0.0 || r.GainBias != 0.0 || r.GainAbsolute != 0.0 {
+			return ErrInvalidResponse
+		}
+		// a simple scaling of the overall sensitivity
+		sensor.InstrumentSensitivity.Value *= (r.ScaleFactor * r.GainFactor)
+		// look for the first stage with a gain
+		for i := range sensor.Stages {
+			stage := sensor.Stages[i]
+			if stage.StageGain == nil {
+				continue
+			}
+			// update the first one found, and ignore the rest
+			stage.StageGain.Value *= (r.ScaleFactor * r.GainFactor)
+			break
+		}
+	case sensor.InstrumentPolynomial != nil:
+
+		// First adjust for any calibrations, these are simply replacing the first two coefficients
+		if r.ScaleFactor != 1.0 || r.ScaleAbsolute != 0.0 {
+			for i := range sensor.Stages {
+				stage := sensor.Stages[i]
+
+				// there can only be one
+				if stage.Polynomial == nil {
+					continue
+				}
+
+				// ignore changes in units, or changes in bounds
+				switch c := len(stage.Polynomial.Coefficients); {
+				case c > 1:
+					stage.Polynomial.Coefficients[1] = PolynomialCoefficient{
+						Number: stage.Polynomial.Coefficients[1].Number,
+						Value:  r.ScaleFactor,
+					}
+					stage.Polynomial.Coefficients[0] = PolynomialCoefficient{
+						Number: stage.Polynomial.Coefficients[0].Number,
+						Value:  r.ScaleAbsolute,
+					}
+				case c > 0:
+					stage.Polynomial.Coefficients[0] = PolynomialCoefficient{
+						Number: stage.Polynomial.Coefficients[0].Number,
+						Value:  r.ScaleAbsolute,
+					}
+				}
+
+				// update the overall instrument polynomial
+				sensor.InstrumentPolynomial.Coefficients = append([]PolynomialCoefficient{}, stage.Polynomial.Coefficients...)
+			}
+		}
+
+		// Second adjust for any gains, these will update the first two coefficents
+		if r.GainFactor != 1.0 || r.GainBias != 0.0 || r.GainAbsolute != 0.0 {
+
+			for i := range sensor.Stages {
+				stage := sensor.Stages[i]
+
+				// there can only be one
+				if stage.Polynomial == nil {
+					continue
+				}
+
+				// ignore changes in units, or changes in bounds
+				switch c := len(stage.Polynomial.Coefficients); {
+				case c > 1:
+					stage.Polynomial.Coefficients[0] = PolynomialCoefficient{
+						Number: stage.Polynomial.Coefficients[0].Number,
+						Value: stage.Polynomial.Coefficients[0].Value*r.GainFactor +
+							stage.Polynomial.Coefficients[1].Value*r.GainBias*r.ScaleBias + r.GainAbsolute,
+					}
+					stage.Polynomial.Coefficients[1] = PolynomialCoefficient{
+						Number: stage.Polynomial.Coefficients[1].Number,
+						Value:  stage.Polynomial.Coefficients[1].Value * r.GainFactor,
+					}
+				case c > 0:
+					stage.Polynomial.Coefficients[0] = PolynomialCoefficient{
+						Number: stage.Polynomial.Coefficients[0].Number,
+						Value:  stage.Polynomial.Coefficients[0].Value*r.GainFactor + r.GainAbsolute,
+					}
+				}
+
+				// update the overall instrument polynomial
+				sensor.InstrumentPolynomial.Coefficients = append([]PolynomialCoefficient{}, stage.Polynomial.Coefficients...)
+			}
+		}
+	default:
+		return nil
+	}
+
+	r.sensor = &sensor
+
+	return nil
+}
+
+// SetDatalogger takes an XML encoded ResponseType that represents a Datalogger and adds it to the Response.
+func (r *InstrumentResponse) SetDatalogger(data []byte) error {
+
+	var datalogger ResponseType
+	if err := xml.Unmarshal(data, &datalogger); err != nil {
+		return err
+	}
+
+	if datalogger.InstrumentSensitivity == nil {
+		return nil
+	}
+
+	// a telemetry gain has been given, prepend an appropriate stage
+	if r.Telemetry != 0.0 {
+		datalogger.Stages = append([]ResponseStageType{{
+			//TODO: technically the poles and zeros are not required, but kept to allow acceptance checks
+			PolesZeros: &PolesZerosType{
+				ResourceId:             "PolesZeros#Telemetry",
+				InputUnits:             datalogger.InstrumentSensitivity.InputUnits,
+				OutputUnits:            datalogger.InstrumentSensitivity.InputUnits,
+				PzTransferFunctionType: LaplaceRadiansSecondPzTransferFunction,
+				NormalizationFactor:    1.0,
+				NormalizationFrequency: r.Frequency,
+			},
+			StageGain: &StageGain{
+				Value:     r.Telemetry,
+				Frequency: r.Frequency,
+			},
+		}}, datalogger.Stages...)
+	}
+
+	// a preamp has been given, prepend an appropriate stage
+	if r.Preamp != 0.0 {
+		datalogger.Stages = append([]ResponseStageType{{
+			//TODO: technically the poles and zeros are not required, but kept to allow acceptance checks
+			PolesZeros: &PolesZerosType{
+				ResourceId:             "PolesZeros#Preamp",
+				InputUnits:             datalogger.InstrumentSensitivity.InputUnits,
+				OutputUnits:            datalogger.InstrumentSensitivity.InputUnits,
+				PzTransferFunctionType: LaplaceRadiansSecondPzTransferFunction,
+				NormalizationFactor:    1.0,
+				NormalizationFrequency: r.Frequency,
+			},
+			StageGain: &StageGain{
+				Value:     r.Preamp,
+				Frequency: r.Frequency,
+			},
+		}}, datalogger.Stages...)
+	}
+
+	r.datalogger = &datalogger
+
+	return nil
+}
+
+// Derived returns a ResponseType when there is only a single set of derived Response stages.
+func (r *InstrumentResponse) Derived(data []byte) (*ResponseType, error) {
+
+	var derived ResponseType
+	if err := xml.Unmarshal(data, &derived); err != nil {
+		return nil, err
+	}
+
+	// must have at least an instrument sensitivity or polynomial
+	if derived.InstrumentSensitivity == nil && derived.InstrumentPolynomial == nil {
+		return nil, nil
+	}
+
+	var stages []ResponseStageType
+	for n, s := range derived.Stages {
+		stage, err := s.Clone()
+		if err != nil {
+			return nil, err
+		}
+
+		if stage.PolesZeros != nil {
+			stage.PolesZeros.Name = fmt.Sprintf("%sstage_%d", r.Prefix, n+1)
+		}
+		if stage.Coefficients != nil {
+			stage.Coefficients.Name = fmt.Sprintf("%sstage_%d", r.Prefix, n+1)
+		}
+		if stage.Polynomial != nil {
+			stage.Polynomial.Name = fmt.Sprintf("%sstage_%d", r.Prefix, n+1)
+		}
+		stage.Number = n + 1
+
+		stages = append(stages, stage)
+	}
+
+	derived.Stages = stages
+
+	return &derived, nil
+}
+
+// Coeffs returns a slice of PolynomialCoeffiencent values present in the Response.
+func (r *InstrumentResponse) Coeffs() []PolynomialCoefficient {
+	var coeffs []PolynomialCoefficient
+
+	if p := r.Polynomial(); p != nil && len(p.Coefficients) > 0 {
+		coeffs = append(coeffs, PolynomialCoefficient{
+			Number: len(coeffs) + 1,
+			Value:  p.Coefficients[0].Value,
+		})
+	}
+
+	if p := r.Polynomial(); p != nil && len(p.Coefficients) > 1 {
+		if scale := r.Scale(); scale != 0.0 {
+			coeffs = append(coeffs, PolynomialCoefficient{
+				Number: len(coeffs) + 1,
+				Value:  p.Coefficients[1].Value / scale,
+			})
+		}
+	}
+
+	return coeffs
+}
+
+// Scale calculates the overall response scale factor.
+func (r *InstrumentResponse) Scale() float64 {
+	scale := 1.0
+	for _, s := range r.stages {
+		if s.StageGain == nil || s.StageGain.Value == 0.0 {
+			continue
+		}
+		scale *= s.StageGain.Value
+	}
+	return scale
+}
+
+// Normalise adjusts the labels and stage gains of a Response.
+func (r *InstrumentResponse) Normalise() error {
+	var stages []ResponseStageType
+	for n, s := range append(r.sensor.Stages, r.datalogger.Stages...) {
+
+		stage, err := s.Clone()
+		if err != nil {
+			return err
+		}
+
+		if stage.PolesZeros != nil {
+			stage.PolesZeros.Name = fmt.Sprintf("%sstage_%d", r.Prefix, n+1)
+			for i := range stage.PolesZeros.Zeros {
+				stage.PolesZeros.Zeros[i].Number = i + 1
+			}
+			for i := range stage.PolesZeros.Poles {
+				stage.PolesZeros.Poles[i].Number = i + 1
+			}
+		}
+		if stage.Coefficients != nil {
+			stage.Coefficients.Name = fmt.Sprintf("%sstage_%d", r.Prefix, n+1)
+			for i := range stage.Coefficients.Numerators {
+				stage.Coefficients.Numerators[i].Number = i + 1
+			}
+			for i := range stage.Coefficients.Denominators {
+				stage.Coefficients.Denominators[i].Number = i + 1
+			}
+		}
+		if stage.Polynomial != nil {
+			stage.Polynomial.Name = fmt.Sprintf("%sstage_%d", r.Prefix, n+1)
+			for i := range stage.Polynomial.Coefficients {
+				stage.Polynomial.Coefficients[i].Number = i + 1
+			}
+		}
+
+		stage.Number = n + 1
+
+		if stage.StageGain != nil {
+			scale := stage.StageGain.Value
+			if stage.PolesZeros != nil {
+				g, z := stage.PolesZeros.Gain(r.Frequency), stage.PolesZeros.Gain(stage.PolesZeros.NormalizationFrequency)
+				stage.PolesZeros.NormalizationFactor = 1.0 / g
+				stage.PolesZeros.NormalizationFrequency = r.Frequency
+				scale /= (z / g)
+			}
+			stage.StageGain = &StageGain{
+				Value:     scale,
+				Frequency: r.Frequency,
+			}
+		}
+		stages = append(stages, stage)
+	}
+
+	r.stages = stages
+
+	return nil
+}
+
+// ResponseType builds a combined ResponseType from a Response.
+func (r *InstrumentResponse) ResponseType() (*ResponseType, error) {
+
+	if err := r.Normalise(); err != nil {
+		return nil, err
+	}
+
+	resp := ResponseType{
+		InstrumentSensitivity: func() *InstrumentSensitivity {
+			if r.sensor.InstrumentSensitivity != nil {
+				return &InstrumentSensitivity{
+					InputUnits:  r.sensor.InstrumentSensitivity.InputUnits,
+					OutputUnits: r.datalogger.InstrumentSensitivity.OutputUnits,
+					Frequency:   r.Frequency,
+					Value:       r.Scale(),
+				}
+			}
+			return nil
+		}(),
+		InstrumentPolynomial: func() *InstrumentPolynomial {
+			if poly := r.Polynomial(); poly != nil {
+				return &InstrumentPolynomial{
+					ResourceId:              "Instrument" + poly.ResourceId + ":" + r.Serial,
+					Name:                    strings.TrimRight(r.Prefix, "."),
+					InputUnits:              poly.InputUnits,
+					OutputUnits:             r.datalogger.InstrumentSensitivity.OutputUnits,
+					ApproximationType:       poly.ApproximationType,
+					FrequencyLowerBound:     poly.FrequencyLowerBound,
+					FrequencyUpperBound:     poly.FrequencyUpperBound,
+					ApproximationLowerBound: poly.ApproximationLowerBound,
+					ApproximationUpperBound: poly.ApproximationUpperBound,
+					MaximumError:            poly.MaximumError,
+					Coefficients:            r.Coeffs(),
+				}
+			}
+			return nil
+		}(),
+		Stages: r.stages,
+
+		// used for polynomial calculations
+		frequency: r.Frequency,
+	}
+
+	return &resp, nil
+}
+
+// Marshal generates an XML encoded version of the Response as a ResponseType.
+func (r *InstrumentResponse) Marshal() ([]byte, error) {
+	resp, err := r.ResponseType()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := xml.Marshal(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/resp/instrument.go
+++ b/resp/instrument.go
@@ -12,7 +12,7 @@ var ErrInvalidResponse = errors.New("attempt to correct the wrong type of respon
 type InstrumentResponseOpt func(*InstrumentResponse)
 
 // InstrumentResponse is used for building an instrument response based on sensor and datalogger pairs. It makes no assumption about
-// the StationXML version, ideally it should encompass all required elements. The conversion from a bas Response to a
+// the StationXML version, ideally it should encompass all required elements. The conversion from a base Response to a
 // particular version is done via encoding interfaces.
 type InstrumentResponse struct {
 	Prefix        string
@@ -86,7 +86,7 @@ func Preamp(preamp float64) InstrumentResponseOpt {
 	}
 }
 
-// NewResponse builds a Response with the given options.
+// NewInstrumentResponse builds a Response with the given options.
 func NewInstrumentResponse(opts ...InstrumentResponseOpt) *InstrumentResponse {
 	r := InstrumentResponse{
 		ScaleFactor: 1.0,

--- a/resp/resp.go
+++ b/resp/resp.go
@@ -2,9 +2,11 @@ package resp
 
 import (
 	"embed"
+	"encoding/xml"
 	"fmt"
 	"io/fs"
 	"os"
+	"sync"
 )
 
 // TODO: add embed when populated
@@ -24,7 +26,7 @@ func LookupFS(fsys fs.FS, response string) ([]byte, error) {
 
 		// return the first one found
 		for _, name := range names {
-			data, err := fs.ReadFile(files, name)
+			data, err := fs.ReadFile(fsys, name)
 			if err != nil {
 				return nil, err
 			}
@@ -52,4 +54,52 @@ func LookupBase(base string, response string) ([]byte, error) {
 		return LookupDir(base, response)
 	}
 	return Lookup(response)
+}
+
+type Resp struct {
+	mu sync.Mutex
+
+	base  string
+	cache map[string][]byte
+}
+
+func NewResp(base string) *Resp {
+	return &Resp{
+		base:  base,
+		cache: make(map[string][]byte),
+	}
+}
+
+func (r *Resp) Lookup(response string) ([]byte, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if v, ok := r.cache[response]; ok {
+		return v, nil
+	}
+
+	v, err := LookupBase(r.base, response)
+	if err != nil {
+		return nil, err
+	}
+
+	r.cache[response] = v
+
+	return v, nil
+}
+
+func (r *Resp) Type(response string) (*ResponseType, error) {
+
+	data, err := r.Lookup(response)
+	if err != nil {
+		return nil, err
+	}
+
+	// decode the response into a simple form.
+	var res ResponseType
+	if err := xml.Unmarshal(data, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
 }

--- a/resp/resp_test.go
+++ b/resp/resp_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/GeoNet/delta/internal/stationxml"
-
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -27,7 +25,7 @@ func TestAuto(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			first, err := stationxml.NewResponseType(raw)
+			first, err := NewResponseType(raw)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -37,7 +35,7 @@ func TestAuto(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			second, err := stationxml.NewResponseType(data)
+			second, err := NewResponseType(data)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -68,7 +66,7 @@ func TestFiles(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			snippet, err := stationxml.NewResponseType(raw)
+			snippet, err := NewResponseType(raw)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/resp/response_type.go
+++ b/resp/response_type.go
@@ -1,0 +1,284 @@
+package resp
+
+import (
+	"bytes"
+	"encoding/gob"
+	"encoding/xml"
+	"math"
+	"math/cmplx"
+)
+
+const LaplaceRadiansSecondPzTransferFunction = "LAPLACE (RADIANS/SECOND)"
+
+type Float struct {
+	Value float64 `xml:",chardata"`
+}
+
+type Units struct {
+	Name        string `xml:"Name"`
+	Description string `xml:"Description,omitempty"`
+}
+
+type ApproximationBound struct {
+	Value float64 `xml:",chardata"`
+}
+
+type NumeratorCoefficient struct {
+	I     int     `xml:"i,attr"`
+	Value float64 `xml:",chardata"`
+}
+
+type PolynomialCoefficient struct {
+	Number int     `xml:"number,attr"`
+	Value  float64 `xml:",chardata"`
+}
+
+type CoefficientNumerator struct {
+	Number int     `xml:"number,attr"`
+	Value  float64 `xml:",chardata"`
+}
+
+type CoefficientDenominator struct {
+	Number int     `xml:"number,attr"`
+	Value  float64 `xml:",chardata"`
+}
+
+type PoleZero struct {
+	Number int `xml:"number,attr"`
+
+	Real      Float `xml:"Real"`
+	Imaginary Float `xml:"Imaginary"`
+}
+
+type CoefficientsType struct {
+	ResourceId  string `xml:"resourceId,attr,omitempty"`
+	Name        string `xml:"name,attr,omitempty"`
+	Description string `xml:"description,attr,omitempty"`
+
+	InputUnits             Units  `xml:"InputUnits"`
+	OutputUnits            Units  `xml:"OutputUnits"`
+	CfTransferFunctionType string `xml:"CfTransferFunctionType"`
+
+	Numerators   []CoefficientNumerator   `xml:"Numerator,omitempty"`
+	Denominators []CoefficientDenominator `xml:"Denominator,omitempty"`
+}
+
+type DecimationType struct {
+	InputSampleRate float64 `xml:"InputSampleRate"`
+	Factor          int     `xml:"Factor"`
+	Offset          int     `xml:"Offset"`
+	Delay           float64 `xml:"Delay"`
+	Correction      float64 `xml:"Correction"`
+}
+
+type FirType struct {
+	ResourceId  string `xml:"resourceId,attr"`
+	Name        string `xml:"name,attr,omitempty"`
+	Description string `xml:"description,attr,omitempty"`
+
+	InputUnits  Units  `xml:"InputUnits"`
+	OutputUnits Units  `xml:"OutputUnits"`
+	Symmetry    string `xml:"Symmetry"`
+
+	NumeratorCoefficients []NumeratorCoefficient `xml:"NumeratorCoefficient"`
+}
+
+type PolesZerosType struct {
+	ResourceId  string `xml:"resourceId,attr"`
+	Name        string `xml:"name,attr,omitempty"`
+	Description string `xml:"description,attr,omitempty"`
+
+	InputUnits  Units `xml:"InputUnits"`
+	OutputUnits Units `xml:"OutputUnits"`
+
+	PzTransferFunctionType string  `xml:"PzTransferFunctionType"`
+	NormalizationFactor    float64 `xml:"NormalizationFactor"`
+	NormalizationFrequency float64 `xml:"NormalizationFrequency"`
+
+	Zeros []PoleZero `xml:"Zero"`
+	Poles []PoleZero `xml:"Pole"`
+}
+
+// Gain ccalculates the poles and zeros response gain at a given frequency
+func (pz PolesZerosType) Gain(freq float64) float64 {
+
+	var w complex128
+	switch pz.PzTransferFunctionType {
+	case LaplaceRadiansSecondPzTransferFunction:
+		w = complex(0.0, 2.0*math.Pi*freq)
+	default:
+		w = complex(0.0, freq)
+	}
+
+	h := complex(float64(1.0), float64(0.0))
+
+	for _, zero := range pz.Zeros {
+		h *= (w - complex(zero.Real.Value, zero.Imaginary.Value))
+	}
+
+	for _, pole := range pz.Poles {
+		h /= (w - complex(pole.Real.Value, pole.Imaginary.Value))
+	}
+
+	return cmplx.Abs(h)
+}
+
+type PolynomialType struct {
+	ResourceId  string `xml:"resourceId,attr,omitempty"`
+	Name        string `xml:"name,attr,omitempty"`
+	Description string `xml:"description,attr,omitempty"`
+
+	InputUnits  Units `xml:"InputUnits"`
+	OutputUnits Units `xml:"OutputUnits"`
+
+	ApproximationType       string             `xml:"ApproximationType"`
+	FrequencyLowerBound     float64            `xml:"FrequencyLowerBound"`
+	FrequencyUpperBound     float64            `xml:"FrequencyUpperBound"`
+	ApproximationLowerBound ApproximationBound `xml:"ApproximationLowerBound"`
+	ApproximationUpperBound ApproximationBound `xml:"ApproximationUpperBound"`
+	MaximumError            float64            `xml:"MaximumError"`
+
+	Coefficients []PolynomialCoefficient `xml:"Coefficient,omitempty"`
+}
+
+func (p PolynomialType) Value(input float64) float64 {
+	var value float64
+	for n, c := range p.Coefficients {
+		value += c.Value * math.Pow(input, float64(n))
+	}
+	return value
+}
+
+type StageGain struct {
+	Value     float64 `xml:"Value"`
+	Frequency float64 `xml:"Frequency"`
+}
+
+type ResponseStageType struct {
+	Number int `xml:"number,attr"`
+
+	Coefficients *CoefficientsType `xml:"Coefficients,omitempty"`
+	Decimation   *DecimationType   `xml:"Decimation,omitempty"`
+	FIR          *FirType          `xml:"FIR,omitempty"`
+	PolesZeros   *PolesZerosType   `xml:"PolesZeros,omitempty"`
+	Polynomial   *PolynomialType   `xml:"Polynomial,omitempty"`
+
+	StageGain *StageGain `xml:"StageGain,omitempty"`
+}
+
+// clone two responses to avoid shared backing arrays
+func (r *ResponseStageType) Clone() (ResponseStageType, error) {
+
+	var buff bytes.Buffer
+
+	if err := gob.NewEncoder(&buff).Encode(r); err != nil {
+		return ResponseStageType{}, err
+	}
+
+	var c ResponseStageType
+	if err := gob.NewDecoder(&buff).Decode(&c); err != nil {
+		return ResponseStageType{}, err
+	}
+
+	return c, nil
+}
+
+type InstrumentSensitivity struct {
+	Value       float64 `xml:"Value"`
+	Frequency   float64 `xml:"Frequency"`
+	InputUnits  Units   `xml:"InputUnits"`
+	OutputUnits Units   `xml:"OutputUnits"`
+}
+
+type InstrumentPolynomial struct {
+	ResourceId  string `xml:"resourceId,attr,omitempty"`
+	Name        string `xml:"name,attr"`
+	Description string `xml:"description,attr,omitempty"`
+
+	InputUnits  Units `xml:"InputUnits"`
+	OutputUnits Units `xml:"OutputUnits"`
+
+	ApproximationType       string             `xml:"ApproximationType"`
+	FrequencyLowerBound     float64            `xml:"FrequencyLowerBound"`
+	FrequencyUpperBound     float64            `xml:"FrequencyUpperBound"`
+	ApproximationLowerBound ApproximationBound `xml:"ApproximationLowerBound"`
+	ApproximationUpperBound ApproximationBound `xml:"ApproximationUpperBound"`
+	MaximumError            float64            `xml:"MaximumError"`
+
+	Coefficients []PolynomialCoefficient `xml:"Coefficient,omitempty"`
+}
+
+// ResponseType is a struct that mimics the StationXML ResponseType element, but is not constrained to a particular version.
+type ResponseType struct {
+	XMLName    xml.Name `xml:"Response"`
+	ResourceId string   `xml:"resourceId,attr,omitempty"`
+
+	InstrumentSensitivity *InstrumentSensitivity `xml:"InstrumentSensitivity,omitempty"`
+	InstrumentPolynomial  *InstrumentPolynomial  `xml:"InstrumentPolynomial,omitempty"`
+
+	Stages []ResponseStageType `xml:"Stage,omitempty"`
+
+	// used for instrument polynomial calculations
+	frequency float64
+}
+
+func NewResponseType(data []byte) (*ResponseType, error) {
+	var s ResponseType
+	if err := s.Unmarshal(data); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func (r *ResponseType) Scale() float64 {
+	scale := 1.0
+	for _, s := range r.Stages {
+		if s.StageGain == nil || s.StageGain.Value == 0.0 {
+			continue
+		}
+		scale *= s.StageGain.Value
+	}
+	return scale
+}
+
+func (r *ResponseType) PolynomialType() *PolynomialType {
+	for _, s := range r.Stages {
+		if s.Polynomial == nil {
+			continue
+		}
+		return s.Polynomial
+	}
+	return nil
+}
+
+func (r *ResponseType) PolynomialCoefficients() []PolynomialCoefficient {
+	var coeffs []PolynomialCoefficient
+
+	if p := r.PolynomialType(); p != nil && len(p.Coefficients) > 0 {
+		coeffs = append(coeffs, p.Coefficients[0])
+	}
+
+	if p := r.PolynomialType(); p != nil && len(p.Coefficients) > 1 {
+		if scale := r.Scale(); scale != 0.0 {
+			coeffs = append(coeffs, PolynomialCoefficient{
+				Number: 1,
+				Value:  p.Coefficients[1].Value / scale,
+			})
+		}
+	}
+
+	return coeffs
+}
+
+func (r *ResponseType) Unmarshal(data []byte) error {
+	return xml.Unmarshal(data, r)
+}
+
+func (r ResponseType) Marshal() ([]byte, error) {
+	body, err := xml.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	head := []byte(xml.Header)
+	return append(head, append(body, '\n')...), nil
+}

--- a/resp/response_type.go
+++ b/resp/response_type.go
@@ -72,7 +72,7 @@ type DecimationType struct {
 }
 
 type FirType struct {
-	ResourceId  string `xml:"resourceId,attr"`
+	ResourceId  string `xml:"resourceId,attr,omitempty"`
 	Name        string `xml:"name,attr,omitempty"`
 	Description string `xml:"description,attr,omitempty"`
 
@@ -84,7 +84,7 @@ type FirType struct {
 }
 
 type PolesZerosType struct {
-	ResourceId  string `xml:"resourceId,attr"`
+	ResourceId  string `xml:"resourceId,attr,omitempty"`
 	Name        string `xml:"name,attr,omitempty"`
 	Description string `xml:"description,attr,omitempty"`
 
@@ -155,7 +155,8 @@ type StageGain struct {
 }
 
 type ResponseStageType struct {
-	Number int `xml:"number,attr"`
+	Number     int    `xml:"number,attr"`
+	ResourceId string `xml:"resourceId,attr,omitempty"`
 
 	Coefficients *CoefficientsType `xml:"Coefficients,omitempty"`
 	Decimation   *DecimationType   `xml:"Decimation,omitempty"`


### PR DESCRIPTION
This helps build configurations that simply needs sensitivities and gains etc.

Most of this code has been moved from internal/stationxml.

The main type InstrumentResponse is likely to be renamed once the current Response struct code is removed.