### PR TITLE
fix: switch to use camera group

### DIFF
--- a/cmd/sensor-config/main.go
+++ b/cmd/sensor-config/main.go
@@ -23,6 +23,7 @@ type Settings struct {
 	manual   string // manualcollect network code
 	volcano  string // volcano camera network code
 	building string // building camera network code
+	camera   string // camera network codes
 	doas     string // doas network code
 
 	seismic  regexp.Regexp // seismic location codes
@@ -62,6 +63,7 @@ func main() {
 	flag.StringVar(&settings.dart, "dart", "TD", "dart buoy network code")
 	flag.StringVar(&settings.enviro, "enviro", "EN", "envirosensor network code")
 	flag.StringVar(&settings.manual, "manual", "MC", "manualcollect network code")
+	flag.StringVar(&settings.camera, "camera", "VC,BC", "volcano camera network codes")
 	flag.StringVar(&settings.volcano, "volcano", "VC", "volcano camera network code")
 	flag.StringVar(&settings.building, "building", "BC", "building camera network code")
 	flag.StringVar(&settings.magnetic, "magnetic", "GM,SM", "geomagnetic network code")

--- a/cmd/sensor-config/mount.go
+++ b/cmd/sensor-config/mount.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/GeoNet/delta/meta"
 )
@@ -186,16 +187,22 @@ func (n *Network) Doas(set *meta.Set, network, label string) error {
 	return nil
 }
 
-func (s Settings) Cameras(set *meta.Set, name, network string) (Group, bool) {
+func (s Settings) Cameras(set *meta.Set, name, networks string) (Group, bool) {
 
-	net, ok := set.Network(network)
-	if !ok {
-		return Group{}, false
+	nets := make(map[string]interface{})
+	for _, n := range strings.Split(networks, ",") {
+		if n = strings.TrimSpace(n); n != "" {
+			nets[n] = true
+		}
 	}
 
 	var mounts []Mount
 	for _, mount := range set.Mounts() {
-		if mount.Network != net.Code {
+		net, ok := set.Network(mount.Network)
+		if !ok {
+			continue
+		}
+		if _, ok := nets[net.Code]; !ok {
 			continue
 		}
 

--- a/cmd/sensor-config/settings.go
+++ b/cmd/sensor-config/settings.go
@@ -109,7 +109,7 @@ func (s Settings) Groups(set *meta.Set) Network {
 		network.Groups = append(network.Groups, group)
 	}
 
-	if group, ok := s.Cameras(set, "Volcano camera", s.volcano); ok {
+	if group, ok := s.Cameras(set, "Camera", s.camera); ok {
 		network.Groups = append(network.Groups, group)
 	}
 


### PR DESCRIPTION
This makes the group name for cameras "Camera" rather than "Volcano Camera"

This option simply lists the camera networks,  an alternative would be to have a master "camera" network code and use this as the external camera code.  This could be addresses if we add more camera networks.