### PR TITLE
Close WHOH view 02 (old camera) to allow new camera (view 03) to appear on website

### DIFF
--- a/network/views.csv
+++ b/network/views.csv
@@ -26,7 +26,7 @@ TOD02,01,,169,,-60,SO2 from Tongariro from Lower Te Maari West,2021-07-29T01:00:
 TOKR,01,Tongariro Te Maari Crater,0,,0,Images of Te Maari Crater on Mount Tongariro from the volcano camera situated at Karewarewa,2012-08-29T02:00:00Z,9999-01-01T00:00:00Z
 WHHB,01,Whakaari/White Island from Whakatāne,347,,0,Images of White Island from the volcano camera situated at Whakatane harbour.,2001-05-21T13:00:10Z,2007-04-13T00:00:00Z
 WHOH,01,Whakaari/White Island from Whakatāne,19,,0,At Whakatane Comms Hub looking at White Island,2006-02-24T14:00:00Z,2018-04-19T00:00:00Z
-WHOH,02,Whakaari/White Island from Whakatāne,19,,0,At Whakatane Comms Hub looking at White Island,2012-12-31T11:16:03Z,9999-01-01T00:00:00Z
+WHOH,02,Whakaari/White Island from Whakatāne,19,,0,At Whakatane Comms Hub looking at White Island,2012-12-31T11:16:03Z,2025-08-11T00:00:00Z
 WHOH,03,Whakaari/White Island from Whakatāne,19,,0,At Whakatane Comms Hub looking at White Island,2025-07-09T06:10:00Z,9999-01-01T00:00:00Z
 WICF,01,Whakaari/White Island Crater Floor,306,,0,Images of White Island crater from the volcano camera situated at the base of Troup Head.,2009-10-28T00:30:00Z,2023-12-01T00:00:00Z
 WID01,01,Whakaari/White Island North-East Point,345,,-90,SO2 from White Island from North-East Point,2009-11-13T03:43:24Z,2021-05-25T02:11:46Z


### PR DESCRIPTION
As per https://github.com/GeoNet/tickets/issues/18459#issuecomment-3161892182

Close the old camera view.

We will need to update the view close time to the camera uninstall time when the old camera is removed.

Until then the old camera images will continue to be archived but not appear on the website.