### PR TITLE
nfc: extend table foreign keys to include column names

### DIFF
--- a/meta/antenna.go
+++ b/meta/antenna.go
@@ -39,9 +39,9 @@ var InstalledAntennaTable Table = Table{
 	headers: installedAntennaHeaders,
 	primary: []string{"Make", "Model", "Serial", "Mark", "Start Date"},
 	native:  []string{"Height", "North", "East", "Azimuth"},
-	foreign: map[string][]string{
-		"Asset": {"Make", "Model", "Serial"},
-		"Mark":  {"Mark"},
+	foreign: map[string]map[string]string{
+		"Asset": {"Make": "Make", "Model": "Model", "Serial": "Serial"},
+		"Mark":  {"Mark": "Mark"},
 	},
 	remap: map[string]string{
 		"Start Date": "Start",

--- a/meta/asset.go
+++ b/meta/asset.go
@@ -29,10 +29,11 @@ var assetHeaders Header = map[string]int{
 }
 
 var AssetTable Table = Table{
-	name:    "Asset",
-	headers: assetHeaders,
-	primary: []string{"Make", "Model", "Serial"},
-	foreign: map[string][]string{},
+	name:     "Asset",
+	headers:  assetHeaders,
+	primary:  []string{"Make", "Model", "Serial"},
+	foreign:  map[string]map[string]string{},
+	nullable: []string{"Notes", "Number"},
 }
 
 type AssetList []Asset

--- a/meta/calibration.go
+++ b/meta/calibration.go
@@ -41,8 +41,14 @@ var CalibrationTable Table = Table{
 	headers: calibrationHeaders,
 	primary: []string{"Make", "Model", "Serial", "Number", "Start Date"},
 	native:  []string{"Scale Factor", "Scale Bias", "Scale Absolute", "Frequency"},
-	foreign: map[string][]string{
-		"Asset": {"Make", "Model", "Serial"},
+	foreign: map[string]map[string]string{
+		"Asset": {"Make": "Make", "Model": "Model", "Serial": "Serial"},
+	},
+	nullable: []string{"Frequency"},
+	defaults: map[string]string{
+		"Scale Factor":   "1.0",
+		"Scale Absolute": "0.0",
+		"Scale Bias":     "0.0",
 	},
 	remap: map[string]string{
 		"Scale Factor":   "ScaleFactor",

--- a/meta/camera.go
+++ b/meta/camera.go
@@ -45,10 +45,11 @@ var InstalledCameraTable Table = Table{
 	headers: installedCameraHeaders,
 	primary: []string{"Make", "Model", "Serial", "Start Date"},
 	native:  []string{"Azimuth", "Dip", "Height", "North", "East"},
-	foreign: map[string][]string{
-		"Asset": {"Make", "Model", "Serial"},
-		"Mount": {"Mount"},
+	foreign: map[string]map[string]string{
+		"Asset": {"Make": "Make", "Model": "Model", "Serial": "Serial"},
+		"Mount": {"Mount": "Mount"},
 	},
+	nullable: []string{"Notes"},
 	remap: map[string]string{
 		"Start Date": "Start",
 		"End Date":   "End",

--- a/meta/channel.go
+++ b/meta/channel.go
@@ -27,13 +27,12 @@ var channelHeaders Header = map[string]int{
 }
 
 var ChannelTable Table = Table{
-	name:    "Channel",
-	headers: channelHeaders,
-	primary: []string{"Make", "Model", "Number", "SamplingRate"},
-	native:  []string{"Number", "SamplingRate"},
-	foreign: map[string][]string{
-		"Network": {"Network"},
-	},
+	name:     "Channel",
+	headers:  channelHeaders,
+	primary:  []string{"Make", "Model", "Number", "SamplingRate"},
+	native:   []string{"Number", "SamplingRate"},
+	foreign:  map[string]map[string]string{},
+	nullable: []string{"Number", "Response"},
 }
 
 // Channel is used to describe a generic recording from a Datalogger.

--- a/meta/citation.go
+++ b/meta/citation.go
@@ -34,11 +34,12 @@ var citationHeaders Header = map[string]int{
 }
 
 var CitationTable Table = Table{
-	name:    "Citation",
-	headers: citationHeaders,
-	primary: []string{"Key"},
-	native:  []string{"Year"},
-	foreign: map[string][]string{},
+	name:     "Citation",
+	headers:  citationHeaders,
+	primary:  []string{"Key"},
+	native:   []string{"Year"},
+	foreign:  map[string]map[string]string{},
+	nullable: []string{"DOI", "Link", "Pages", "Published", "Retrieved", "Volume"},
 }
 
 type Citation struct {

--- a/meta/class.go
+++ b/meta/class.go
@@ -38,13 +38,12 @@ var classHeaders Header = map[string]int{
 }
 
 var ClassTable Table = Table{
-	name:    "Class",
-	headers: classHeaders,
-	primary: []string{"Station"},
-	native:  []string{"Vs30", "Basement Depth"},
-	foreign: map[string][]string{
-		"Citations": {"Citation"},
-	},
+	name:     "Class",
+	headers:  classHeaders,
+	primary:  []string{"Station"},
+	native:   []string{"Vs30", "Basement Depth"},
+	foreign:  map[string]map[string]string{},
+	nullable: []string{"Citations", "Link", "Notes"},
 	remap: map[string]string{
 		"Site Class":     "SiteClass",
 		"Vs30 Quality":   "Vs30Quality",

--- a/meta/component.go
+++ b/meta/component.go
@@ -36,13 +36,12 @@ var componentHeaders Header = map[string]int{
 }
 
 var ComponentTable Table = Table{
-	name:    "Component",
-	headers: componentHeaders,
-	primary: []string{"Make", "Model", "Number", "Source", "Subsource", "Sampling Rate"},
-	native:  []string{"Number", "Dip", "Azimuth", "Sampling Rate"},
-	foreign: map[string][]string{
-		"Asset": {"Make", "Model"},
-	},
+	name:     "Component",
+	headers:  componentHeaders,
+	primary:  []string{"Make", "Model", "Number", "Source", "Subsource", "Sampling Rate"},
+	native:   []string{"Number", "Dip", "Azimuth", "Sampling Rate"},
+	foreign:  map[string]map[string]string{},
+	nullable: []string{"Sampling Rate", "Source", "Type"},
 	remap: map[string]string{
 		"Sampling Rate": "SamplingRate",
 	},

--- a/meta/connection.go
+++ b/meta/connection.go
@@ -31,9 +31,10 @@ var ConnectionTable Table = Table{
 	name:    "Connection",
 	headers: connectionHeaders,
 	primary: []string{"Station", "Location", "Place", "Number", "Start Date"},
-	foreign: map[string][]string{
-		"Site": {"Station", "Location"},
+	foreign: map[string]map[string]string{
+		"Site": {"Station": "Station", "Location": "Location"},
 	},
+	nullable: []string{"Role", "Number", "Location"},
 	remap: map[string]string{
 		"Start Date": "Start",
 		"End Date":   "End",

--- a/meta/constituent.go
+++ b/meta/constituent.go
@@ -33,8 +33,8 @@ var ConstituentTable Table = Table{
 	headers: constituentHeaders,
 	primary: []string{"Gauge", "Number", "Start Date"},
 	native:  []string{"Amplitude", "Lage"},
-	foreign: map[string][]string{
-		"Gauge": {"Gauge"},
+	foreign: map[string]map[string]string{
+		"Gauge": {"Gauge": "Gauge"},
 	},
 	remap: map[string]string{
 		"Start Date": "Start",

--- a/meta/dart.go
+++ b/meta/dart.go
@@ -28,7 +28,7 @@ var DartTable Table = Table{
 	headers: dartHeaders,
 	primary: []string{"Station", "Start Date"},
 	native:  []string{},
-	foreign: map[string][]string{},
+	foreign: map[string]map[string]string{},
 	remap: map[string]string{
 		"WMO Identifier": "WmoIdentifier",
 		"Start Date":     "Start",

--- a/meta/datalogger.go
+++ b/meta/datalogger.go
@@ -32,10 +32,11 @@ var DeployedDataloggerTable Table = Table{
 	headers: deployedDataloggerHeaders,
 	primary: []string{"Make", "Model", "Serial", "Place", "Role", "Start Date"},
 	native:  []string{},
-	foreign: map[string][]string{
-		"Asset":      {"Make", "Model", "Serial"},
-		"Connection": {"Place", "Role"},
+	foreign: map[string]map[string]string{
+		"Asset":      {"Make": "Make", "Model": "Model", "Serial": "Serial"},
+		"Connection": {"Place": "Place", "Role": "Role"},
 	},
+	nullable: []string{"Role"},
 	remap: map[string]string{
 		"Start Date": "Start",
 		"End Date":   "End",

--- a/meta/doas.go
+++ b/meta/doas.go
@@ -43,9 +43,9 @@ var InstalledDoasTable Table = Table{
 	headers: installedDoasHeaders,
 	primary: []string{"Make", "Model", "Serial", "Start Date"},
 	native:  []string{"Azimuth", "Dip", "Height", "North", "East"},
-	foreign: map[string][]string{
-		"Asset": {"Make", "Model", "Serial"},
-		"Mount": {"Mount"},
+	foreign: map[string]map[string]string{
+		"Asset": {"Make": "Make", "Model": "Model", "Serial": "Serial"},
+		"Mount": {"Mount": "Mount"},
 	},
 	remap: map[string]string{
 		"Start Date": "Start",

--- a/meta/feature.go
+++ b/meta/feature.go
@@ -33,9 +33,10 @@ var FeatureTable Table = Table{
 	name:    "Feature",
 	headers: featureHeaders,
 	primary: []string{"Station", "Location", "Sublocation", "Property", "Description", "Aspect", "Start Date"},
-	foreign: map[string][]string{
-		"Site": {"Station", "Location"},
+	foreign: map[string]map[string]string{
+		"Site": {"Station": "Station", "Location": "Location"},
 	},
+	nullable: []string{"Aspect", "Description", "Location", "Sublocation"},
 	remap: map[string]string{
 		"Start Date": "Start",
 		"End Date":   "End",

--- a/meta/firmware.go
+++ b/meta/firmware.go
@@ -39,9 +39,10 @@ var FirmwareHistoryTable Table = Table{
 	headers: firmwareHistoryHeaders,
 	primary: []string{"Make", "Model", "Serial", "Start Date"},
 	native:  []string{},
-	foreign: map[string][]string{
-		"Asset": {"Make", "Model", "Serial"},
+	foreign: map[string]map[string]string{
+		"Asset": {"Make": "Make", "Model": "Model", "Serial": "Serial"},
 	},
+	nullable: []string{"Notes"},
 	remap: map[string]string{
 		"Start Date": "Start",
 		"End Date":   "End",

--- a/meta/gain.go
+++ b/meta/gain.go
@@ -34,14 +34,12 @@ var gainHeaders Header = map[string]int{
 }
 
 var GainTable Table = Table{
-	name:    "Gain",
-	headers: gainHeaders,
-	primary: []string{"Station", "Location", "Sublocation", "Subsource", "Start Date"},
-	native:  []string{"Scale Factor", "Scale Bias", "Absolute Bias"},
-	foreign: map[string][]string{
-		"Site":    {"Station", "Location"},
-		"Feature": {"Station", "Location", "Sublocation"},
-	},
+	name:     "Gain",
+	headers:  gainHeaders,
+	primary:  []string{"Station", "Location", "Sublocation", "Subsource", "Start Date"},
+	native:   []string{"Scale Factor", "Scale Bias", "Absolute Bias"},
+	foreign:  map[string]map[string]string{},
+	nullable: []string{"Absolute Bias", "Scale Bias", "Scale Factor", "Sublocation", "Subsource"},
 	remap: map[string]string{
 		"Scale Factor":  "Factor",
 		"Scale Bias":    "Bias",

--- a/meta/gauge.go
+++ b/meta/gauge.go
@@ -38,8 +38,8 @@ var GaugeTable Table = Table{
 	//TODO: the Analysis Latitude is a used to avoid an overlap clash on NZC
 	primary: []string{"Gauge", "Identification Number", "Analysis Latitude", "Start Date"},
 	native:  []string{"Analysis Time Zone", "Analysis Latitude", "Analysis Longitude"},
-	foreign: map[string][]string{
-		"Network": {"Network"},
+	foreign: map[string]map[string]string{
+		"Network": {"Network": "Network"},
 	},
 	remap: map[string]string{
 		"Gauge":                 "Code",

--- a/meta/mark.go
+++ b/meta/mark.go
@@ -39,8 +39,8 @@ var MarkTable Table = Table{
 	headers: markHeaders,
 	primary: []string{"Mark", "Start Date"},
 	native:  []string{"Latitude", "Longitude", "Elevation"},
-	foreign: map[string][]string{
-		"Network": {"Network"},
+	foreign: map[string]map[string]string{
+		"Network": {"Network": "Network"},
 	},
 	remap: map[string]string{
 		"Mark":       "Code",

--- a/meta/metsensor.go
+++ b/meta/metsensor.go
@@ -47,10 +47,11 @@ var InstalledMetSensorTable Table = Table{
 	headers: installedMetSensorHeaders,
 	primary: []string{"Make", "Model", "Serial", "Start Date"},
 	native:  []string{"Latitude", "Longitude", "Elevation", "Humidity", "Pressure", "Temperature"},
-	foreign: map[string][]string{
-		"Asset": {"Make", "Model", "Serial"},
-		"Mark":  {"Mark"},
+	foreign: map[string]map[string]string{
+		"Asset": {"Make": "Make", "Model": "Model", "Serial": "Serial"},
+		"Mark":  {"Mark": "Mark"},
 	},
+	nullable: []string{"IMS Comment"},
 	remap: map[string]string{
 		"IMS Comment": "IMSComment",
 		"Start Date":  "Start",

--- a/meta/monument.go
+++ b/meta/monument.go
@@ -41,9 +41,10 @@ var MonumentTable Table = Table{
 	headers: monumentHeaders,
 	primary: []string{"Mark"},
 	native:  []string{"Ground Relationship", "Foundation Depth"},
-	foreign: map[string][]string{
-		"Mark": {"Mark"},
+	foreign: map[string]map[string]string{
+		"Mark": {"Mark": "Mark"},
 	},
+	nullable: []string{"Domes Number", "Geology", "Bedrock"},
 	remap: map[string]string{
 		"Domes Number":        "DomesNumber",
 		"Mark Type":           "MarkType",

--- a/meta/mount.go
+++ b/meta/mount.go
@@ -39,8 +39,8 @@ var MountTable Table = Table{
 	headers: mountHeaders,
 	primary: []string{"Mount", "Start Date"},
 	native:  []string{"Latitude", "Longitude", "Elevation"},
-	foreign: map[string][]string{
-		"Network": {"Network"},
+	foreign: map[string]map[string]string{
+		"Network": {"Network": "Network"},
 	},
 	remap: map[string]string{
 		"Mount":      "Code",

--- a/meta/network.go
+++ b/meta/network.go
@@ -26,7 +26,7 @@ var NetworkTable Table = Table{
 	headers: networkHeaders,
 	primary: []string{"Network"},
 	native:  []string{},
-	foreign: map[string][]string{},
+	foreign: map[string]map[string]string{},
 	remap: map[string]string{
 		"Network": "Code",
 	},

--- a/meta/placenames.go
+++ b/meta/placenames.go
@@ -30,11 +30,11 @@ var placenameHeaders Header = map[string]int{
 }
 
 var PlacenameTable Table = Table{
-	name:    "Name",
+	name:    "Placename",
 	headers: placenameHeaders,
 	primary: []string{"Name"},
 	native:  []string{"Latitude", "Longitude", "Level"},
-	foreign: map[string][]string{},
+	foreign: map[string]map[string]string{},
 }
 
 // Placename is used to describe distances and azimuths to known places.

--- a/meta/point.go
+++ b/meta/point.go
@@ -39,9 +39,10 @@ var PointTable Table = Table{
 	headers: pointHeaders,
 	primary: []string{"Sample", "Location", "Start Date"},
 	native:  []string{"Latitude", "Longitude", "Elevation", "Depth"},
-	foreign: map[string][]string{
-		"Sample": {"Sample"},
+	foreign: map[string]map[string]string{
+		"Sample": {"Code": "Sample"},
 	},
+	nullable: []string{"Depth"},
 	remap: map[string]string{
 		"Start Date": "Start",
 		"End Date":   "End",

--- a/meta/polarity.go
+++ b/meta/polarity.go
@@ -40,9 +40,10 @@ var PolarityTable Table = Table{
 	primary: []string{"Station", "Location", "Sublocation", "Subsource", "Start Date"},
 	//native:  []string{"Primary", "Reversed"},
 	native: []string{},
-	foreign: map[string][]string{
-		"Site": {"Station", "Location"},
+	foreign: map[string]map[string]string{
+		"Site": {"Station": "Station", "Location": "Location"},
 	},
+	nullable: []string{"Citation", "Method", "Sublocation", "Subsource"},
 	remap: map[string]string{
 		"Primary":    "IsPrimary",
 		"Reversed":   "IsReversed",

--- a/meta/preamp.go
+++ b/meta/preamp.go
@@ -32,9 +32,10 @@ var PreampTable Table = Table{
 	headers: preampHeaders,
 	primary: []string{"Station", "Location", "Subsource", "Start Date"},
 	native:  []string{"Scale Factor"},
-	foreign: map[string][]string{
-		"Site": {"Station", "Location"},
+	foreign: map[string]map[string]string{
+		"Site": {"Station": "Station", "Location": "Location"},
 	},
+	nullable: []string{"Subsource"},
 	remap: map[string]string{
 		"Scale Factor": "ScaleFactor",
 		"Start Date":   "Start",

--- a/meta/radome.go
+++ b/meta/radome.go
@@ -30,8 +30,8 @@ var InstalledRadomeTable Table = Table{
 	headers: installedRadomeHeaders,
 	primary: []string{"Make", "Model", "Serial", "Start Date"},
 	native:  []string{},
-	foreign: map[string][]string{
-		"Mark": {"Mark"},
+	foreign: map[string]map[string]string{
+		"Mark": {"Mark": "Mark"},
 	},
 	remap: map[string]string{
 		"Start Date": "Start",

--- a/meta/receiver.go
+++ b/meta/receiver.go
@@ -30,9 +30,9 @@ var DeployedReceiverTable Table = Table{
 	headers: deployedReceiverHeaders,
 	primary: []string{"Make", "Model", "Serial", "Start Date"},
 	native:  []string{},
-	foreign: map[string][]string{
-		"Asset": {"Make", "Model", "Serial"},
-		"Mark":  {"Mark"},
+	foreign: map[string]map[string]string{
+		"Asset": {"Make": "Make", "Model": "Model", "Serial": "Serial"},
+		"Mark":  {"Mark": "Mark"},
 	},
 	remap: map[string]string{
 		"Start Date": "Start",

--- a/meta/recorder.go
+++ b/meta/recorder.go
@@ -43,9 +43,10 @@ var InstalledRecorderTable Table = Table{
 	headers: installedRecorderHeaders,
 	primary: []string{"Make", "Sensor", "Datalogger", "Serial", "Start Date"},
 	native:  []string{"Azimuth", "Dip", "Depth"},
-	foreign: map[string][]string{
-		"Asset": {"Make", "Model", "Serial"},
+	foreign: map[string]map[string]string{
+		"Asset": {"Make": "Make", "Model": "Sensor", "Serial": "Serial"},
 	},
+	nullable: []string{"Method"},
 	remap: map[string]string{
 		"Start Date": "Start",
 		"End Date":   "End",

--- a/meta/sample.go
+++ b/meta/sample.go
@@ -39,9 +39,10 @@ var SampleTable Table = Table{
 	headers: sampleHeaders,
 	primary: []string{"Station", "Start Date"},
 	native:  []string{"Latitude", "Longitude", "Elevation", "Depth"},
-	foreign: map[string][]string{
-		"Network": {"Network"},
+	foreign: map[string]map[string]string{
+		"Network": {"Network": "Network"},
 	},
+	nullable: []string{"Depth"},
 	remap: map[string]string{
 		"Station":    "Code",
 		"Start Date": "Start",

--- a/meta/sensor.go
+++ b/meta/sensor.go
@@ -49,10 +49,11 @@ var InstalledSensorTable Table = Table{
 	headers: installedSensorHeaders,
 	primary: []string{"Make", "Model", "Serial", "Station", "Location", "Start Date"},
 	native:  []string{"Azimuth", "Dip", "Depth", "North", "East", "Scale Factor", "Scale Bias"},
-	foreign: map[string][]string{
-		"Asset": {"Make", "Model", "Serial"},
-		"Site":  {"Station", "Location"},
+	foreign: map[string]map[string]string{
+		"Asset": {"Make": "Make", "Model": "Model", "Serial": "Serial"},
+		"Site":  {"Station": "Station", "Location": "Location"},
 	},
+	nullable: []string{"Location", "Method"},
 	remap: map[string]string{
 		"Scale Factor": "Factor",
 		"Scale Bias":   "Bias",

--- a/meta/session.go
+++ b/meta/session.go
@@ -41,8 +41,8 @@ var SessionTable Table = Table{
 	headers: sessionHeaders,
 	primary: []string{"Mark", "Interval", "Start Date"},
 	native:  []string{"Elevation Mask"},
-	foreign: map[string][]string{
-		"Mark": {"Mark"},
+	foreign: map[string]map[string]string{
+		"Mark": {"Mark": "Mark"},
 	},
 	remap: map[string]string{
 		"Satellite System": "SatelliteSystem",

--- a/meta/site.go
+++ b/meta/site.go
@@ -39,9 +39,10 @@ var SiteTable Table = Table{
 	headers: siteHeaders,
 	primary: []string{"Station", "Location", "Start Date"},
 	native:  []string{"Latitude", "Longitude", "Elevation", "Depth"},
-	foreign: map[string][]string{
-		"Station": {"Station"},
+	foreign: map[string]map[string]string{
+		"Station": {"Station": "Station"},
 	},
+	nullable: []string{"Depth", "Location"}, //TODO: the Location shouldn't be empty
 	remap: map[string]string{
 		"Start Date": "Start",
 		"End Date":   "End",

--- a/meta/station.go
+++ b/meta/station.go
@@ -45,9 +45,10 @@ var StationTable = Table{
 	headers: stationHeaders,
 	primary: []string{"Station", "Start Date"},
 	native:  []string{"Latitude", "Longitude", "Elevation", "Depth"},
-	foreign: map[string][]string{
-		"Network": {"Network"},
+	foreign: map[string]map[string]string{
+		"Network": {"Network": "Network"},
 	},
+	nullable: []string{"Depth"},
 	remap: map[string]string{
 		"Station":    "Code",
 		"Start Date": "Start",

--- a/meta/streams.go
+++ b/meta/streams.go
@@ -39,9 +39,10 @@ var StreamTable Table = Table{
 	headers: streamHeaders,
 	primary: []string{"Station", "Location", "Source", "Sampling Rate", "Start Date"},
 	native:  []string{"Sampling Rate"},
-	foreign: map[string][]string{
-		"Site": {"Station", "Location"},
+	foreign: map[string]map[string]string{
+		"Site": {"Station": "Station", "Location": "Location"},
 	},
+	nullable: []string{"Band", "Source"},
 	remap: map[string]string{
 		"Sampling Rate": "SamplingRate",
 		"Start Date":    "Start",

--- a/meta/table.go
+++ b/meta/table.go
@@ -6,15 +6,17 @@ import (
 
 // Table holds internal settings suitable for automatic code generation.
 type Table struct {
-	name    string
-	headers Header
-	primary []string
-	native  []string
-	foreign map[string][]string
-	remap   map[string]string
-	ignore  bool
-	start   string
-	end     string
+	name     string
+	headers  Header
+	primary  []string
+	native   []string
+	foreign  map[string]map[string]string
+	nullable []string
+	defaults map[string]string
+	remap    map[string]string
+	ignore   bool
+	start    string
+	end      string
 }
 
 // Name returns the table name.
@@ -75,6 +77,28 @@ func (t Table) IsNative(col int) bool {
 		return true
 	}
 	return false
+}
+
+// IsNullable returns whether the column can be set to NULL.
+func (t Table) IsNullable(col int) bool {
+	for _, s := range t.nullable {
+		if n, ok := t.headers[s]; !ok || n != col {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// HasDefault returns whether the column has a default value.
+func (t Table) HasDefault(col int) (string, bool) {
+	for s, v := range t.defaults {
+		if n, ok := t.headers[s]; !ok || n != col {
+			continue
+		}
+		return v, true
+	}
+	return "", false
 }
 
 // IsDateTime returns whether the column is a date and may need extra formatting.

--- a/meta/telemetry.go
+++ b/meta/telemetry.go
@@ -30,8 +30,11 @@ var TelemetryTable Table = Table{
 	headers: telemetryHeaders,
 	primary: []string{"Station", "Location", "Start Date"},
 	native:  []string{"Scale Factor"},
-	foreign: map[string][]string{
-		"Site": {"Station", "Location"},
+	foreign: map[string]map[string]string{
+		"Site": {"Station": "Station", "Location": "Location"},
+	},
+	defaults: map[string]string{
+		"Scale Factor": "1.0",
 	},
 	remap: map[string]string{
 		"Scale Factor": "ScaleFactor",

--- a/meta/timing.go
+++ b/meta/timing.go
@@ -28,8 +28,8 @@ var TimingTable Table = Table{
 	headers: timingHeaders,
 	primary: []string{"Station", "Location", "Start Date"},
 	native:  []string{},
-	foreign: map[string][]string{
-		"Site": {"Station", "Location"},
+	foreign: map[string]map[string]string{
+		"Site": {"Station": "Station", "Location": "Location"},
 	},
 	remap: map[string]string{
 		"Start Date": "Start",

--- a/meta/view.go
+++ b/meta/view.go
@@ -37,9 +37,10 @@ var ViewTable Table = Table{
 	headers: viewHeaders,
 	primary: []string{"Mount", "View", "Start Date"},
 	native:  []string{"Azimuth", "Dip"},
-	foreign: map[string][]string{
-		"Mount": {"Mount"},
+	foreign: map[string]map[string]string{
+		"Mount": {"Mount": "Mount"},
 	},
+	nullable: []string{"Label", "Method"},
 	remap: map[string]string{
 		"Start Date": "Start",
 		"End Date":   "End",

--- a/meta/visibility.go
+++ b/meta/visibility.go
@@ -27,8 +27,8 @@ var VisibilityTable Table = Table{
 	//TODO: needs a column for describing feature
 	primary: []string{"Mark", "Start Date"},
 	native:  []string{},
-	foreign: map[string][]string{
-		"Mark": {"Mark"},
+	foreign: map[string]map[string]string{
+		"Mark": {"Mark": "Mark"},
 	},
 	remap: map[string]string{
 		"Sky Visibility": "SkyVisibility",


### PR DESCRIPTION
This is aimed at better building sql tables, and includes being more specific about the foreign keys by including column names, and adding any columns that can be set to null, as well as any columns that can't but have a default to avoid this.

There are likely to be some other fields with defaults, but at the moment it is not clear what the value should be, e.g. a blank entry may mean all values. Perhaps some form of expression is needed.

The current implementation is a proof of concept, whereas the next iteration will hopefully aim at a more designed solution.

It also fixes a few misconfigured foreign key tables which had no impact.