### PR TITLE
fix: update tilde config to update site times instead of station times

### DIFF
--- a/cmd/tilde-config/coastal.go
+++ b/cmd/tilde-config/coastal.go
@@ -58,8 +58,8 @@ func (t *Tilde) Coastal(set *meta.Set, network string) error {
 
 			sens = append(sens, Sensor{
 				Code:  c.Location,
-				Start: toTimePtr(s.Start),
-				End:   toTimePtr(s.End),
+				Start: toTimePtr(c.Start),
+				End:   toTimePtr(c.End),
 
 				Latitude:       toFloat(fmt.Sprintf("%.4f", c.Latitude)),
 				Longitude:      toFloat(fmt.Sprintf("%.4f", c.Longitude)),

--- a/cmd/tilde-config/dart.go
+++ b/cmd/tilde-config/dart.go
@@ -40,8 +40,8 @@ func (t *Tilde) Dart(set *meta.Set, network string) error {
 			}
 			sens = append(sens, Sensor{
 				Code:  c.Location,
-				Start: toTimePtr(s.Start),
-				End:   toTimePtr(s.End),
+				Start: toTimePtr(c.Start),
+				End:   toTimePtr(c.End),
 
 				Latitude:       toFloat(fmt.Sprintf("%.4f", c.Latitude)),
 				Longitude:      toFloat(fmt.Sprintf("%.4f", c.Longitude)),

--- a/cmd/tilde-config/envirosensor.go
+++ b/cmd/tilde-config/envirosensor.go
@@ -49,8 +49,8 @@ func (t *Tilde) EnviroSensor(set *meta.Set, enviro string) error {
 
 			sens = append(sens, Sensor{
 				Code:  c.Location,
-				Start: toTimePtr(s.Start),
-				End:   toTimePtr(s.End),
+				Start: toTimePtr(c.Start),
+				End:   toTimePtr(c.End),
 
 				Latitude:       toFloat(fmt.Sprintf("%.4f", c.Latitude)),
 				Longitude:      toFloat(fmt.Sprintf("%.4f", c.Longitude)),

--- a/cmd/tilde-config/geomag.go
+++ b/cmd/tilde-config/geomag.go
@@ -36,8 +36,8 @@ func (t *Tilde) Geomag(set *meta.Set, geomag string, extra ...string) error {
 
 			sens = append(sens, Sensor{
 				Code:  x.Location,
-				Start: toTimePtr(s.Start),
-				End:   toTimePtr(s.End),
+				Start: toTimePtr(x.Start),
+				End:   toTimePtr(x.End),
 
 				Latitude:       toFloat(fmt.Sprintf("%.4f", x.Latitude)),
 				Longitude:      toFloat(fmt.Sprintf("%.4f", x.Longitude)),


### PR DESCRIPTION
This should handle the case of sites closing meaning the sensor is no longer installed rather than relying on the station times.