### PR TITLE
feat: bump go version to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GeoNet/delta
 
-go 1.21
+go 1.22
 
 require (
 	aqwari.net/xml v0.0.0-20210331023308-d9421b293817


### PR DESCRIPTION
This is needed to pass the vulnerability checks