### PR TITLE
nfc: NLSN - updated visibility table 

### DIFF
--- a/environment/visibility.csv
+++ b/environment/visibility.csv
@@ -121,7 +121,8 @@ NLS1,-,2011-12-19T00:00:00Z,2013-11-14T00:00:00Z
 NLS2,ok,2011-12-20T00:00:00Z,2013-11-14T00:00:00Z
 NLSN,No obstruction above 10 degrees,2004-02-06T00:00:00Z,2019-01-18T23:59:59Z
 NLSN,vegetation (gorse) around the GNSS antenna impacting time series,2019-01-19T00:00:00Z,2019-04-26T23:59:59Z
-NLSN,No obstruction above 10 degrees,2019-04-27T00:00:00Z,9999-01-01T00:00:00Z
+NLSN,No obstruction above 10 degrees,2019-04-27T00:00:00Z,2026-04-27T23:59:59Z
+NLSN,Massive amount of gorse cleared from site. No obstruction above 10 degrees,2026-04-28T00:00:00Z,9999-01-01T00:00:00Z
 NMAI,"Excellent, no obstructions",2008-04-07T00:00:00Z,9999-01-01T00:00:00Z
 NPLY,No obstruction above 5 degrees elevation.,2003-03-20T00:00:00Z,9999-01-01T00:00:00Z
 NRRD,Skyview is obstructed by windturbines between bearings of 260 and 340 (true) at angles of between 6 and 10 degrees. The wind turbines are about 2 kilometers from the proposed site.,2008-03-27T00:00:00Z,9999-01-01T00:00:00Z


### PR DESCRIPTION
Updated visibility table to reflect current and past conditions at the site. 

Timeseries starts to get wobbly a few weeks after the start of 2026, so have put the starting date as the first day of the year to reflect this. 

Edit: Have changed the file to not include the extra line about gorse from the start of the year on discussion with Aleks.