### PR TITLE
feat: Skeleton file generating for bnc-config

### DIFF
--- a/cmd/bnc-config/build.go
+++ b/cmd/bnc-config/build.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewConfig is a function that extracts information from delta meta data and local csv files.
-func NewConfig(set *meta.Set, caster *ntrip.Caster, extra bool) (*Config, error) {
+func NewConfig(set *meta.Set, caster *ntrip.Caster) (*Config, error) {
 
 	var config Config
 
@@ -31,29 +31,6 @@ func NewConfig(set *meta.Set, caster *ntrip.Caster, extra bool) (*Config, error)
 			Longitude: strconv.FormatFloat(mark.Longitude, 'f', 2, 64),
 			Format:    strings.Replace(m.Format, " ", "_", -1),
 		})
-	}
-
-	if extra {
-		for _, a := range caster.Aliases() {
-			mount, ok := mounts[a.Mount]
-			if !ok {
-				continue
-			}
-			mark, ok := set.Mark(mount.Mark)
-			if !ok {
-				continue
-			}
-
-			config.Mounts = append(config.Mounts, MountConfig{
-				Mount:     a.Alias,
-				Mark:      mark.Code,
-				Name:      mark.Name,
-				Country:   mount.Country,
-				Latitude:  strconv.FormatFloat(mark.Latitude, 'f', 2, 64),
-				Longitude: strconv.FormatFloat(mark.Longitude, 'f', 2, 64),
-				Format:    strings.Replace(mount.Format, " ", "_", -1),
-			})
-		}
 	}
 
 	config.Sort()

--- a/cmd/bnc-config/config_test.go
+++ b/cmd/bnc-config/config_test.go
@@ -32,7 +32,7 @@ func TestFiles_Config(t *testing.T) {
 	}
 
 	// build config from test files
