### PR TITLE
feat: add nil sensor to GNSS domain

### DIFF
--- a/cmd/tilde-config/gnss.go
+++ b/cmd/tilde-config/gnss.go
@@ -12,14 +12,33 @@ func (t *Tilde) Gnss(set *meta.Set) error {
 
 	// all marks are GNSS stations
 	for _, m := range set.Marks() {
+
+		// GNSS data does not explicitly have sensor information, which is currently
+		// problematic with Tilde's expectation of station + sensor,
+		// see: https://github.com/GeoNet/tickets/issues/17327.
+		// Simply create a nil sensor, which inherits station level information
+
+		sens := []Sensor{
+			Sensor{
+				Code:      "nil",
+				Start:     toTimePtr(m.Start),
+				End:       toTimePtr(m.End),
+				Latitude:  toFloat(fmt.Sprintf("%0.4f", m.Latitude)),
+				Longitude: toFloat(fmt.Sprintf("%0.4f", m.Longitude)),
+				Elevation: toFloat(fmt.Sprintf("%0.0f", math.Round(m.Elevation))),
+				Datum:     m.Datum,
+			},
+		}
+
 		stns = append(stns, Station{
 			Code:        m.Code,
 			Description: m.Name,
-			Start:       toTimePtr(m.Start),
-			End:         toTimePtr(m.End),
-			Latitude:    toFloat(fmt.Sprintf("%0.4f", m.Latitude)),
-			Longitude:   toFloat(fmt.Sprintf("%0.4f", m.Longitude)),
-			Elevation:   toFloat(fmt.Sprintf("%0.0f", math.Round(m.Elevation))),
+			Start:       sens[0].Start,
+			End:         sens[0].End,
+			Latitude:    sens[0].Latitude,
+			Longitude:   sens[0].Longitude,
+			Elevation:   sens[0].Elevation,
+			Sensors:     sens,
 		})
 	}
 


### PR DESCRIPTION
Helps resolve https://github.com/GeoNet/tickets/issues/17322

Allows for station-level metadata fallback, whilst still maintaining the "no sensor" concept.

Responses now look like:
```json
 "series": {
      "domain": "gnss",
      "station": "AVLN",
      "name": "displacement",
      "sensorCode": "nil",
      "method": "1d",
      "aspect": "up"
    },
    "latitude": -41.1964,
    "longitude": 174.9329,
    "elevationM": 40,
    "datum": "WGS84",
    "relativeHeightM": 0,
    "valueUnit": "m",
    "errorUnit": "m"
```

and

```json
"sensorCodes": {
            "nil": {
              "sensorCode": "nil",
              "metadata": {
                "latitude": -41.1964,
                "longitude": 174.9329
              },
```