### PR TITLE
fix: BNC-Client: SCTB skeleton file has incorrect country code

### DIFF
--- a/cmd/bnc-config/main.go
+++ b/cmd/bnc-config/main.go
@@ -87,13 +87,13 @@ func main() {
 		t := time.Now().UTC().Unix() // skeleton needs a reference time for the installations
 		for _, m := range config.Mounts {
 			// note: skeleton() will return with generic header content when error occured
-			s, err := skeleton(m.Mark, set, t)
+			s, err := skeleton(m.Mark, m.Country, set, t)
 			if err != nil {
 				fallbacks = append(fallbacks, m.Mark)
 			} else {
 				successes = append(successes, m.Mark)
 			}
-			err = os.WriteFile(filepath.Join(settings.sklPath, fmt.Sprintf("%s00NZL.SKL", m.Mark)), []byte(s), 0600)
+			err = os.WriteFile(filepath.Join(settings.sklPath, fmt.Sprintf("%s00%s.SKL", m.Mark, m.Country)), []byte(s), 0600)
 			if err != nil {
 				log.Fatalf("couldn't write skeleton file: %s", err)
 			}

--- a/cmd/bnc-config/skl.go
+++ b/cmd/bnc-config/skl.go
@@ -11,7 +11,7 @@ var geo = ellipsoid.Init("WGS84", ellipsoid.Degrees, ellipsoid.Meter, ellipsoid.
 
 // genetrate skeleton file for a site,
 // based on the receiver, firmware, and antenna metadata at a given time (e.g. now)
-func skeleton(code string, set *meta.Set, ts int64) (content string, err error) {
+func skeleton(code string, country string, set *meta.Set, ts int64) (content string, err error) {
 	var mark meta.Mark
 
 	defer func() {
@@ -112,9 +112,9 @@ func skeleton(code string, set *meta.Set, ts int64) (content string, err error) 
 	}
 
 	content = fmt.Sprintf(skeletonFormat,
-		fmt.Sprintf("%s00NZL", code),       // MARKER NAME
-		domesNumber,                        // MARKER NUMBER
-		dr.Serial, dr.Model, ifirm.Version, // REC # / TYPE / VERS
+		fmt.Sprintf("%s00%s", code, country), // MARKER NAME
+		domesNumber,                          // MARKER NUMBER
+		dr.Serial, dr.Model, ifirm.Version,   // REC # / TYPE / VERS
 		ia.Serial, ia.Model, radome, //ANT # / TYPE
 		x, y, z, //APPROX POSITION XYZ
 		ia.Offset.Vertical, ia.Offset.East, ia.Offset.North) // ANTENNA: DELTA H/E/N

--- a/cmd/bnc-config/skl_test.go
+++ b/cmd/bnc-config/skl_test.go
@@ -17,7 +17,7 @@ func TestSkeleton(t *testing.T) {
 	}
 
 	tm := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	b, err := skeleton("AVLN", set, tm.UTC().Unix())
+	b, err := skeleton("AVLN", "NZL", set, tm.UTC().Unix())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func TestGenericSkeleton(t *testing.T) {
 
 	// set the reference time to before the mark's install time
 	tm := time.Date(2005, 1, 1, 0, 0, 0, 0, time.UTC)
-	b, err := skeleton("AVLN", set, tm.UTC().Unix())
+	b, err := skeleton("AVLN", "NZL", set, tm.UTC().Unix())
 	if err == nil {
 		t.Fatalf("expected to get error but got nil")
 	}


### PR DESCRIPTION
As title. Existing process is using NZL as SCTB's country code. Should be ATA instead, and the country code information is already in metadata (https://github.com/GeoNet/dmc-config/blob/main/config/gps-files/staging/mounts.csv).

This PR uses the country field in the metadata, instead of hard-coding NZL.