-	config, err := NewConfig(set, caster, true)
+	config, err := NewConfig(set, caster)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/bnc-config/main.go
+++ b/cmd/bnc-config/main.go
@@ -101,8 +101,8 @@ func main() {
 		if settings.summary != "" {
 			// output a summary info of skeleton generating
 			var output strings.Builder
-			output.WriteString("successes: " + fmt.Sprintln(successes))
-			output.WriteString("generic headers: " + fmt.Sprintln(fallbacks))
+			output.WriteString("successes: " + strings.Join(successes, ", "))
+			output.WriteString("generic headers: " + strings.Join(fallbacks, ", "))
 			if err = os.WriteFile(settings.summary, []byte(output.String()), 0600); err != nil {
 				log.Fatalf("couldn't write fallback summary file: %s", err)
 			}

--- a/cmd/bnc-config/main.go
+++ b/cmd/bnc-config/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"time"
 
@@ -15,13 +14,12 @@ import (
 )
 
 type Settings struct {
-	base        string   // delta base directory
-	common      string   // ntrip common files directory
-	input       string   // ntrip input files directory
-	extra       bool     // add aliases to mounts list
-	output      string   // optional output file
-	sklPath     string   // optional path to write skeleton files
-	skippingSkl []string // optional list of marks to skip skeleton file generation
+	base    string // delta base directory
+	common  string // ntrip common files directory
+	input   string // ntrip input files directory
+	output  string // optional output file
+	sklPath string // optional path to write skeleton files
+	summary string // optional path-filename to write skeleton summary info
 }
 
 func main() {
@@ -44,17 +42,10 @@ func main() {
 	flag.StringVar(&settings.base, "base", "", "delta base directory for config files")
 	flag.StringVar(&settings.common, "common", "", "ntrip common csv file directory")
 	flag.StringVar(&settings.input, "input", "", "ntrip input csv config file directory")
-	flag.BoolVar(&settings.extra, "extra", false, "add aliases to mounts list")
 	flag.StringVar(&settings.output, "output", "", "optional output file")
 	flag.StringVar(&settings.sklPath, "skl", "", "optional path to write skeleton files")
-	var skippingSkl string
-	flag.StringVar(&skippingSkl, "skip-skl", "", "optional comma separated list of marks to skip skeleton file generation")
-
+	flag.StringVar(&settings.summary, "summary", "", "optional filename to output summary info for skeleton file")
 	flag.Parse()
-
-	if skippingSkl != "" {
-		settings.skippingSkl = strings.Split(skippingSkl, ",")
-	}
 
 	// set recovers the delta tables
 	set, err := delta.NewBase(settings.base)
@@ -68,7 +59,7 @@ func main() {
 	}
 
 	// generate the configuration structures
-	config, err := NewConfig(set, caster, settings.extra)
+	config, err := NewConfig(set, caster)
 	if err != nil {
 		log.Fatalf("unable to build config: %v", err)
 	}
@@ -90,19 +81,30 @@ func main() {
 
 	// generate skeleton file for each mount
 	if settings.sklPath != "" {
+		// we'll output the list in the end
+		fallbacks := make([]string, 0)
+		successes := make([]string, 0)
 		t := time.Now().UTC().Unix() // skeleton needs a reference time for the installations
 		for _, m := range config.Mounts {
-			if !slices.Contains(settings.skippingSkl, m.Mark) {
-				if s, err := skeleton(m.Mark, set, t); err == nil {
-					if len(s) > 0 { // empty means no valid mark during the reference time, simply skip without error
-						err = os.WriteFile(filepath.Join(settings.sklPath, fmt.Sprintf("%s00NZL.SKL", m.Mark)), []byte(s), 0600)
-						if err != nil {
-							log.Fatalf("couldn't write skeleton file: %s", err)
-						}
-					}
-				} else {
-					log.Fatalf("couldn't create skeleton: %s", err)
-				}
+			// note: skeleton() will return with generic header content when error occured
+			s, err := skeleton(m.Mark, set, t)
+			if err != nil {
+				fallbacks = append(fallbacks, m.Mark)
+			} else {
+				successes = append(successes, m.Mark)
+			}
+			err = os.WriteFile(filepath.Join(settings.sklPath, fmt.Sprintf("%s00NZL.SKL", m.Mark)), []byte(s), 0600)
+			if err != nil {
+				log.Fatalf("couldn't write skeleton file: %s", err)
+			}
+		}
+		if settings.summary != "" {
+			// output a summary info of skeleton generating
+			var output strings.Builder
+			output.WriteString("successes: " + fmt.Sprintln(successes))
+			output.WriteString("generic headers: " + fmt.Sprintln(fallbacks))
+			if err = os.WriteFile(settings.summary, []byte(output.String()), 0600); err != nil {
+				log.Fatalf("couldn't write fallback summary file: %s", err)
 			}
 		}
 	}

--- a/cmd/bnc-config/skl.go
+++ b/cmd/bnc-config/skl.go
@@ -11,15 +11,32 @@ var geo = ellipsoid.Init("WGS84", ellipsoid.Degrees, ellipsoid.Meter, ellipsoid.
 
 // genetrate skeleton file for a site,
 // based on the receiver, firmware, and antenna metadata at a given time (e.g. now)
-func skeleton(code string, set *meta.Set, ts int64) (string, error) {
+func skeleton(code string, set *meta.Set, ts int64) (content string, err error) {
 	var mark meta.Mark
+
+	defer func() {
+		if err != nil {
+			// if any error occurs, compose generic header + distribution comment as the result
+			// however, still keep the error
+			content = generic_header
+			if mark.Network == "LI" {
+				content += linzComment
+			} else {
+				content += geonetComment
+			}
+		}
+	}()
+
 	mark, ok := set.Mark(code)
 	if !ok {
-		return "", fmt.Errorf("no mark found for %s", code)
+		err = fmt.Errorf("no mark found for %s", code)
+		return
 	}
 	if !inWindow(ts, mark.Span) {
-		return "", nil // it's fine if there's no valid mark for the reference time
+		err = fmt.Errorf("no valid mark found for this time period for %s", code)
+		return
 	}
+
 	receivers := set.DeployedReceivers()
 	var dr meta.DeployedReceiver
 	for _, r := range receivers {
@@ -30,7 +47,8 @@ func skeleton(code string, set *meta.Set, ts int64) (string, error) {
 	}
 
 	if dr.Span.Start.IsZero() { // empty value
-		return "", fmt.Errorf("no effective deployed receiver version found for this time for %s", mark.Code)
+		err = fmt.Errorf("no effective deployed receiver version found for this time for %s", mark.Code)
+		return
 	}
 
 	x, y, z := geo.ToECEF(mark.Latitude, mark.Longitude, mark.Elevation)
@@ -44,7 +62,8 @@ func skeleton(code string, set *meta.Set, ts int64) (string, error) {
 	}
 
 	if ifirm.Span.Start.IsZero() {
-		return "", fmt.Errorf("no effective firmware version found for this time for %s", mark.Code)
+		err = fmt.Errorf("no effective firmware version found for this time for %s", mark.Code)
+		return
 	}
 
 	antennas := set.InstalledAntennas()
@@ -57,7 +76,8 @@ func skeleton(code string, set *meta.Set, ts int64) (string, error) {
 	}
 
 	if ia.Span.Start.IsZero() {
-		return "", fmt.Errorf("no effective installed antenna found for this time for %s", mark.Code)
+		err = fmt.Errorf("no effective installed antenna found for this time for %s", mark.Code)
+		return
 	}
 
 	radomes := set.InstalledRadomes()
@@ -91,7 +111,7 @@ func skeleton(code string, set *meta.Set, ts int64) (string, error) {
 		domesNumber = monument.DomesNumber
 	}
 
-	s := fmt.Sprintf(skeletonFormat,
+	content = fmt.Sprintf(skeletonFormat,
 		fmt.Sprintf("%s00NZL", code),       // MARKER NAME
 		domesNumber,                        // MARKER NUMBER
 		dr.Serial, dr.Model, ifirm.Version, // REC # / TYPE / VERS
@@ -99,12 +119,12 @@ func skeleton(code string, set *meta.Set, ts int64) (string, error) {
 		x, y, z, //APPROX POSITION XYZ
 		ia.Offset.Vertical, ia.Offset.East, ia.Offset.North) // ANTENNA: DELTA H/E/N
 	if mark.Network == "LI" {
-		s += linzComment
+		content += linzComment
 	} else {
-		s += geonetComment
+		content += geonetComment
 	}
 
-	return s, nil
+	return
 }
 
 const skeletonFormat = `                    OBSERVATION DATA    M (Mixed)           RINEX VERSION / TYPE
@@ -114,6 +134,24 @@ const skeletonFormat = `                    OBSERVATION DATA    M (Mixed)       
 %-20s%-16s%-4s                    ANT # / TYPE
 %-20.4f%-20.4f%-20.4fAPPROX POSITION XYZ
 %-20.4f%-20.4f%-20.4fANTENNA: DELTA H/E/N
+GEODETIC                                                    MARKER TYPE
+GeoNet              GNS                                     OBSERVER / AGENCY
+G   15 C1C C1X C2W C2X C5X L1C L1X L2W L2X L5X S1C S1X S2W  SYS / # / OBS TYPES
+       S2X S5X                                              SYS / # / OBS TYPES
+E   15 C1X C5X C6X C7X C8I L1X L5X L6X L7X L8I S1X S5X S6X  SYS / # / OBS TYPES
+       S7X S8I                                              SYS / # / OBS TYPES
+R   15 C1C C1P C2C C2P C3X L1C L1P L2C L2P L3X S1C S1P S2C  SYS / # / OBS TYPES
+       S2P S3X                                              SYS / # / OBS TYPES
+C   15 C1X C2I C5X C6I C7I L1X L2I L5X L6I L7I S1X S2I S5X  SYS / # / OBS TYPES
+       S6I S7I                                              SYS / # / OBS TYPES
+J   18 C1C C1X C1Z C2X C5X C6L L1C L1X L1Z L2X L5X L6L S1C  SYS / # / OBS TYPES
+       S1X S1Z S2X S5X S6L                                  SYS / # / OBS TYPES
+G L2X -0.25000                                              SYS / PHASE SHIFT
+R L1P  0.25000                                              SYS / PHASE SHIFT
+R L2C -0.25000                                              SYS / PHASE SHIFT
+J L2X  0.25000                                              SYS / PHASE SHIFT
+`
+const generic_header = `                    OBSERVATION DATA    M (Mixed)           RINEX VERSION / TYPE
 GEODETIC                                                    MARKER TYPE
 GeoNet              GNS                                     OBSERVER / AGENCY
 G   15 C1C C1X C2W C2X C5X L1C L1X L2W L2X L5X S1C S1X S2W  SYS / # / OBS TYPES

--- a/cmd/bnc-config/skl.go
+++ b/cmd/bnc-config/skl.go
@@ -18,7 +18,7 @@ func skeleton(code string, set *meta.Set, ts int64) (content string, err error) 
 		if err != nil {
 			// if any error occurs, compose generic header + distribution comment as the result
 			// however, still keep the error
-			content = generic_header
+			content = genericHeader
 			if mark.Network == "LI" {
 				content += linzComment
 			} else {
@@ -151,7 +151,7 @@ R L1P  0.25000                                              SYS / PHASE SHIFT
 R L2C -0.25000                                              SYS / PHASE SHIFT
 J L2X  0.25000                                              SYS / PHASE SHIFT
 `
-const generic_header = `                    OBSERVATION DATA    M (Mixed)           RINEX VERSION / TYPE
+const genericHeader = `                    OBSERVATION DATA    M (Mixed)           RINEX VERSION / TYPE
 GEODETIC                                                    MARKER TYPE
 GeoNet              GNS                                     OBSERVER / AGENCY
 G   15 C1C C1X C2W C2X C5X L1C L1X L2W L2X L5X S1C S1X S2W  SYS / # / OBS TYPES

--- a/cmd/bnc-config/skl.go
+++ b/cmd/bnc-config/skl.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/GeoNet/Golang-Ellipsoid/ellipsoid"
+	"github.com/GeoNet/delta/meta"
+)
+
+var geo = ellipsoid.Init("WGS84", ellipsoid.Degrees, ellipsoid.Meter, ellipsoid.LongitudeIsSymmetric, ellipsoid.BearingIsSymmetric)
+
+// genetrate skeleton file for a site,
+// based on the receiver, firmware, and antenna metadata at a given time (e.g. now)
+func skeleton(code string, set *meta.Set, ts int64) (string, error) {
+	var mark meta.Mark
+	for _, m := range set.Marks() {
+		if m.Code == code && inWindow(ts, m.Span) {
+			mark = m
+		}
+	}
+	if mark.Span.Start.IsZero() {
+		return "", fmt.Errorf("no mark found for %s", code)
+	}
+
+	receivers := set.DeployedReceivers()
+	var dr meta.DeployedReceiver
+	for _, r := range receivers {
+		if r.Mark == code && inWindow(ts, r.Span) {
+			dr = r
+			break
+		}
+	}
+
+	if dr.Span.Start.IsZero() { // empty value
+		return "", fmt.Errorf("no effective deployed receiver version found for this time for %s", mark.Code)
+	}
+
+	x, y, z := geo.ToECEF(mark.Latitude, mark.Longitude, mark.Elevation)
+	firmwares := set.FirmwareHistory()
+	var ifirm meta.FirmwareHistory
+	for _, f := range firmwares {
+		if dr.Model == f.Model && dr.Serial == f.Serial && inWindow(ts, f.Span) {
+			ifirm = f
+			break
+		}
+	}
+
+	if ifirm.Span.Start.IsZero() {
+		return "", fmt.Errorf("no effective firmware version found for this time for %s", mark.Code)
+	}
+
+	antennas := set.InstalledAntennas()
+	var ia meta.InstalledAntenna
+	for _, a := range antennas {
+		if a.Mark == code && inWindow(ts, a.Span) {
+			ia = a
+			break
+		}
+	}
+
+	if ia.Span.Start.IsZero() {
+		return "", fmt.Errorf("no effective installed antenna found for this time for %s", mark.Code)
+	}
+
+	radomes := set.InstalledRadomes()
+	var rad meta.InstalledRadome
+	for _, r := range radomes {
+		if r.Mark == code && inWindow(ts, r.Span) {
+			rad = r
+			break
+		}
+	}
+	// radome is optional, can be nil
+	var radome string
+	if rad.Span.Start.IsZero() {
+		radome = "NONE"
+	} else {
+		radome = rad.Model
+	}
+
+	var monument meta.Monument
+	for _, n := range set.Monuments() {
+		if n.Mark == code && inWindow(ts, n.Span) {
+			monument = n
+			break
+		}
+	}
+
+	var domesNumber string
+	if monument.Span.Start.IsZero() {
+		domesNumber = "UNKNOWN"
+	} else {
+		domesNumber = monument.DomesNumber
+	}
+
+	s := fmt.Sprintf(skeletonFormat,
+		fmt.Sprintf("%s00NZL", code),       // MARKER NAME
+		domesNumber,                        // MARKER NUMBER
+		dr.Serial, dr.Model, ifirm.Version, // REC # / TYPE / VERS
+		ia.Serial, ia.Model, radome, //ANT # / TYPE
+		x, y, z, //APPROX POSITION XYZ
+		ia.Offset.Vertical, ia.Offset.East, ia.Offset.North) // ANTENNA: DELTA H/E/N
+	if mark.Network == "LI" {
+		s += linzComment
+	} else {
+		s += geonetComment
+	}
+
+	return s, nil
+}
+
+const skeletonFormat = `                    OBSERVATION DATA    M (Mixed)           RINEX VERSION / TYPE
+%-60sMARKER NAME
+%-60sMARKER NUMBER
+%-20s%-20s%-20sREC # / TYPE / VERS
+%-20s%-16s%-4s                    ANT # / TYPE
+%-20.4f%-20.4f%-20.4fAPPROX POSITION XYZ
+%-20.4f%-20.4f%-20.4fANTENNA: DELTA H/E/N
+GEODETIC                                                    MARKER TYPE
+GeoNet              GNS                                     OBSERVER / AGENCY
+G   15 C1C C1X C2W C2X C5X L1C L1X L2W L2X L5X S1C S1X S2W  SYS / # / OBS TYPES 
+       S2X S5X                                              SYS / # / OBS TYPES 
+E   15 C1X C5X C6X C7X C8I L1X L5X L6X L7X L8I S1X S5X S6X  SYS / # / OBS TYPES 
+       S7X S8I                                              SYS / # / OBS TYPES
+R   15 C1C C1P C2C C2P C3X L1C L1P L2C L2P L3X S1C S1P S2C  SYS / # / OBS TYPES 
+       S2P S3X                                              SYS / # / OBS TYPES
+C   15 C1X C2I C5X C6I C7I L1X L2I L5X L6I L7I S1X S2I S5X  SYS / # / OBS TYPES 
+       S6I S7I                                              SYS / # / OBS TYPES
+J   18 C1C C1X C1Z C2X C5X C6L L1C L1X L1Z L2X L5X L6L S1C  SYS / # / OBS TYPES 
+       S1X S1Z S2X S5X S6L                                  SYS / # / OBS TYPES
+G L2X -0.25000                                              SYS / PHASE SHIFT   
+R L1P  0.25000                                              SYS / PHASE SHIFT   
+R L2C -0.25000                                              SYS / PHASE SHIFT   
+J L2X  0.25000                                              SYS / PHASE SHIFT
+`
+
+const geonetComment = `These data are supplied by GeoNet. GeoNet is core           COMMENT
+funded by EQC, LINZ and MBIE and is operated by             COMMENT
+GNS Science on behalf of stakeholders and all New           COMMENT
+Zealanders. The data policy, disclaimer, licence and        COMMENT
+contact information can be found at www.geonet.org.nz       COMMENT
+`
+
+const linzComment = `This station is part of the LINZ PositioNZ and GeoNet       COMMENT
+cGNSS networks and is jointly funded by Land Information    COMMENT
+New Zealand and GNS Science. This data is licenced for      COMMENT
+re-use under the Creative Commons Attribution 4.0           COMMENT
+International licence. For more detail please refer         COMMENT
+to https://www.linz.govt.nz/linz-copyright                  COMMENT
+`
+
+func inWindow(t int64, s meta.Span) bool {
+	return t >= s.Start.Unix() && t <= s.End.Unix()
+}

--- a/cmd/bnc-config/skl_test.go
+++ b/cmd/bnc-config/skl_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/GeoNet/delta"
+)
+
+func TestSkeleton(t *testing.T) {
+	// set recovers the delta tables
+	set, err := delta.NewBase("./testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tm := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	b, err := skeleton("AVLN", set, tm.UTC().Unix())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.ReadFile("./testdata/AVLN00NZL.SKL")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal([]byte(b), f) {
+		t.Errorf("generated skeleton file does not match:\n\n%s", b)
+	}
+}

--- a/cmd/bnc-config/skl_test.go
+++ b/cmd/bnc-config/skl_test.go
@@ -28,6 +28,6 @@ func TestSkeleton(t *testing.T) {
 	}
 
 	if !bytes.Equal([]byte(b), f) {
-		t.Errorf("generated skeleton file does not match:\n\n%s", b)
+		t.Errorf("generated skeleton file does not match(%d vs %d):\n%s", len(b), len(f), b)
 	}
 }

--- a/cmd/bnc-config/skl_test.go
+++ b/cmd/bnc-config/skl_test.go
@@ -31,3 +31,26 @@ func TestSkeleton(t *testing.T) {
 		t.Errorf("generated skeleton file does not match(%d vs %d):\n%s", len(b), len(f), b)
 	}
 }
+
+// tests the case where we unable to generate a skeleton file by given metadata,
+// and the generic skeleton file is used instead.
+func TestGenericSkeleton(t *testing.T) {
+	set, err := delta.NewBase("./testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// set the reference time to before the mark's install time
+	tm := time.Date(2005, 1, 1, 0, 0, 0, 0, time.UTC)
+	b, err := skeleton("AVLN", set, tm.UTC().Unix())
+	if err == nil {
+		t.Fatalf("expected to get error but got nil")
+	}
+	f, err := os.ReadFile("./testdata/AVLN-generic.SKL")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal([]byte(b), f) {
+		t.Errorf("generated skeleton file does not match(%d vs %d)", len(b), len(f))
+	}
+}

--- a/cmd/bnc-config/testdata/AVLN-generic.SKL
+++ b/cmd/bnc-config/testdata/AVLN-generic.SKL
@@ -1,0 +1,22 @@
+                    OBSERVATION DATA    M (Mixed)           RINEX VERSION / TYPE
+GEODETIC                                                    MARKER TYPE
+GeoNet              GNS                                     OBSERVER / AGENCY
+G   15 C1C C1X C2W C2X C5X L1C L1X L2W L2X L5X S1C S1X S2W  SYS / # / OBS TYPES
+       S2X S5X                                              SYS / # / OBS TYPES
+E   15 C1X C5X C6X C7X C8I L1X L5X L6X L7X L8I S1X S5X S6X  SYS / # / OBS TYPES
+       S7X S8I                                              SYS / # / OBS TYPES
+R   15 C1C C1P C2C C2P C3X L1C L1P L2C L2P L3X S1C S1P S2C  SYS / # / OBS TYPES
+       S2P S3X                                              SYS / # / OBS TYPES
+C   15 C1X C2I C5X C6I C7I L1X L2I L5X L6I L7I S1X S2I S5X  SYS / # / OBS TYPES
+       S6I S7I                                              SYS / # / OBS TYPES
+J   18 C1C C1X C1Z C2X C5X C6L L1C L1X L1Z L2X L5X L6L S1C  SYS / # / OBS TYPES
+       S1X S1Z S2X S5X S6L                                  SYS / # / OBS TYPES
+G L2X -0.25000                                              SYS / PHASE SHIFT
+R L1P  0.25000                                              SYS / PHASE SHIFT
+R L2C -0.25000                                              SYS / PHASE SHIFT
+J L2X  0.25000                                              SYS / PHASE SHIFT
+These data are supplied by GeoNet. GeoNet is core           COMMENT
+funded by EQC, LINZ and MBIE and is operated by             COMMENT
+GNS Science on behalf of stakeholders and all New           COMMENT
+Zealanders. The data policy, disclaimer, licence and        COMMENT
+contact information can be found at www.geonet.org.nz       COMMENT

--- a/cmd/bnc-config/testdata/AVLN00NZL.SKL
+++ b/cmd/bnc-config/testdata/AVLN00NZL.SKL
@@ -7,19 +7,19 @@ AVLN00NZL                                                   MARKER NAME
 0.0550              0.0000              0.0000              ANTENNA: DELTA H/E/N
 GEODETIC                                                    MARKER TYPE
 GeoNet              GNS                                     OBSERVER / AGENCY
-G   15 C1C C1X C2W C2X C5X L1C L1X L2W L2X L5X S1C S1X S2W  SYS / # / OBS TYPES 
-       S2X S5X                                              SYS / # / OBS TYPES 
-E   15 C1X C5X C6X C7X C8I L1X L5X L6X L7X L8I S1X S5X S6X  SYS / # / OBS TYPES 
+G   15 C1C C1X C2W C2X C5X L1C L1X L2W L2X L5X S1C S1X S2W  SYS / # / OBS TYPES
+       S2X S5X                                              SYS / # / OBS TYPES
+E   15 C1X C5X C6X C7X C8I L1X L5X L6X L7X L8I S1X S5X S6X  SYS / # / OBS TYPES
        S7X S8I                                              SYS / # / OBS TYPES
-R   15 C1C C1P C2C C2P C3X L1C L1P L2C L2P L3X S1C S1P S2C  SYS / # / OBS TYPES 
+R   15 C1C C1P C2C C2P C3X L1C L1P L2C L2P L3X S1C S1P S2C  SYS / # / OBS TYPES
        S2P S3X                                              SYS / # / OBS TYPES
-C   15 C1X C2I C5X C6I C7I L1X L2I L5X L6I L7I S1X S2I S5X  SYS / # / OBS TYPES 
+C   15 C1X C2I C5X C6I C7I L1X L2I L5X L6I L7I S1X S2I S5X  SYS / # / OBS TYPES
        S6I S7I                                              SYS / # / OBS TYPES
-J   18 C1C C1X C1Z C2X C5X C6L L1C L1X L1Z L2X L5X L6L S1C  SYS / # / OBS TYPES 
+J   18 C1C C1X C1Z C2X C5X C6L L1C L1X L1Z L2X L5X L6L S1C  SYS / # / OBS TYPES
        S1X S1Z S2X S5X S6L                                  SYS / # / OBS TYPES
-G L2X -0.25000                                              SYS / PHASE SHIFT   
-R L1P  0.25000                                              SYS / PHASE SHIFT   
-R L2C -0.25000                                              SYS / PHASE SHIFT   
+G L2X -0.25000                                              SYS / PHASE SHIFT
+R L1P  0.25000                                              SYS / PHASE SHIFT
+R L2C -0.25000                                              SYS / PHASE SHIFT
 J L2X  0.25000                                              SYS / PHASE SHIFT
 These data are supplied by GeoNet. GeoNet is core           COMMENT
 funded by EQC, LINZ and MBIE and is operated by             COMMENT

--- a/cmd/bnc-config/testdata/AVLN00NZL.SKL
+++ b/cmd/bnc-config/testdata/AVLN00NZL.SKL
@@ -1,0 +1,28 @@
+                    OBSERVATION DATA    M (Mixed)           RINEX VERSION / TYPE
+AVLN00NZL                                                   MARKER NAME
+                                                            MARKER NUMBER
+5921R40175          TRIMBLE ALLOY       5.45                REC # / TYPE / VERS
+1441047151          TRM57971.00     NONE                    ANT # / TYPE
+-4787496.5711       424505.1612         -4178889.3498       APPROX POSITION XYZ
+0.0550              0.0000              0.0000              ANTENNA: DELTA H/E/N
+GEODETIC                                                    MARKER TYPE
+GeoNet              GNS                                     OBSERVER / AGENCY
+G   15 C1C C1X C2W C2X C5X L1C L1X L2W L2X L5X S1C S1X S2W  SYS / # / OBS TYPES 
+       S2X S5X                                              SYS / # / OBS TYPES 
+E   15 C1X C5X C6X C7X C8I L1X L5X L6X L7X L8I S1X S5X S6X  SYS / # / OBS TYPES 
+       S7X S8I                                              SYS / # / OBS TYPES
+R   15 C1C C1P C2C C2P C3X L1C L1P L2C L2P L3X S1C S1P S2C  SYS / # / OBS TYPES 
+       S2P S3X                                              SYS / # / OBS TYPES
+C   15 C1X C2I C5X C6I C7I L1X L2I L5X L6I L7I S1X S2I S5X  SYS / # / OBS TYPES 
+       S6I S7I                                              SYS / # / OBS TYPES
+J   18 C1C C1X C1Z C2X C5X C6L L1C L1X L1Z L2X L5X L6L S1C  SYS / # / OBS TYPES 
+       S1X S1Z S2X S5X S6L                                  SYS / # / OBS TYPES
+G L2X -0.25000                                              SYS / PHASE SHIFT   
+R L1P  0.25000                                              SYS / PHASE SHIFT   
+R L2C -0.25000                                              SYS / PHASE SHIFT   
+J L2X  0.25000                                              SYS / PHASE SHIFT
+These data are supplied by GeoNet. GeoNet is core           COMMENT
+funded by EQC, LINZ and MBIE and is operated by             COMMENT
+GNS Science on behalf of stakeholders and all New           COMMENT
+Zealanders. The data policy, disclaimer, licence and        COMMENT
+contact information can be found at www.geonet.org.nz       COMMENT

--- a/cmd/bnc-config/testdata/config.yaml
+++ b/cmd/bnc-config/testdata/config.yaml
@@ -6,10 +6,3 @@ gns_bnc::mounts:
   longitude: "174.93"
   country: NZL
   format: RTCM_3.2
-- mount: MOUNT
-  mark: AVLN
-  name: Avalon Sound Stage
-  latitude: "-41.20"
-  longitude: "174.93"
-  country: NZL
-  format: RTCM_3.2

--- a/cmd/bnc-config/testdata/install/antennas.csv
+++ b/cmd/bnc-config/testdata/install/antennas.csv
@@ -1,0 +1,2 @@
+Make,Model,Serial,Mark,Height,North,East,Azimuth,Start Date,End Date
+Trimble Navigation Ltd.,TRM57971.00,1441047151,AVLN,0.055,0,0,0,2016-09-19T02:31:29Z,9999-01-01T00:00:00Z

--- a/cmd/bnc-config/testdata/install/firmware.csv
+++ b/cmd/bnc-config/testdata/install/firmware.csv
@@ -1,0 +1,2 @@
+Make,Model,Serial,Version,Start Date,End Date,Notes
+Trimble Navigation Ltd.,TRIMBLE ALLOY,5921R40175,5.45,2022-11-01T06:00:25Z,9999-01-01T00:00:00Z,

--- a/cmd/bnc-config/testdata/install/radomes.csv
+++ b/cmd/bnc-config/testdata/install/radomes.csv
@@ -1,0 +1,1 @@
+Make,Model,Serial,Mark,Start Date,End Date

--- a/cmd/bnc-config/testdata/install/receivers.csv
+++ b/cmd/bnc-config/testdata/install/receivers.csv
@@ -1,0 +1,2 @@
+Make,Model,Serial,Mark,Start Date,End Date
+Trimble Navigation Ltd.,TRIMBLE ALLOY,5921R40175,AVLN,2020-07-08T02:12:16Z,9999-01-01T00:00:00Z

--- a/cmd/bnc-config/testdata/network/monuments.csv
+++ b/cmd/bnc-config/testdata/network/monuments.csv
@@ -1,0 +1,2 @@
+Mark,Domes Number,Mark Type,Type,Ground Relationship,Foundation Type,Foundation Depth,Start Date,End Date,Bedrock,Geology
+AVLN,,Forced Centering,Steel Mast,-14.16,Stainless Steel Rod,0,2006-02-24T00:00:00Z,9999-01-01T00:00:00Z,,

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	aqwari.net/xml v0.0.0-20210331023308-d9421b293817
+	github.com/GeoNet/Golang-Ellipsoid v0.0.0-20150223084230-5a1ed895422f
 	github.com/GeoNet/kit v0.0.0-20230815043857-8f23eb4013a5
 	github.com/google/go-cmp v0.5.9
 	golang.org/x/text v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 aqwari.net/xml v0.0.0-20210331023308-d9421b293817 h1:+3Rh5EaTzNLnzWx3/uy/mAaH/dGI7svJ6e0oOIDcPuE=
 aqwari.net/xml v0.0.0-20210331023308-d9421b293817/go.mod h1:c7kkWzc7HS/t8Q2DcVY8P2d1dyWNEhEVT5pL0ZHO11c=
+github.com/GeoNet/Golang-Ellipsoid v0.0.0-20150223084230-5a1ed895422f h1:tRCEmA+r2wU2heEirDXfculZRSTyhTJXxaTEMrYtSJI=
+github.com/GeoNet/Golang-Ellipsoid v0.0.0-20150223084230-5a1ed895422f/go.mod h1:kjNbDcM40uUBNVelOQCqQ6BVaxKUTH2fLlHMVsU/N3k=
 github.com/GeoNet/kit v0.0.0-20230815043857-8f23eb4013a5 h1:00hCgOim7i7c5mtWbNiSQ86H37jerccy2P+oy5ozjto=
 github.com/GeoNet/kit v0.0.0-20230815043857-8f23eb4013a5/go.mod h1:yc5CLny5lcAiZeNmJvIKbTwQrLHriKvcMX1suqsilhc=
 github.com/aws/aws-sdk-go-v2 v1.16.2/go.mod h1:ytwTPBG6fXTZLxxeeCCWj2/EMYp/xDUgX+OET6TLNNU=

--- a/vendor/github.com/GeoNet/Golang-Ellipsoid/LICENSE
+++ b/vendor/github.com/GeoNet/Golang-Ellipsoid/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2011 Stefan Schroeder
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS ORIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS INTHE SOFTWARE. 

--- a/vendor/github.com/GeoNet/Golang-Ellipsoid/ellipsoid/ellipsoid.go
+++ b/vendor/github.com/GeoNet/Golang-Ellipsoid/ellipsoid/ellipsoid.go
@@ -1,0 +1,713 @@
+package ellipsoid
+
+// Written in Go by Stefan Schroeder, New York, 2013
+// Version 1.0 based on Geo::Ellipsoid Version 1.12.
+// Version 1.1 Added ECEF functions.
+// Version 1.2 Replaced Fabs with Abs.
+// Version 1.3 Added Displacement function
+
+/*
+
+SYNOPSIS
+
+See hello-wgs84.go example.
+
+DESCRIPTION
+
+ellipsoid performs geometrical calculations on the surface of
+an ellipsoid. An ellipsoid is a three-dimension object formed from
+the rotation of an ellipse about one of its axes. The approximate
+shape of the earth is an ellipsoid, so ellipsoid can accurately
+calculate distance and bearing between two widely-separated locations
+on the earth's surface.
+
+The shape of an ellipsoid is defined by the lengths of its
+semi-major and semi-minor axes. The shape may also be specifed by
+the flattening ratio f as:
+
+    f = ( semi-major - semi-minor ) / semi-major
+
+which, since f is a small number, is normally given as the reciprocal
+of the flattening 1/f.
+
+The shape of the earth has been surveyed and estimated differently
+at different times over the years. The two most common sets of values
+used to describe the size and shape of the earth in the United States
+are 'NAD27', dating from 1927, and 'WGS84', from 1984. United States
+Geological Survey topographical maps, for example, use one or the
+other of these values, and commonly-available Global Positioning
+System (GPS) units can be set to use one or the other.
+See "DEFINED ELLIPSOIDS" below for the ellipsoid survey values
+that may be selected for use by ellipsoid.
+
+*/
+
+import "math"
+import "fmt"
+
+const (
+	pi           = math.Pi
+	twopi        = math.Pi * 2.0
+	maxLoopCount = 20
+	eps          = 1.0e-23
+	debug        = false
+	// Meter is one of the output/input units.
+	Meter = 0 //    1.0    meter
+	// Foot is one of the output/input units.
+	Foot = 1 //    0.3048 meter are a foot
+	// Kilometer is one of the output/input units.
+	Kilometer = 2 // 1000.0    meter are a kilometer
+	// Mile is one of the output/input units.
+	Mile = 3 // 1609.344  meter are a mile
+	// Nm (nautical mile) is one of the output/input units.
+	Nm = 4 // 1852.0    meter are a nautical mile,
+	// Degrees is one of the possible angle units for input/output.
+	Degrees = iota
+	// Radians is one of the possible angle units for input/output.
+	Radians = iota
+	// LongitudeIsSymmetric determines that the output longitude shall be symmetric.
+	LongitudeIsSymmetric = true
+	// LongitudeIsSymmetric determines that the output longitude shall not be symmetric.
+	LongitudeNotSymmetric = false
+	// BearingIsSymmetric determines that the output bearing shall be symmetric.
+	BearingIsSymmetric = true
+	// BearingIsSymmetric determines that the output bearing shall not be symmetric.
+	BearingNotSymmetric = false
+)
+
+// Ellipsoid is the main object to store information about one ellispoid.
+type Ellipsoid struct {
+	Ellipse            ellipse
+	Units              int
+	Distance_units     int
+	LongitudeSymmetric bool
+	Bearing_symmetry   bool
+	Distance_factor    float64
+	// Having the Distance_factor AND the Distance_units in this struct is redundant
+	// but it looks nicer in the code.
+}
+
+type ellipse struct {
+	Equatorial     float64
+	Inv_flattening float64
+}
+
+// Shortcut for a location
+type Location struct {
+	Lat float64
+	Lon float64
+	Ele float64
+}
+
+func deg2rad(d float64) (r float64) {
+	return d * pi / 180.0
+}
+func rad2deg(d float64) (r float64) {
+	return d * 180.0 / pi
+}
+
+/* Init
+
+The Init constructor must be called with a list of parameters to set
+the value of the ellipsoid to be used, the value of the units to be
+used for angles and distances, and whether or not the output range
+of longitudes and bearing angles should be symmetric around zero
+or always greater than zero. There is no default constructor, all
+arguments are required; they may not be abbreviated.
+
+Example:
+
+	geo := ellipsoid.Init(
+		"WGS84",  // for possible values see below.
+		ellipsoid.Degrees, // possible values: Degrees or Radians
+		ellipsoid.Meter,   // possible values: Meter, Kilometer,
+				   // Foot, Nm, Mile
+		ellipsoid.LongitudeIsSymmetric, // possible values
+						  // LongitudeIsSymmetric or
+						  // LongitudeNotSymmetric
+		ellipsoid.BearingIsSymmetric    // possible
+						  // values BearingIsSymmetric or
+						  // BearingNotSymmetric
+	)
+
+*/
+func Init(name string, units int, dist_units int, long_sym bool, bear_sym bool) (e Ellipsoid) {
+	m := map[string]ellipse{
+		"AIRY":                  {6377563.396, 299.3249646},
+		"AIRY-MODIFIED":         {6377340.189, 299.3249646},
+		"AUSTRALIAN":            {6378160.0, 298.25},
+		"BESSEL-1841":           {6377397.155, 299.1528128},
+		"BESSEL-1841-NAMIBIA":   {6377483.865, 299.152813},
+		"CLARKE-1866":           {6378206.400, 294.978698},
+		"CLARKE-1880":           {6378249.145, 293.465},
+		"EVEREST-1830":          {6377276.345, 300.8017},
+		"EVEREST-1948":          {6377304.063, 300.8017},
+		"EVEREST-SABAH-SARAWAK": {6377298.556, 300.801700},
+		"EVEREST-1956":          {6377301.243, 300.801700},
+		"EVEREST-1969":          {6377295.664, 300.801700},
+		"FISHER-1960":           {6378166.0, 298.3},
+		"FISCHER-1960-MODIFIED": {6378155.000, 298.300000},
+		"FISHER-1968":           {6378150.0, 298.3},
+		"GRS80":                 {6378137.0, 298.25722210088},
+		"HELMERT-1906":          {6378200.000, 298.300000},
+		"HOUGH-1956":            {6378270.0, 297.0},
+		"HAYFORD":               {6378388.0, 297.0},
+		"IAU76":                 {6378140.0, 298.257},
+		"INTERNATIONAL":         {6378388.000, 297.000000},
+		"KRASSOVSKY-1938":       {6378245.0, 298.3},
+		"NAD27":                 {6378206.4, 294.9786982138},
+		"NWL-9D":                {6378145.0, 298.25},
+		"SGS85":                 {6378136.000, 298.257000},
+		"SOUTHAMERICAN-1969":    {6378160.0, 298.25},
+		"SOVIET-1985":           {6378136.0, 298.257},
+		"WGS60":                 {6378165.000, 298.300000},
+		"WGS66":                 {6378145.000, 298.250000},
+		"WGS72":                 {6378135.0, 298.26},
+		"WGS84":                 {6378137.0, 298.257223563},
+	}
+
+	e2, ok := m[name]
+	if !ok {
+		fmt.Printf("ellipsoid.go: Warning: Invalid ellipse type '%v'\n", name)
+	}
+
+	//                      m    ft      km      mi        nm
+	conversion := []float64{1.0, 0.3048, 1000.0, 1609.344, 1852.0}
+	ellipsoid := Ellipsoid{e2, units, dist_units, long_sym, bear_sym, conversion[dist_units]}
+	return ellipsoid
+}
+
+/* Intermediate
+
+Takes two coordinates with longitude and latitude; and a step count and
+returns range and bearing and an array with the lons and lats of intermediate
+points on a straight line (whatever that is on an ellipsoid), INCLUDING the
+start and the endpoint.
+
+So if you put in point1 and point2 with step count 4, the output will be
+(you make 4 hops, right?)
+
+	point1
+	i1
+	i2
+	i3
+	point2
+
+Each point is two float64 values, lat and lon, thus you have an array
+with 4*2 + 2 = 5*2 cells.
+
+steps shall not be 0.
+
+I havent tested the upper limit for steps.
+
+*/
+func (ellipsoid Ellipsoid) Intermediate(lat1, lon1, lat2, lon2 float64, steps int) (distance, bearing float64, arr []float64) {
+	if steps == 0 {
+		return
+	}
+	r, phi := ellipsoid.To(lat1, lon1, lat2, lon2)
+	var v []float64 = make([]float64, steps*2+2)
+	for i := 0; i <= steps; i++ {
+		a, b := ellipsoid.At(lat1, lon1, r*float64(i)/float64(steps), phi)
+		v[i*2], v[i*2+1] = a, b
+	}
+	arr = v
+	return r, phi, arr
+
+}
+
+/* To returns range, bearing between two specified locations.
+
+   dist, theta  = geo.To( lat1, lon1, lat2, lon2 )
+
+*/
+func (ellipsoid Ellipsoid) To(lat1, lon1, lat2, lon2 float64) (distance, bearing float64) {
+
+	if ellipsoid.Units == Degrees {
+		lat1 = deg2rad(lat1)
+		lon1 = deg2rad(lon1)
+		lat2 = deg2rad(lat2)
+		lon2 = deg2rad(lon2)
+	}
+
+	distance, bearing = ellipsoid.calculateBearing(lat1, lon1, lat2, lon2)
+	if ellipsoid.Units == Degrees {
+		bearing = rad2deg(bearing)
+	}
+
+	distance /= ellipsoid.Distance_factor
+
+	return
+}
+
+/* At returns the list latitude,longitude in degrees or radians that is a
+specified range and bearing from a given location.
+
+    lat2, lon2  = geo.At( lat1, lon1, range, bearing )
+
+*/
+func (ellipsoid Ellipsoid) At(lat1, lon1, distance, bearing float64) (lat2, lon2 float64) {
+
+	if ellipsoid.Units == Degrees {
+		lat1 = deg2rad(lat1)
+		lon1 = deg2rad(lon1)
+		bearing = deg2rad(bearing)
+	}
+
+	lat2, lon2 = ellipsoid.calculateTargetlocation(lat1, lon1, distance, bearing)
+
+	if ellipsoid.LongitudeSymmetric == LongitudeIsSymmetric {
+		if lon2 > pi {
+			lon2 -= twopi
+		}
+	}
+	if ellipsoid.LongitudeSymmetric == LongitudeNotSymmetric {
+		if lon2 < 0.0 {
+			lon2 += twopi
+		}
+	}
+
+	if ellipsoid.Units == Degrees {
+		lat2 = rad2deg(lat2)
+		lon2 = rad2deg(lon2)
+	}
+
+	return
+}
+
+/* Displacement returns the (x,y) displacement in distance units between the two specified
+locations.
+
+    x, y  = geo.Displacement( lat1, lon1, lat2, lon2 )
+
+NOTE: The x and y displacements are only approximations and only valid
+between two locations that are fairly near to each other. Beyond 10 kilometers
+or more, the concept of X and Y on a curved surface loses its meaning.
+
+*/
+func (ellipsoid Ellipsoid) Displacement(lat1, lon1, lat2, lon2 float64) (x, y float64) {
+	// FIXME: Normalize!!! before use.
+	r, bearing := ellipsoid.To(lat1, lon1, lat2, lon2)
+
+	if ellipsoid.Units == Degrees {
+		bearing = deg2rad(bearing)
+	}
+
+	x = r * math.Sin(bearing)
+	y = r * math.Cos(bearing)
+	return x, y
+}
+
+/* Location returns the list (latitude,longitude) of a location at a given (x,y)
+displacement from a given location.
+
+	lat2, lon2 = geo.Location( lat1, lon1, x, y )
+
+The note from Displacement applies.
+
+*/
+func (ellipsoid Ellipsoid) Location(lat1, lon1, x, y float64) (lat, lon float64) {
+	degrees_per_radian := 180.0 / math.Pi
+
+	range1 := math.Sqrt(x*x + y*y)
+	bearing1 := math.Atan2(x, y)
+
+	if ellipsoid.Units == Degrees {
+		bearing1 *= degrees_per_radian
+	}
+
+	return ellipsoid.At(lat1, lon1, range1, bearing1)
+}
+
+func (ellipsoid Ellipsoid) calculateTargetlocation(lat1, lon1, distance, bearing float64) (lat2, lon2 float64) {
+
+	if debug == true {
+		fmt.Printf("_forward(lat1=%v,lon1=%v,range=%v,bearing=%v)\n", lat1, lon1, distance, bearing)
+	}
+
+	eps := 0.5e-13
+
+	a := ellipsoid.Ellipse.Equatorial
+	f := 1.0 / ellipsoid.Ellipse.Inv_flattening
+	r := 1.0 - f
+
+	clat1 := math.Cos(lat1)
+	if clat1 == 0 {
+		fmt.Printf("WARNING: Division by Zero in ellipsoid.go.\n")
+		return 0.0, 0.0
+	}
+	tu := r * math.Sin(lat1) / clat1
+	faz := bearing
+
+	s := ellipsoid.Distance_factor * distance
+
+	sf := math.Sin(faz)
+	cf := math.Cos(faz)
+
+	baz := 0.0
+	if cf != 0.0 {
+		baz = 2.0 * math.Atan2(tu, cf)
+	}
+
+	cu := 1.0 / math.Sqrt(1.0+tu*tu)
+	su := tu * cu
+	sa := cu * sf
+	c2a := 1.0 - (sa * sa)
+	x := 1.0 + math.Sqrt((((1.0/(r*r))-1.0)*c2a)+1.0)
+	x = (x - 2.0) / x
+	c := 1.0 - x
+	c = (((x * x) / 4.0) + 1.0) / c
+	d := x * ((0.375 * x * x) - 1.0)
+	tu = ((s / r) / a) / c
+	y := tu
+
+	if debug == true {
+		fmt.Printf("r=%.8f, tu=%.8f, faz=%.8f\n", r, tu, faz)
+		fmt.Printf("baz=%.8f, sf=%.8f, cf=%.8f\n", baz, sf, cf)
+		fmt.Printf("cu=%.8f, su=%.8f, sa=%.8f\n", cu, su, sa)
+		fmt.Printf("x=%.8f, c=%.8f, y=%.8f\n", x, c, y)
+	}
+
+	var cy, cz, e, sy float64
+	for true {
+		sy = math.Sin(y)
+		cy = math.Cos(y)
+		cz = math.Cos(baz + y)
+		e = (2.0 * cz * cz) - 1.0
+		c = y
+		x = e * cy
+		y = (2.0 * e) - 1.0
+		y = (((((((((sy * sy * 4.0) - 3.0) * y * cz * d) / 6.0) + x) * d) / 4.0) - cz) * sy * d) + tu
+
+		if math.Abs(y-c) <= eps {
+			break
+		}
+	}
+	baz = (cu * cy * cf) - (su * sy)
+	c = r * math.Sqrt((sa*sa)+(baz*baz))
+	d = su*cy + cu*sy*cf
+	lat2 = math.Atan2(d, c)
+	c = cu*cy - su*sy*cf
+	x = math.Atan2(sy*sf, c)
+	c = (((((-3.0 * c2a) + 4.0) * f) + 4.0) * c2a * f) / 16.0
+	d = ((((e * cy * c) + cz) * sy * c) + y) * sa
+	lon2 = lon1 + x - (1.0-c)*d*f
+
+	if debug == true {
+		fmt.Printf("returns(lat2=%v,lon2=%v)\n", lat2, lon2)
+	}
+	return lat2, lon2
+}
+
+func (ellipsoid Ellipsoid) calculateBearing(lat1, lon1, lat2, lon2 float64) (distance, bearing float64) {
+	a := ellipsoid.Ellipse.Equatorial
+	f := 1 / ellipsoid.Ellipse.Inv_flattening
+
+	if lon1 < 0 {
+		lon1 += twopi
+	}
+	if lon2 < 0 {
+		lon2 += twopi
+	}
+
+	r := 1.0 - f
+	clat1 := math.Cos(lat1)
+	if clat1 == 0 {
+		fmt.Printf("WARNING: Division by Zero in ellipsoid.go.\n")
+		return 0.0, 0.0
+	}
+	clat2 := math.Cos(lat2)
+	if clat2 == 0 {
+		fmt.Printf("WARNING: Division by Zero in ellipsoid.go.\n")
+		return 0.0, 0.0
+	}
+	tu1 := r * math.Sin(lat1) / clat1
+	tu2 := r * math.Sin(lat2) / clat2
+	cu1 := 1.0 / (math.Sqrt((tu1 * tu1) + 1.0))
+	su1 := cu1 * tu1
+	cu2 := 1.0 / (math.Sqrt((tu2 * tu2) + 1.0))
+	s := cu1 * cu2
+	baz := s * tu2
+	faz := baz * tu1
+	dlon := lon2 - lon1
+
+	if debug == true {
+		fmt.Printf("a=%v, f=%v\n", a, f)
+		fmt.Printf("lat1=%v, lon1=%v\n", lat1, lon1)
+		fmt.Printf("lat2=%v, lon2=%v\n", lat2, lon2)
+
+		fmt.Printf("r=%v, tu1=%v, tu2=%v\n", r, tu1, tu2)
+		fmt.Printf("faz=%.8f, dlon=%.8f, su1=%v\n", faz, dlon, su1)
+	}
+
+	x := dlon
+	cnt := 0
+
+	var c2a, c, cx, cy, cz, d, del, e, sx, sy, y float64
+	// This originally was a do-while loop. Exit condition is at end of loop.
+	for true {
+		if debug == true {
+			fmt.Printf("  x=%.8f\n", x)
+		}
+		sx = math.Sin(x)
+		cx = math.Cos(x)
+		tu1 = cu2 * sx
+		tu2 = baz - (su1 * cu2 * cx)
+
+		if debug == true {
+			fmt.Printf("    sx=%.8f, cx=%.8f, tu1=%.8f, tu2=%.8f\n", sx, cx, tu1, tu2)
+		}
+
+		sy = math.Sqrt(tu1*tu1 + tu2*tu2)
+		cy = s*cx + faz
+		y = math.Atan2(sy, cy)
+		var sa float64
+		if sy == 0.0 {
+			sa = 1.0
+		} else {
+			sa = (s * sx) / sy
+		}
+
+		if debug == true {
+			fmt.Printf("    sy=%.8f, cy=%.8f, y=%.8f, sa=%.8f\n", sy, cy, y, sa)
+		}
+
+		c2a = 1.0 - (sa * sa)
+		cz = faz + faz
+		if c2a > 0.0 {
+			cz = ((-cz) / c2a) + cy
+		}
+		e = (2.0 * cz * cz) - 1.0
+		c = (((((-3.0 * c2a) + 4.0) * f) + 4.0) * c2a * f) / 16.0
+		d = x
+		x = ((e*cy*c+cz)*sy*c + y) * sa
+		x = (1.0-c)*x*f + dlon
+		del = d - x
+
+		if debug == true {
+			fmt.Printf("    c2a=%.8f, cz=%.8f\n", c2a, cz)
+			fmt.Printf("    e=%.8f, d=%.8f\n", e, d)
+			fmt.Printf("    (d-x)=%.8g\n", del)
+		}
+		if math.Abs(del) <= eps {
+			break
+		}
+		cnt++
+		if cnt > maxLoopCount {
+			break
+		}
+
+	}
+
+	faz = math.Atan2(tu1, tu2)
+	baz = math.Atan2(cu1*sx, (baz*cx-su1*cu2)) + pi
+	x = math.Sqrt(((1.0/(r*r))-1.0)*c2a+1.0) + 1.0
+	x = (x - 2.0) / x
+	c = 1.0 - x
+	c = ((x*x)/4.0 + 1.0) / c
+	d = ((0.375 * x * x) - 1.0) * x
+	x = e * cy
+
+	if debug == true {
+		fmt.Printf("e=%.8f, cy=%.8f, x=%.8f\n", e, cy, x)
+		fmt.Printf("sy=%.8f, c=%.8f, d=%.8f\n", sy, c, d)
+		fmt.Printf("cz=%.8f, a=%.8f, r=%.8f\n", cz, a, r)
+	}
+
+	s = 1.0 - e - e
+	s = ((((((((sy * sy * 4.0) - 3.0) * s * cz * d / 6.0) - x) * d / 4.0) + cz) * sy * d) + y) * c * a * r
+
+	if debug == true {
+		fmt.Printf("s=%.8f\n", s)
+	}
+
+	// adjust azimuth to (0,360) or (-180,180) as specified
+	if ellipsoid.Bearing_symmetry == BearingIsSymmetric {
+		if faz < -(pi) {
+			faz += twopi
+		}
+		if faz >= pi {
+			faz -= twopi
+		}
+	} else {
+		if faz < 0 {
+			faz += twopi
+		}
+		if faz >= twopi {
+			faz -= twopi
+		}
+	}
+
+	distance, bearing = s, faz
+	return
+}
+
+/* ToLLA takes three cartesian coordinates x, y, z and returns
+the latitude, longitude, elevation list.
+
+FIXME: This algorithm cannot handle x==0, although this is a valid value.
+WARNING: I put in an if condition to catch this. Is it still necessary?
+
+*/
+func (ellipsoid Ellipsoid) ToLLA(x, y, z float64) (lat1, lon1, alt1 float64) {
+
+	if x == 0 {
+		fmt.Printf("FATAL: Caught x==0 (div by zero).\n")
+		return
+	}
+
+	a := ellipsoid.Ellipse.Equatorial
+	f := 1 / ellipsoid.Ellipse.Inv_flattening
+
+	b := a * (1.0 - f)
+	e := math.Sqrt((a*a - b*b) / (a * a))
+	e2 := math.Sqrt((a*a - b*b) / (b * b)) // e'
+	esq := e * e                           // e squared
+	e2sq := e2 * e2                        // e' squared
+	p := math.Sqrt(x*x + y*y)
+
+	theta := math.Atan2(z*a, p*b)
+	stheta3 := math.Sin(theta) * math.Sin(theta) * math.Sin(theta)
+	ctheta3 := math.Cos(theta) * math.Cos(theta) * math.Cos(theta)
+
+	lon1 = math.Atan2(y, x)
+	phi := math.Atan2(z+e2sq*b*stheta3, p-esq*a*ctheta3)
+	lat1 = phi
+
+	sphisq := math.Sin(phi) * math.Sin(phi)
+	N := a / (math.Sqrt(1 - esq*sphisq))
+	alt1 = p/math.Cos(phi) - N
+
+	if ellipsoid.LongitudeSymmetric == LongitudeIsSymmetric {
+		if lon1 > pi {
+			lon1 -= twopi
+		}
+	}
+	if ellipsoid.LongitudeSymmetric == LongitudeNotSymmetric {
+		if lon1 < 0.0 {
+			lon1 += twopi
+		}
+	}
+
+	if ellipsoid.Units == Degrees {
+		lat1 = rad2deg(lat1)
+		lon1 = rad2deg(lon1)
+	}
+	return lat1, lon1, alt1
+}
+
+/* ToECEF takes the latitude, longitude, elevation list and
+   returns three cartesian coordinates x, y, z */
+func (ellipsoid Ellipsoid) ToECEF(lat1, lon1, alt1 float64) (x, y, z float64) {
+	a := ellipsoid.Ellipse.Equatorial
+	f := 1 / ellipsoid.Ellipse.Inv_flattening
+
+	b := a * (1.0 - f)
+	e := math.Sqrt((a*a - b*b) / (a * a))
+	esq := e * e // e squared
+
+	if ellipsoid.Units == Degrees {
+		lat1 = deg2rad(lat1)
+		lon1 = deg2rad(lon1)
+	}
+
+	h := alt1 // renamed for convenience
+	phi := lat1
+	lambda := lon1
+
+	cphi := math.Cos(phi)
+	sphi := math.Sin(phi)
+	sphisq := sphi * sphi
+	clam := math.Cos(lambda)
+	slam := math.Sin(lambda)
+	N := a / (math.Sqrt(1 - esq*sphisq))
+	x = (N + h) * cphi * clam
+	y = (N + h) * cphi * slam
+	z = ((b*b*N)/(a*a) + h) * sphi
+
+	return x, y, z
+}
+
+/*
+ DEFINED ELLIPSOIDS
+
+The following ellipsoids are defined in Geo::Ellipsoid, with the
+semi-major axis in meters and the reciprocal flattening as shown.
+
+
+    Ellipsoid        Semi-Major Axis (m.)     1/Flattening
+    ---------        -------------------     ---------------
+    AIRY                 6377563.396         299.3249646
+    AIRY-MODIFIED        6377340.189         299.3249646
+    AUSTRALIAN           6378160.0           298.25
+    BESSEL-1841          6377397.155         299.1528128
+    CLARKE-1880          6378249.145         293.465
+    EVEREST-1830         6377276.345         290.8017
+    EVEREST-MODIFIED     6377304.063         290.8017
+    FISHER-1960          6378166.0           298.3
+    FISHER-1968          6378150.0           298.3
+    GRS80                6378137.0           298.25722210088
+    HOUGH-1956           6378270.0           297.0
+    HAYFORD              6378388.0           297.0
+    IAU76                6378140.0           298.257
+    KRASSOVSKY-1938      6378245.0           298.3
+    NAD27                6378206.4           294.9786982138
+    NWL-9D               6378145.0           298.25
+    SOUTHAMERICAN-1969   6378160.0           298.25
+    SOVIET-1985          6378136.0           298.257
+    WGS72                6378135.0           298.26
+    WGS84                6378137.0           298.257223563
+
+plus a few more ...
+
+ LIMITATIONS
+
+The methods should not be used on points which are too near the poles
+(above or below 89 degrees), and should not be used on points which
+are antipodal, i.e., exactly on opposite sides of the ellipsoid. The
+methods will not return valid results in these cases.
+
+The Go-version does not support all features of the Perl module. If you
+need advanced features, like defining your own ellipses at runtime,
+calculating x,y dislocations, etc, please refer to the package on CPAN
+
+Geo::Ellipsoid
+
+http://search.cpan.org/~jgibson/Geo-Ellipsoid-1.12/lib/Geo/Ellipsoid.pm
+
+FIXME: Add more checks for div by 0.
+
+ ACKNOWLEDGEMENTS
+
+The conversion algorithms used here are Perl translations of Fortran
+routines written by LCDR L. Pfeifer NGS Rockville MD that implement
+T. Vincenty's Modified Rainsford's method with Helmert's elliptical
+terms as published in "Direct and Inverse Solutions of Ellipsoid on
+the Ellipsoid with Application of Nested Equations", T. Vincenty,
+Survey Review, April 1975.
+
+The Fortran source code files inverse.for and forward.for
+may be obtained from
+
+    ftp://ftp.ngs.noaa.gov/pub/pcsoft/for_inv.3d/source/
+
+ AUTHOR
+
+Jim Gibson, <Jim@Gibson.org> (Perl version)
+Stefan Schroeder <ondekoza@gmail.com> (Port from Perl to Golang)
+
+ BUGS
+
+See LIMITATIONS, above.
+
+Please report any bugs or feature requests to
+the author.
+
+COPYRIGHT & LICENSE
+
+Copyright 2005-2008 Jim Gibson, all rights reserved.
+
+This program is free software; you can redistribute it and/or modify it
+under the same terms as Perl.
+
+*/

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -3,6 +3,9 @@
 aqwari.net/xml/internal/dependency
 aqwari.net/xml/xmltree
 aqwari.net/xml/xsd
+# github.com/GeoNet/Golang-Ellipsoid v0.0.0-20150223084230-5a1ed895422f
+## explicit
+github.com/GeoNet/Golang-Ellipsoid/ellipsoid
 # github.com/GeoNet/kit v0.0.0-20230815043857-8f23eb4013a5
 ## explicit; go 1.16
 github.com/GeoNet/kit/gloria_pb


### PR DESCRIPTION
- Added an optional switches for `bnc-config`
  -  `-skl {path}` to generate Skeleton files, based on the configured sites. 
  - `-summary {path-name}` to generate skeleton files summary so operators know how many files success/failed

- Also remove functionality to import aliases for bnc-config. ref https://github.com/GeoNet/tickets/issues/6495

Plan to run this from ac-tool, and generate SKL files into `puppet_gps_files/files/data/skl-{environment}` (or somewhere else, will decide in ac-tool). PR for ac-tool : https://github.com/GeoNet/ac-tools/pull/408

This is part of the steps towards https://github.com/GeoNet/tickets/issues/15788.
