### PR TITLE
feat: add SB network to sensor config

### DIFF
--- a/cmd/sensor-config/main.go
+++ b/cmd/sensor-config/main.go
@@ -53,7 +53,7 @@ func main() {
 	}
 
 	flag.StringVar(&settings.base, "base", "", "delta base files")
-	flag.StringVar(&settings.networks, "networks", "AK,CB,CH,EC,FI,HB,IU,KI,NM,NZ,OT,RA,RT,SC,SI,SM,SP,TP,TR,WL", "installed network codes")
+	flag.StringVar(&settings.networks, "networks", "AK,CB,CH,EC,FI,HB,IU,KI,NM,NZ,OT,RA,RT,SB,SC,SI,SM,SP,TP,TR,WL", "installed network codes")
 	flag.StringVar(&settings.coastal, "coastal", "TG", "coastal tsunami gauge network code")
 	flag.StringVar(&settings.lentic, "lentic", "LG", "lentic tsunami gauge network code")
 	flag.StringVar(&settings.dart, "dart", "TD", "dart buoy network code")


### PR DESCRIPTION
Adding building array network code `SB` to the list of networks included by default in sensor-config
This will hopefully allow these sites to be displayed on the sensor map search, and have metadata available in the geonet api