### PR TITLE
feat: update visibility table to use Mark label

### DIFF
--- a/environment/README.md
+++ b/environment/README.md
@@ -111,7 +111,7 @@ The level should be from 0 to 3, with 3 used for the smallest places.
 
 | Field | Description |
 | --- | --- |
-| _Code_ | Code to uniquely identify GNSS _Mark_ (or recording _Station_)
+| _Mark_ | Code to uniquely identify GNSS _Mark_
 | _Sky Visibility_ | Free form description of the site sky visibility and obstructions
 | _Start Date_ | General date and time at which the visibility was accurate
 | _End Date_ | General date and time at which the visibility was no longer accurate

--- a/environment/visibility.csv
+++ b/environment/visibility.csv
@@ -1,4 +1,4 @@
-Code,Sky Visibility,Start Date,End Date
+Mark,Sky Visibility,Start Date,End Date
 2406,good,2012-02-13T00:00:00Z,9999-01-01T00:00:00Z
 AHTI,dec. inc. 142 7 169 10,2009-01-01T00:00:00Z,9999-01-01T00:00:00Z
 AKTO,"Good to north, some fully grown trees to north east.",2006-04-27T00:00:00Z,9999-01-01T00:00:00Z

--- a/meta/list_test.go
+++ b/meta/list_test.go
@@ -380,7 +380,7 @@ func TestList(t *testing.T) {
 			"testdata/visibility.csv",
 			&VisibilityList{
 				Visibility{
-					Code:          "AHTI",
+					Mark:          "AHTI",
 					SkyVisibility: "good",
 					Span: Span{
 						Start: time.Date(2009, time.January, 1, 0, 0, 0, 0, time.UTC),
@@ -388,7 +388,7 @@ func TestList(t *testing.T) {
 					},
 				},
 				Visibility{
-					Code:          "DUND",
+					Mark:          "DUND",
 					SkyVisibility: "clear to NW",
 					Span: Span{
 						Start: time.Date(2005, time.August, 10, 0, 0, 0, 0, time.UTC),

--- a/meta/testdata/visibility.csv
+++ b/meta/testdata/visibility.csv
@@ -1,3 +1,3 @@
-Code,Sky Visibility,Start Date,End Date
+Mark,Sky Visibility,Start Date,End Date
 AHTI,good,2009-01-01T00:00:00Z,9999-01-01T00:00:00Z
 DUND,clear to NW,2005-08-10T00:00:00Z,9999-01-01T00:00:00Z

--- a/meta/visibility.go
+++ b/meta/visibility.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	visibilityCode = iota
+	visibilityMark = iota
 	visibilitySkyVisibility
 	visibilityStartTime
 	visibilityEndTime
@@ -15,7 +15,7 @@ const (
 )
 
 var visibilityHeaders Header = map[string]int{
-	"Code":           visibilityCode,
+	"Mark":           visibilityMark,
 	"Sky Visibility": visibilitySkyVisibility,
 	"Start Date":     visibilityStartTime,
 	"End Date":       visibilityEndTime,
@@ -23,7 +23,7 @@ var visibilityHeaders Header = map[string]int{
 
 type Visibility struct {
 	Span
-	Code          string
+	Mark          string
 	SkyVisibility string
 }
 
@@ -33,9 +33,9 @@ func (v VisibilityList) Len() int      { return len(v) }
 func (v VisibilityList) Swap(i, j int) { v[i], v[j] = v[j], v[i] }
 func (v VisibilityList) Less(i, j int) bool {
 	switch {
-	case v[i].Code < v[j].Code:
+	case v[i].Mark < v[j].Mark:
 		return true
-	case v[i].Code > v[j].Code:
+	case v[i].Mark > v[j].Mark:
 		return false
 	default:
 		return v[i].Start.Before(v[j].Start)
@@ -49,7 +49,7 @@ func (v VisibilityList) encode() [][]string {
 
 	for _, row := range v {
 		data = append(data, []string{
-			strings.TrimSpace(row.Code),
+			strings.TrimSpace(row.Mark),
 			strings.TrimSpace(row.SkyVisibility),
 			row.Start.Format(DateTimeFormat),
 			row.End.Format(DateTimeFormat),
@@ -79,7 +79,7 @@ func (v *VisibilityList) decode(data [][]string) error {
 			return err
 		}
 		visibilities = append(visibilities, Visibility{
-			Code:          strings.TrimSpace(d[visibilityCode]),
+			Mark:          strings.TrimSpace(d[visibilityMark]),
 			SkyVisibility: strings.TrimSpace(d[visibilitySkyVisibility]),
 			Span: Span{
 				Start: start,


### PR DESCRIPTION
This is part of making delta easier to reference via variables.

It is only used for GNSS sites and switching from Code to Mark makes it easier to track, other than the initial header swap there is no change to data or other applications.