### PR TITLE
fix: switch "Short Period Borehole Seismometer" to "Short Period Seismometer"

### DIFF
--- a/install/components.csv
+++ b/install/components.csv
@@ -34,9 +34,9 @@ Chaparral Physics,M64Vx2,Infrasound Sensor,0,,F,0,0,W,,sensor_Chaparral_60Vx2_LP
 Danish Meteorological Institute,FGE,Fluxgate Magnetometer,0,,X,0,90,G,,sensor_Danish_Meteorological_Institute_FGE
 Danish Meteorological Institute,FGE,Fluxgate Magnetometer,1,,Y,0,0,G,,sensor_Danish_Meteorological_Institute_FGE
 Danish Meteorological Institute,FGE,Fluxgate Magnetometer,2,,Z,-90,0,G,,sensor_Danish_Meteorological_Institute_FGE
-Duke University,2 Hz Duke Malin Seismometer,Short Period Borehole Seismometer,0,,Z,-90,0,G,,sensor_Duke-University_2-Hz-Duke-Malin-Seismometer
-Duke University,2 Hz Duke Malin Seismometer,Short Period Borehole Seismometer,1,,N,0,0,G,,sensor_Duke-University_2-Hz-Duke-Malin-Seismometer
-Duke University,2 Hz Duke Malin Seismometer,Short Period Borehole Seismometer,2,,E,0,90,G,,sensor_Duke-University_2-Hz-Duke-Malin-Seismometer
+Duke University,2 Hz Duke Malin Seismometer,Short Period Seismometer,0,,Z,-90,0,G,,sensor_Duke-University_2-Hz-Duke-Malin-Seismometer
+Duke University,2 Hz Duke Malin Seismometer,Short Period Seismometer,1,,N,0,0,G,,sensor_Duke-University_2-Hz-Duke-Malin-Seismometer
+Duke University,2 Hz Duke Malin Seismometer,Short Period Seismometer,2,,E,0,90,G,,sensor_Duke-University_2-Hz-Duke-Malin-Seismometer
 Streckeisen,STS-2,Broadband Seismometer,0,,Z,-90,0,G,,sensor_Streckeisen_STS-2
 Streckeisen,STS-2,Broadband Seismometer,1,,N,0,0,G,,sensor_Streckeisen_STS-2
 Streckeisen,STS-2,Broadband Seismometer,2,,E,0,90,G,,sensor_Streckeisen_STS-2


### PR DESCRIPTION
This should allow Duke sensors on the web site