### PR TITLE
poc: add GeoNet datasets DOI to delta

### DIFF
--- a/network/networks.csv
+++ b/network/networks.csv
@@ -13,6 +13,7 @@ GN,GN,The GNS CGPS network,false
 HA,NZ,Hydrophone Array,false
 HB,NZ,Hawke's Bay regional seismic network,false
 IG,LI,LINZ IGS CGPS Network,false
+IU,NZ,Global Seismograph Network,false
 KI,NZ,Kermadec Islands volcano seismic network,false
 LG,NZ,Lake tsunami gauge network,false
 LI,LI,The LINZ national CGPS network,false

--- a/references/README.md
+++ b/references/README.md
@@ -7,6 +7,7 @@ _Reference citations and external source information._
 Reference information for the GeoNet sensor networks and manual data collection systems.
  
 * `citations.csv` - Reference citations
+* `datasets.csv` - Datasets Digital Object Identifiers
 * `tilde_methods.csv` - Tilde  method descriptions
 
 #### _CITATIONS_ ####
@@ -32,6 +33,16 @@ All fields, other than Key, are optional and can be left blank.
     Key,Author,Year,Title,Published,Volume,Pages,DOI,Link,Retrieved
     Fry2020,"Fry, B., S.-J. McCurrach, K. Gledhill, W. Power, M. Williams, M. Angove, D. Arcas, and C. Moore",2020,Sensor network warns of stealth tsunamis,Eos,101,,https://doi.org/10.1029/2020EO144274,,
 
+#### _DATASETS_ ####
+List of GeoNet datasets DOIs (Digital Object Identifier).
+GeoNet hosts a number of datasets that have a DOI assigned. Datasets DOIs are assigned based on data domain and data processing level (i.e. raw , derived, etc).
+
+| _Network_ | Code used to group stations together by project or operator
+| _External_ | Alternative code used to externally represent this _Network_
+| _DOI_ | Digital Object Identifier
+| _Dataset_ | name of the dataset associated with the _DOI_
+
+
 #### _METHODS_ ####
 The range of methods used in the Tilde application is diverse. In some cases, the details of a method are well
 know only to those familiar with a data set or with a similar data set from another institution.
@@ -51,3 +62,4 @@ link to publicly available resources that provide additional information.
 
 - Dates should be given as in _ISO 8601_ (i.e. `2016-09-18T02:24:26Z`)
 - Any field entries with commas should be enclosed within double quotes. (e.g. "Last, F., Name ...")
+

--- a/references/datasets.csv
+++ b/references/datasets.csv
@@ -1,0 +1,8 @@
+Network,External,DOI,Dataset
+CG,CG,https://doi.org/10.21420/RXKE-AZ44,GeoNet Aotearoa New Zealand Continuous GNSS Network - RINEX Files
+IU,NZ,https://doi.org/10.7914/SN/IU,Global Seismograph Network (GSN - IRIS/USGS)
+LG,NZ,https://doi.org/10.21420/EJ6W-RC96,GeoNet Aotearoa New Zealand Coastal Tsunami Gauge Digital Waveform Dataset
+LI,LI,https://doi.org/10.21420/RXKE-AZ44,GeoNet Aotearoa New Zealand Continuous GNSS Network - RINEX Files
+NZ,NZ,https://doi.org/10.21420/G19Y-9D40,GeoNet Aotearoa New Zealand Seismic Digital Waveform Dataset
+TD,NZ,https://doi.org/10.21420/8TCZ-TV02,GeoNet Aotearoa New Zealand Deep-ocean Assessment and Reporting of Tsunami (DART) Dataset
+TG,NZ,https://doi.org/10.21420/EJ6W-RC96,GeoNet Aotearoa New Zealand Coastal Tsunami Gauge Digital Waveform Dataset


### PR DESCRIPTION
Hi @ozym (and @staylorofford )

this is a very drafted proof of concept to try to capture into delta those DOIs that are associated with GeoNet core or "adopted" data.

It is not comprehensive of all DOIs we have assigned, but is a very first step towards potentially providing the DOI information alongside our data (i.e. via StationXML, GeodesyML, potentially tilde??).

An up to date list of all GeoNet datasets DOIs minted so far is available here: https://www.geonet.org.nz/policy

there is more behind all that, this pr was is just a very first step, and prompted by the SZNO use case (and some others that we discussed in the past).

