### PR TITLE
chore: replace response type in stationxml with resp module

### DIFF
--- a/cmd/stationxml-build/build.go
+++ b/cmd/stationxml-build/build.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/GeoNet/delta/meta"
 	"github.com/GeoNet/delta/resp"
-
-	"github.com/GeoNet/delta/internal/stationxml"
 )
 
 // Builder is a cache of response files.
@@ -51,7 +49,7 @@ func (b *Builder) Frequency(code string) float64 {
 }
 
 // Response returns a stationxml ResponseType based on whether the Component has a sampling rate or not.
-func (b *Builder) Response(collection meta.Collection, correction meta.Correction) (*stationxml.ResponseType, error) {
+func (b *Builder) Response(collection meta.Collection, correction meta.Correction) (*resp.ResponseType, error) {
 	switch {
 	case collection.Component.SamplingRate != 0:
 		return b.DerivedResponseType(collection)
@@ -70,11 +68,11 @@ func (b *Builder) Prefix(c meta.Collection) string {
 }
 
 // DerivedResponseType return a ResponseType pointer for the derived type.
-func (b *Builder) DerivedResponseType(c meta.Collection) (*stationxml.ResponseType, error) {
-	pair := stationxml.NewResponse(
-		stationxml.Prefix(b.Prefix(c)),
-		stationxml.Serial(c.InstalledSensor.Serial),
-		stationxml.Frequency(b.Frequency(c.Code())),
+func (b *Builder) DerivedResponseType(c meta.Collection) (*resp.ResponseType, error) {
+	pair := resp.NewInstrumentResponse(
+		resp.Prefix(b.Prefix(c)),
+		resp.Serial(c.InstalledSensor.Serial),
+		resp.Frequency(b.Frequency(c.Code())),
 	)
 
 	// find the derived response
@@ -104,11 +102,11 @@ func (b *Builder) DerivedResponseType(c meta.Collection) (*stationxml.ResponseTy
 }
 
 // PairedResponseType return a ResponseType pointer where both a datalogger and sensor will be described.
-func (b *Builder) PairedResponseType(c meta.Collection, v meta.Correction) (*stationxml.ResponseType, error) {
-	pair := stationxml.NewResponse(
-		stationxml.Prefix(b.Prefix(c)),
-		stationxml.Serial(c.InstalledSensor.Serial),
-		stationxml.Frequency(b.Frequency(c.Code())),
+func (b *Builder) PairedResponseType(c meta.Collection, v meta.Correction) (*resp.ResponseType, error) {
+	pair := resp.NewInstrumentResponse(
+		resp.Prefix(b.Prefix(c)),
+		resp.Serial(c.InstalledSensor.Serial),
+		resp.Frequency(b.Frequency(c.Code())),
 	)
 
 	// adjust for corrections

--- a/internal/stationxml/encoder10.go
+++ b/internal/stationxml/encoder10.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/GeoNet/delta/resp"
+
 	stationxml "github.com/GeoNet/delta/internal/stationxml/v1.0"
 )
 
@@ -52,7 +54,7 @@ func (e Encoder10) toSampleRateRatio(f float64) *stationxml.SampleRateRatioType 
 	}
 }
 
-func (e Encoder10) Response(response *ResponseType) *stationxml.ResponseType {
+func (e Encoder10) Response(response *resp.ResponseType) *stationxml.ResponseType {
 	var stages []stationxml.ResponseStageType
 
 	for _, s := range response.Stages {
@@ -233,7 +235,7 @@ func (e Encoder10) Response(response *ResponseType) *stationxml.ResponseType {
 
 			gain = stationxml.GainType{
 				Value:     value,
-				Frequency: response.frequency,
+				Frequency: response.Frequency(),
 			}
 		}
 
@@ -301,7 +303,7 @@ func (e Encoder10) Response(response *ResponseType) *stationxml.ResponseType {
 		sensitivity = &stationxml.SensitivityType{
 			GainType: stationxml.GainType{
 				Value:     value,
-				Frequency: response.frequency,
+				Frequency: response.Frequency(),
 			},
 			InputUnits: stationxml.UnitsType{
 				Name:        response.InstrumentPolynomial.InputUnits.Name,

--- a/internal/stationxml/encoder11.go
+++ b/internal/stationxml/encoder11.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/GeoNet/delta/resp"
+
 	stationxml "github.com/GeoNet/delta/internal/stationxml/v1.1"
 )
 
@@ -52,7 +54,7 @@ func (e Encoder11) toSampleRateRatio(f float64) *stationxml.SampleRateRatioType 
 	}
 }
 
-func (e Encoder11) Response(response *ResponseType) *stationxml.ResponseType {
+func (e Encoder11) Response(response *resp.ResponseType) *stationxml.ResponseType {
 	var stages []stationxml.ResponseStageType
 
 	for _, s := range response.Stages {

--- a/internal/stationxml/encoder12.go
+++ b/internal/stationxml/encoder12.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/GeoNet/delta/resp"
+
 	stationxml "github.com/GeoNet/delta/internal/stationxml/v1.2"
 )
 
@@ -52,7 +54,7 @@ func (e Encoder12) toSampleRateRatio(f float64) *stationxml.SampleRateRatioType 
 	}
 }
 
-func (e Encoder12) Response(response *ResponseType) *stationxml.ResponseType {
+func (e Encoder12) Response(response *resp.ResponseType) *stationxml.ResponseType {
 	var stages []stationxml.ResponseStageType
 
 	for _, s := range response.Stages {

--- a/internal/stationxml/root.go
+++ b/internal/stationxml/root.go
@@ -2,6 +2,8 @@ package stationxml
 
 import (
 	"time"
+
+	"github.com/GeoNet/delta/resp"
 )
 
 // Equipment describes a StationXML Equipment element
@@ -34,7 +36,7 @@ type Stream struct {
 	StartDate time.Time
 	EndDate   time.Time
 
-	Response *ResponseType
+	Response *resp.ResponseType
 }
 
 // Channel forms the main part of a set of StationXML Channel elements

--- a/resp/response_type.go
+++ b/resp/response_type.go
@@ -231,6 +231,14 @@ func NewResponseType(data []byte) (*ResponseType, error) {
 	return &s, nil
 }
 
+func (r *ResponseType) Frequency() float64 {
+	return r.frequency
+}
+
+func (r *ResponseType) SetFrequency(freq float64) {
+	r.frequency = freq
+}
+
 func (r *ResponseType) Scale() float64 {
 	scale := 1.0
 	for _, s := range r.Stages {


### PR DESCRIPTION
The resp module should now handle response file generation and encoding. This should be a no-op change to how things run.

The Frequency() part is needed to expose the private frequency value (which is private to avoid it being encoded into the XML), this is only needed for version 1.0 and will be removed once we no longer need to maintain 1.0 (and 1.1).