### PR TITLE
feat: extend CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,9 +7,12 @@
 *    @ozym @GeoNet/dmc
 
 # Codes and tests for downstream applications
+go.mod    @GeoNet/platform-team @GeoNet/ssd-team-developer
+go.sum    @GeoNet/platform-team @GeoNet/ssd-team-developer
 /cmd/    @GeoNet/platform-team @GeoNet/ssd-team-developer
 /internal/    @GeoNet/platform-team @GeoNet/ssd-team-developer
 /meta/    @GeoNet/platform-team @GeoNet/ssd-team-developer
+/resp/    @GeoNet/platform-team @GeoNet/ssd-team-developer
 /tests/    @GeoNet/platform-team @GeoNet/ssd-team-developer
 /tools/    @GeoNet/platform-team @GeoNet/ssd-team-developer
 /vendor/    @GeoNet/platform-team @GeoNet/ssd-team-developer

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@ go.sum    @GeoNet/platform-team @GeoNet/ssd-team-developer
 /cmd/    @GeoNet/platform-team @GeoNet/ssd-team-developer
 /internal/    @GeoNet/platform-team @GeoNet/ssd-team-developer
 /meta/    @GeoNet/platform-team @GeoNet/ssd-team-developer
-/resp/    @GeoNet/platform-team @GeoNet/ssd-team-developer
+/resp/    @GeoNet/platform-team @GeoNet/ssd-team-developer @GeoNet/dmc
 /tests/    @GeoNet/platform-team @GeoNet/ssd-team-developer
 /tools/    @GeoNet/platform-team @GeoNet/ssd-team-developer
 /vendor/    @GeoNet/platform-team @GeoNet/ssd-team-developer


### PR DESCRIPTION
This extends the ownership of the golang parts to the platform/developer teams