### PR TITLE
feat: add extra equipment installation checks

### DIFF
--- a/tests/antennas_test.go
+++ b/tests/antennas_test.go
@@ -46,6 +46,17 @@ var antennaChecks = map[string]func(*meta.Set) func(t *testing.T){
 		}
 	},
 
+	"check for invalid installation dates": func(set *meta.Set) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, i := range set.InstalledAntennas() {
+				if i.End.After(i.Start) {
+					continue
+				}
+				t.Errorf("installed antenna is removed before it has been installed: %s", i.String())
+			}
+		}
+	},
+
 	"check for antenna installation mark overlaps": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 			installs := make(map[string]meta.InstalledAntennaList)

--- a/tests/cameras_test.go
+++ b/tests/cameras_test.go
@@ -46,6 +46,17 @@ var cameraChecks = map[string]func(*meta.Set) func(t *testing.T){
 		}
 	},
 
+	"check for invalid installation dates": func(set *meta.Set) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, i := range set.InstalledCameras() {
+				if i.End.After(i.Start) {
+					continue
+				}
+				t.Errorf("installed camera is removed before it has been installed: %s", i.String())
+			}
+		}
+	},
+
 	"check for cameras installation mount overlaps": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 			keys := make(map[string]interface{})

--- a/tests/dataloggers_test.go
+++ b/tests/dataloggers_test.go
@@ -90,6 +90,17 @@ var dataloggerChecks = map[string]func(*meta.Set) func(t *testing.T){
 			}
 		}
 	},
+
+	"check for invalid installation dates": func(set *meta.Set) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, i := range set.DeployedDataloggers() {
+				if i.End.After(i.Start) {
+					continue
+				}
+				t.Errorf("deployed datalogger is removed before it has been installed: %s", i.String())
+			}
+		}
+	},
 }
 
 func TestDataloggers(t *testing.T) {

--- a/tests/doases_test.go
+++ b/tests/doases_test.go
@@ -46,6 +46,17 @@ var doasChecks = map[string]func(*meta.Set) func(t *testing.T){
 		}
 	},
 
+	"check for invalid installation dates": func(set *meta.Set) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, i := range set.Doases() {
+				if i.End.After(i.Start) {
+					continue
+				}
+				t.Errorf("installed doas is removed before it has been installed: %s", i.String())
+			}
+		}
+	},
+
 	"check for doases installation mount overlaps": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 			keys := make(map[string]interface{})

--- a/tests/metsensors_test.go
+++ b/tests/metsensors_test.go
@@ -44,6 +44,16 @@ var metSensorChecks = map[string]func(*meta.Set) func(t *testing.T){
 			}
 		}
 	},
+	"check for invalid installation dates": func(set *meta.Set) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, i := range set.InstalledMetSensors() {
+				if i.End.After(i.Start) {
+					continue
+				}
+				t.Errorf("installed metsensor is removed before it has been installed: %s", i.String())
+			}
+		}
+	},
 	"check for missing metsensor marks": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 			keys := make(map[string]interface{})

--- a/tests/radomes_test.go
+++ b/tests/radomes_test.go
@@ -34,7 +34,6 @@ var installedRadomeChecks = map[string]func(*meta.Set) func(t *testing.T){
 			}
 		}
 	},
-
 	"check for overlapping radomes installations": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 			installs := make(map[string]meta.InstalledRadomeList)
@@ -59,6 +58,17 @@ var installedRadomeChecks = map[string]func(*meta.Set) func(t *testing.T){
 							v[i].Mark, v[i].Model, v[i].Serial, v[j].Model, v[j].Serial, v[i].Start.Format(meta.DateTimeFormat), v[i].End.Format(meta.DateTimeFormat))
 					}
 				}
+			}
+		}
+	},
+
+	"check for invalid installation dates": func(set *meta.Set) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, i := range set.InstalledRadomes() {
+				if i.End.After(i.Start) {
+					continue
+				}
+				t.Errorf("installed radome is removed before it has been installed: %s", i.String())
 			}
 		}
 	},

--- a/tests/receivers_test.go
+++ b/tests/receivers_test.go
@@ -63,6 +63,17 @@ var deployedReceiverChecks = map[string]func(*meta.Set) func(t *testing.T){
 		}
 	},
 
+	"check for invalid installation dates": func(set *meta.Set) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, i := range set.DeployedReceivers() {
+				if i.End.After(i.Start) {
+					continue
+				}
+				t.Errorf("deployed receiver is removed before it has been installed: %s", i.String())
+			}
+		}
+	},
+
 	"check for missing receiver marks": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 

--- a/tests/recorders_test.go
+++ b/tests/recorders_test.go
@@ -47,6 +47,17 @@ var installedRecorderChecks = map[string]func(*meta.Set) func(t *testing.T){
 		}
 	},
 
+	"check for invalid installation dates": func(set *meta.Set) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, i := range set.InstalledRecorders() {
+				if i.End.After(i.Start) {
+					continue
+				}
+				t.Errorf("installed recorder is removed before it has been installed: %s", i.String())
+			}
+		}
+	},
+
 	"check for invalid sensor azimuth": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 

--- a/tests/sensors_test.go
+++ b/tests/sensors_test.go
@@ -47,6 +47,17 @@ var installedSensorChecks = map[string]func(*meta.Set) func(t *testing.T){
 		}
 	},
 
+	"check for invalid installation dates": func(set *meta.Set) func(t *testing.T) {
+		return func(t *testing.T) {
+			for _, i := range set.InstalledSensors() {
+				if i.End.After(i.Start) {
+					continue
+				}
+				t.Errorf("installed sensor is removed before it has been installed: %s", i.String())
+			}
+		}
+	},
+
 	"check for invalid sensor azimuth": func(set *meta.Set) func(t *testing.T) {
 		return func(t *testing.T) {
 


### PR DESCRIPTION
These checks help spot when something has been installed after it has been removed, or removed before it has been installed