### PR TITLE
fix: update the volcam config

### DIFF
--- a/cmd/volcam-config/main.go
+++ b/cmd/volcam-config/main.go
@@ -38,7 +38,7 @@ var ids = map[string]string{
 	"Ruapehu & Ngauruhoe from East":        "ruapehungauruhoe",
 	"Ruapehu from South":                   "ruapehusouth",
 	"Raoul Island":                         "raoulisland",
-	"Taranaki from New Plymouth":           "taranaki",
+	"Taranaki Maunga from New Plymouth":    "taranaki",
 	"Whakaari/White Island from Te Kaha":   "tekaha",
 	"Tongariro Te Maari Crater":            "tongarirotemaaricrater",
 	"Whakaari/White Island from Whakatāne": "whakatane",


### PR DESCRIPTION
This updates the caption for the camera images, uses the view name to match the caption etc.