### PR TITLE
fix: avoid multiple volcam images per endpoint

### DIFF
--- a/cmd/volcam-config/main.go
+++ b/cmd/volcam-config/main.go
@@ -79,6 +79,8 @@ func main() {
 	// avoids null when marshalling an empty slice
 	volcs := make([]Volcam, 0)
 
+	counts := make(map[string]int)
+
 	for _, view := range set.Views() {
 		if time.Since(view.Span.End) > 0 {
 			continue
@@ -133,6 +135,12 @@ func main() {
 				if !ok {
 					continue
 				}
+
+				count := counts[id]
+				if count > 0 {
+					continue
+				}
+				counts[id]++
 
 				volcs = append(volcs, Volcam{
 					Id:        id,


### PR DESCRIPTION
Having two cameras with the same id will generate multiple update issues. This is a simple check to only process one, it relies on the order being correct as to which one it allows through.