### PR TITLE
add transactions and a key value table for deltadb

### DIFF
--- a/cmd/deltadb/README.md
+++ b/cmd/deltadb/README.md
@@ -29,8 +29,6 @@ Options:
         initialise the database if a file on disk
   -listen
         should a web service be enabled
-  -schema string
-        optional database schema to use
 
 ```
 

--- a/cmd/deltadb/main.go
+++ b/cmd/deltadb/main.go
@@ -22,8 +22,7 @@ type Settings struct {
 
 	base string // base directory of delta files on disk
 
-	db     string // name of the database file
-	schema string // name of the database schema
+	db string // name of the database file
 
 	init     bool   // should the database be updated
 	listen   bool   // should a web service be enabled
@@ -54,7 +53,6 @@ func main() {
 
 	flag.StringVar(&settings.base, "base", "", "base directory of delta files on disk")
 	flag.StringVar(&settings.db, "db", "", "name of the database file on disk")
-	flag.StringVar(&settings.schema, "schema", "", "optional database schema to use")
 	flag.StringVar(&settings.hostport, "hostport", ":8080", "base directory of delta files on disk")
 
 	flag.Parse()
@@ -88,7 +86,7 @@ func main() {
 	if settings.db == "" || settings.init {
 		log.Println("initialise database")
 		start := time.Now()
-		if err := sqlite.New(db, settings.schema).Init(ctx, set.TableList()); err != nil {
+		if err := sqlite.New(db).Init(ctx, set.TableList()); err != nil {
 			log.Fatalf("unable to run database exec: %v", err)
 		}
 		log.Printf("database initialised in %s", time.Since(start).String())

--- a/meta/sqlite/database.go
+++ b/meta/sqlite/database.go
@@ -1,19 +1,22 @@
 package sqlite
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/GeoNet/delta/meta"
 )
 
 type Database struct {
+	db     *sql.DB
 	schema string
 }
 
-func New(schema string) Database {
+func New(db *sql.DB, schema string) Database {
 	return Database{
+		db:     db,
 		schema: schema,
 	}
 }
@@ -24,13 +27,70 @@ func (d Database) Schema() string {
 	return ""
 }
 
-func (d Database) Drop(table meta.Table) []string {
-	var drop strings.Builder
-	fmt.Fprintf(&drop, "DROP TABLE IF EXISTS %s%s;\n", d.Schema(), table.Name())
-	return []string{drop.String()}
+func (d Database) exec(ctx context.Context, tx *sql.Tx, cmds ...string) error {
+	for _, cmd := range cmds {
+		if _, err := tx.ExecContext(ctx, cmd); err != nil {
+			return fmt.Errorf("cmd %q: %w", cmd, err)
+		}
+	}
+	return nil
 }
 
-func (d Database) Create(table meta.Table) []string {
+func (d Database) prepare(ctx context.Context, tx *sql.Tx, cmd string, values ...[]any) error {
+
+	stmt, err := tx.PrepareContext(ctx, cmd)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for _, v := range values {
+		if _, err := stmt.ExecContext(ctx, v...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d Database) Init(ctx context.Context, tables []meta.TableList) error {
+
+	// Get a Tx for making transaction requests.
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	// Defer a rollback in case anything fails, not actually
+	// worried about any rollback error.
+	defer func() { _ = tx.Rollback() }()
+
+	for _, t := range tables {
+		if err := d.exec(ctx, tx, d.create(t.Table)...); err != nil {
+			return err
+		}
+
+		cmd, values, ok := d.insert(t.Table, t.List)
+		if !ok {
+			continue
+		}
+
+		if err := d.prepare(ctx, tx, cmd, values...); err != nil {
+			return err
+		}
+	}
+
+	// Commit the transaction.
+	if err = tx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d Database) create(table meta.Table) []string {
+	var drop strings.Builder
+	fmt.Fprintf(&drop, "DROP TABLE IF EXISTS %s%s;\n", d.Schema(), table.Name())
+
 	var create strings.Builder
 
 	var primary []string
@@ -111,36 +171,42 @@ func (d Database) Create(table meta.Table) []string {
 		fmt.Fprintf(&trigger, "END;\n")
 	}
 
-	return []string{create.String(), trigger.String()}
+	return []string{drop.String(), create.String(), trigger.String()}
 }
 
-func (d Database) Insert(table meta.Table, list meta.ListEncoder) []string {
-	var sb strings.Builder
+func (d Database) insert(table meta.Table, list meta.ListEncoder) (string, [][]any, bool) {
 
 	lines := table.Encode(list)
 	if !(len(lines) > 0) {
-		return nil
+		return "", nil, false
 	}
 
 	var header []string
 	for _, x := range lines[0] {
 		header = append(header, table.Remap(x))
 	}
+	var parts []string
+	for n := range header {
+		parts = append(parts, fmt.Sprintf("$%d", n+1))
+	}
 
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "INSERT INTO %s%s (%s) VALUES (%s);\n", d.Schema(), table.Name(), strings.Join(header, ","), strings.Join(parts, ","))
+
+	var values [][]any
 	for _, line := range lines[1:] {
-		var parts []string
+		var parts []any
 		for n, p := range line {
 			switch {
 			case table.IsNative(n) && p == "":
 				parts = append(parts, "0")
-			case table.IsNative(n):
-				parts = append(parts, p)
 			default:
-				parts = append(parts, strconv.Quote(p))
+				parts = append(parts, p)
 			}
 		}
-		fmt.Fprintf(&sb, "INSERT INTO %s%s (%s) VALUES (%s);\n", d.Schema(), table.Name(), strings.Join(header, ","), strings.Join(parts, ","))
+		values = append(values, parts)
 	}
 
-	return []string{sb.String()}
+	return sb.String(), values, true
 }


### PR DESCRIPTION
This is needed to extend initialisation of the deltadb to include other tables such as responses.

This rework shifts most of the database code away from the Table definitions, it now merely is a means of listing the various tables and their associated data.  This can then be used as needed by the actual database implementations.

This depends on #2275 
